### PR TITLE
Feat: Change to Markdown Format

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -9,8 +9,8 @@ import { Badge } from "./ui/badge";
 import {
   ProcessedEvent,
 } from "./ActivityTimeline";
-import { StreamEventRenderer } from "./StreamEventRenderer";
-import { StreamEvent, ToolCall } from "../hooks/useDataStream";
+import { StreamEvent } from "../hooks/useDataStream";
+import ReactMarkdown from "react-markdown";
 
 // Markdown component props type from former ReportView
 type MdComponentProps = {
@@ -171,17 +171,11 @@ const HumanMessageBubble: React.FC<HumanMessageBubbleProps> = ({
     <div
       className={`text-white rounded-3xl break-words min-h-7 bg-neutral-700 max-w-[100%] sm:max-w-[90%] p-3 rounded-br-xs`}
     >
-
-      <div dangerouslySetInnerHTML={{
-        __html: typeof message.content === "string"
-          ? message.content.replace(/\n/g, '<br>')
-          : JSON.stringify(message.content)
-      }} />
-      {/* <ReactMarkdown components={mdComponents}>
+      <ReactMarkdown components={mdComponents}>
         {typeof message.content === "string"
           ? message.content
           : JSON.stringify(message.content)}
-      </ReactMarkdown> */}
+      </ReactMarkdown>
     </div>
   );
 };
@@ -202,27 +196,13 @@ const AiMessageBubble: React.FC<AiMessageBubbleProps> = ({
 }) => {
   return (
     <div className={`relative break-words flex flex-col w-full`}>
-      <div className="w-full" dangerouslySetInnerHTML={{
-        __html: typeof message.content === "string"
-          ? message.content
-          : JSON.stringify(message.content)
-      }} />
-      {/* <Button
-        variant="default"
-        className={`cursor-pointer bg-neutral-700 border-neutral-600 text-neutral-300 self-end ${message.content.length > 0 ? "visible" : "hidden"
-          }`}
-        onClick={() =>
-          handleCopy(
-            typeof message.content === "string"
-              ? message.content
-              : JSON.stringify(message.content),
-            message.id!
-          )
-        }
-      >
-        {copiedMessageId === message.id ? "Copied" : "Copy"}
-        {copiedMessageId === message.id ? <CopyCheck /> : <Copy />}
-      </Button> */}
+      <div className="w-full prose prose-invert max-w-none">
+        <ReactMarkdown components={mdComponents}>
+          {typeof message.content === "string"
+            ? message.content
+            : JSON.stringify(message.content)}
+        </ReactMarkdown>
+      </div>
     </div>
   );
 };

--- a/src/frontend/components/StreamEventRenderer.tsx
+++ b/src/frontend/components/StreamEventRenderer.tsx
@@ -10,6 +10,7 @@ import {
   Play,
   Zap,
 } from "lucide-react";
+import ReactMarkdown from "react-markdown";
 
 interface StreamEventRendererProps {
   events: StreamEvent[];
@@ -98,13 +99,13 @@ export function StreamEventRenderer({ events, isLoading }: StreamEventRendererPr
                   <span className="text-sm font-medium text-purple-100">AI Thinking</span>
                   {isLoading && <Loader2 className="w-3 h-3 text-purple-400 animate-spin" />}
                 </div>
-                <p className="text-sm text-purple-200/80 italic">
-                  <div dangerouslySetInnerHTML={{
-                    __html: typeof event.content === "string"
+                <div className="text-sm text-purple-200/80 italic">
+                  <ReactMarkdown>
+                    {typeof event.content === "string"
                       ? event.content
-                      : JSON.stringify(event.content)
-                  }} />
-                </p>
+                      : JSON.stringify(event.content)}
+                  </ReactMarkdown>
+                </div>
               </div>
             </div>
           </div>
@@ -196,11 +197,11 @@ export function StreamEventRenderer({ events, isLoading }: StreamEventRendererPr
                   AI Response
                 </div>
                 <div className="text-sm text-neutral-200 prose prose-sm prose-invert max-w-none">
-                <div dangerouslySetInnerHTML={{
-                    __html: typeof event.content === "string"
+                  <ReactMarkdown>
+                    {typeof event.content === "string"
                       ? event.content
-                      : JSON.stringify(event.content)
-                  }} />
+                      : JSON.stringify(event.content)}
+                  </ReactMarkdown>
                   {isLoading && <span className="animate-pulse">|</span>}
                 </div>
               </div>


### PR DESCRIPTION
This PR changes the UI to output in Markdown rather than HTML. The reasoning behind this is that Markdown is more stable as most LLMs are trained to output in Markdown. There are also less formatting issues on the UI when the agent outputs in Markdown.

The associated PR on the template-agent is https://github.com/redhat-data-and-ai/template-agent/pull/21