### PR TITLE
Feat: Submit with enter key and create new line with shift+enter

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -174,7 +174,7 @@ const HumanMessageBubble: React.FC<HumanMessageBubbleProps> = ({
 
       <div dangerouslySetInnerHTML={{
         __html: typeof message.content === "string"
-          ? message.content
+          ? message.content.replace(/\n/g, '<br>')
           : JSON.stringify(message.content)
       }} />
       {/* <ReactMarkdown components={mdComponents}>

--- a/src/frontend/components/InputForm.tsx
+++ b/src/frontend/components/InputForm.tsx
@@ -30,8 +30,8 @@ export const InputForm: React.FC<InputFormProps> = ({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    // Submit with Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac)
-    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+    // Submit with Enter and create new line with Shift+Enter
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleInternalSubmit();
     }


### PR DESCRIPTION
This MR updates the UI to match the UX of other enterprise AI Agent UI's. The MR allows users to submit their queries with the enter key and create new lines with shift+enter. 

The MR also fixes a bug where new lines only appear in the input form, but do not appear in the human message bubble. For example if a user submits:

```
test
test
```

The human message bubble appears only with `test test` as the new line does not get detected. This MR fixes this bug by replacing the \n character with a </br>.