### PR TITLE
fix(ui): path-scoped agent UI with gateway SSO passthrough

### DIFF
--- a/src/frontend/components/ChatErrorBoundary.tsx
+++ b/src/frontend/components/ChatErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { ErrorRecovery } from './ErrorRecovery';
+import { buildAppPath } from '../lib/app-paths';
 
 interface Props {
   children: ReactNode;
@@ -32,7 +33,7 @@ export class ChatErrorBoundary extends Component<Props, State> {
   };
 
   private handleGoHome = () => {
-    window.location.href = '/';
+    globalThis.location.href = buildAppPath('/');
   };
 
   private handleRefreshChat = () => {

--- a/src/frontend/components/ErrorBoundary.tsx
+++ b/src/frontend/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { ErrorRecovery } from './ErrorRecovery';
+import { buildAppPath } from '../lib/app-paths';
 
 interface Props {
   children: ReactNode;
@@ -41,7 +42,7 @@ export class ErrorBoundary extends Component<Props, State> {
   };
 
   private handleGoHome = () => {
-    window.location.href = '/';
+    globalThis.location.href = buildAppPath('/');
   };
 
   render() {

--- a/src/frontend/components/InputForm.tsx
+++ b/src/frontend/components/InputForm.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import { SquarePen, ArrowUp, StopCircle } from "lucide-react";
 import { Alert } from "@patternfly/react-core";
+import { buildAppPath } from '../lib/app-paths';
 
 interface InputFormProps {
   onSubmit: (inputValue: string) => void;
@@ -109,7 +110,7 @@ export const InputForm = forwardRef<HTMLTextAreaElement, InputFormProps>(functio
         <div className="flex items-center justify-end">
           <button
             type="button"
-            onClick={() => onNewChat ? onNewChat() : (window.location.href = ((window as any).APP_DATA?.basePath || '') + '/')}
+            onClick={() => onNewChat ? onNewChat() : (globalThis.location.href = buildAppPath('/'))}
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted"
           >
             <SquarePen size={12} />

--- a/src/frontend/components/InputForm.tsx
+++ b/src/frontend/components/InputForm.tsx
@@ -109,7 +109,7 @@ export const InputForm = forwardRef<HTMLTextAreaElement, InputFormProps>(functio
         <div className="flex items-center justify-end">
           <button
             type="button"
-            onClick={() => onNewChat ? onNewChat() : (window.location.href = '/')}
+            onClick={() => onNewChat ? onNewChat() : (window.location.href = ((window as any).APP_DATA?.basePath || '') + '/')}
             className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-muted"
           >
             <SquarePen size={12} />

--- a/src/frontend/components/SessionExpiredModal.tsx
+++ b/src/frontend/components/SessionExpiredModal.tsx
@@ -11,9 +11,14 @@ export interface SessionExpiredModalProps {
   isOpen: boolean;
 }
 
-export function SessionExpiredModal({ isOpen }: SessionExpiredModalProps) {
+function buildGatewayLoginUrl(): string {
+  const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}` || '/';
+  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+}
+
+export function SessionExpiredModal({ isOpen }: Readonly<SessionExpiredModalProps>) {
   const goToLogin = () => {
-    window.location.assign('/login');
+    globalThis.location.assign(buildGatewayLoginUrl());
   };
 
   return (

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -237,13 +237,13 @@ export function AppLayout({ children }: AppLayoutProps) {
     (chatId: string) => {
       dispatch(deleteChat(chatId));
       dispatch(addToast({ title: 'Chat deleted', variant: 'success' }));
-      if (window.location.pathname === `/chat/${chatId}`) {
+      if (location.pathname === `/chat/${chatId}`) {
         const remaining = chats.filter((c) => c.id !== chatId);
         navigate(remaining.length > 0 ? `/chat/${remaining[0].id}` : '/');
       }
       deleteThread(chatId).catch(() => {});
     },
-    [dispatch, chats, navigate]
+    [dispatch, chats, navigate, location.pathname]
   );
 
   const handleDeleteAllChats = useCallback(() => {

--- a/src/frontend/hooks/useAgentHealth.ts
+++ b/src/frontend/hooks/useAgentHealth.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildAppPath } from '../lib/app-paths';
 
 export type AgentHealthStatus = 'healthy' | 'unhealthy' | 'unknown';
 
@@ -28,7 +29,7 @@ export function useAgentHealth(): AgentHealthState {
     const controller = new AbortController();
     const timeoutId = window.setTimeout(() => controller.abort(), 10_000);
     try {
-      const res = await fetch('/api/health/agent', {
+      const res = await fetch(buildAppPath('/api/health/agent'), {
         credentials: 'same-origin',
         signal: controller.signal,
       });

--- a/src/frontend/hooks/useDataStream.tsx
+++ b/src/frontend/hooks/useDataStream.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState, useRef, useEffect } from "react";
 import type { AIMessage, Message } from "@langchain/langgraph-sdk";
 import { useRefreshableToken } from "./useRefreshableToken";
 import { chatStorage } from "@/services/chatStorage";
+import { buildAgentApiUrl } from "../lib/app-paths";
 
 export interface ToolCall {
   name: string;
@@ -93,7 +94,7 @@ export function useDataStream({
 
       const streamUrl = apiUrl
         ? `${apiUrl}/v1/stream`
-        : `/api/proxy/agent/v1/stream`;
+        : buildAgentApiUrl('/v1/stream');
 
       const response = await fetch(streamUrl, {
         method: "POST",

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -20,6 +20,7 @@ import {
   type StreamingState,
 } from '@/redux/slices/chats';
 import { chatStorage } from '@/services/chatStorage';
+import { buildAgentApiUrl } from '@/lib/app-paths';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
 
@@ -188,7 +189,7 @@ export function useStreamingAPI(threadId: string) {
         return;
       }
       const apiUrl = typeof window.APP_DATA?.apiUrl === 'string' ? window.APP_DATA.apiUrl : '';
-      const cancelUrl = apiUrl ? `${apiUrl}/v1/stream/cancel` : '/api/proxy/agent/v1/stream/cancel';
+      const cancelUrl = apiUrl ? `${apiUrl}/v1/stream/cancel` : buildAgentApiUrl('/v1/stream/cancel');
       if (typeof navigator.sendBeacon === 'function') {
         const payload = JSON.stringify({
           thread_id: threadIdRef.current,

--- a/src/frontend/lib/app-paths.ts
+++ b/src/frontend/lib/app-paths.ts
@@ -1,0 +1,36 @@
+function normalizeBasePath(value: string | undefined): string {
+  const trimmed = (value || '').trim();
+  if (!trimmed || trimmed === '/') return '/';
+  const normalized = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return normalized.replace(/\/+$/, '') || '/';
+}
+
+function normalizeSuffix(path: string): string {
+  if (!path || path === '/') return '';
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function getAppBasePath(): string {
+  return normalizeBasePath(globalThis.window?.APP_DATA?.basePath);
+}
+
+export function buildAppPath(path: string): string {
+  const basePath = getAppBasePath();
+  const suffix = normalizeSuffix(path);
+  if (basePath === '/') {
+    return suffix || '/';
+  }
+  return `${basePath}${suffix}` || basePath;
+}
+
+export function getAgentApiBaseUrl(): string {
+  const apiUrl = globalThis.window?.APP_DATA?.apiUrl;
+  if (typeof apiUrl === 'string' && apiUrl.trim() !== '') {
+    return apiUrl.replace(/\/+$/, '');
+  }
+  return buildAppPath('/api/proxy/agent');
+}
+
+export function buildAgentApiUrl(path: string): string {
+  return `${getAgentApiBaseUrl()}${normalizeSuffix(path)}`;
+}

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@langchain/langgraph-sdk';
 
 import { parseRetryAfterSeconds, triggerRateLimit } from '@/services/authenticated-fetch';
+import { buildAgentApiUrl } from '../app-paths';
 
 import type { SSEEvent } from './SSEProcessor';
 import { SSEProcessor } from './SSEProcessor';
@@ -111,7 +112,7 @@ export class StreamingManager {
 
     const streamUrl = request.apiUrl
       ? `${request.apiUrl}/v1/stream`
-      : '/api/proxy/agent/v1/stream';
+      : buildAgentApiUrl('/v1/stream');
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { store } from './redux/store';
 import App from './App';
+import { getAppBasePath } from './lib/app-paths';
 
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
@@ -12,7 +13,7 @@ import './global.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={getAppBasePath()}>
       <Provider store={store}>
         <App />
       </Provider>

--- a/src/frontend/services/agent-rest.ts
+++ b/src/frontend/services/agent-rest.ts
@@ -1,5 +1,6 @@
 import { AIMessage, Message } from "@langchain/langgraph-sdk";
 import { authenticatedFetch } from "./authenticated-fetch";
+import { buildAgentApiUrl } from "../lib/app-paths";
 
 export interface Thread {
   id: string;
@@ -7,8 +8,6 @@ export interface Thread {
   messages: Message[];
   updatedAt?: string;
 }
-
-const apiUrl = window.APP_DATA?.apiUrl || '';
 
 /**
  * When a supervisor agent echoes a sub-agent's response, the stored
@@ -113,9 +112,7 @@ function getAuthHeaders(): Record<string, string> {
  * Does NOT fetch full state (which is extremely slow per-thread).
  */
 export async function getAllThreadsByUserId(userId: string): Promise<Thread[]> {
-  const searchUrl = apiUrl
-    ? `${apiUrl}/threads/search`
-    : `/api/proxy/agent/threads/search`;
+  const searchUrl = buildAgentApiUrl('/threads/search');
 
   let response: Response;
   try {
@@ -151,9 +148,7 @@ export async function getAllThreadsByUserId(userId: string): Promise<Thread[]> {
  * Returns true if the deletion succeeded (or thread was already gone).
  */
 export async function deleteThread(threadId: string): Promise<boolean> {
-  const deleteUrl = apiUrl
-    ? `${apiUrl}/threads/${threadId}`
-    : `/api/proxy/agent/threads/${threadId}`;
+  const deleteUrl = buildAgentApiUrl(`/threads/${threadId}`);
 
   try {
     const resp = await authenticatedFetch(deleteUrl, {
@@ -171,9 +166,7 @@ export async function deleteThread(threadId: string): Promise<boolean> {
  * Called only when a user navigates into a specific chat.
  */
 export async function getThreadState(threadId: string): Promise<Message[]> {
-  const stateUrl = apiUrl
-    ? `${apiUrl}/threads/${threadId}/state`
-    : `/api/proxy/agent/threads/${threadId}/state`;
+  const stateUrl = buildAgentApiUrl(`/threads/${threadId}/state`);
 
   try {
     const resp = await authenticatedFetch(stateUrl, {

--- a/src/frontend/services/feedback-api.ts
+++ b/src/frontend/services/feedback-api.ts
@@ -1,3 +1,5 @@
+import { buildAgentApiUrl } from '../lib/app-paths';
+
 export interface FeedbackPayload {
   traceId: string;
   name: string;
@@ -9,7 +11,7 @@ export interface FeedbackPayload {
 }
 
 export async function submitFeedback(payload: FeedbackPayload): Promise<void> {
-  const response = await fetch('/api/proxy/agent/feedback', {
+  const response = await fetch(buildAgentApiUrl('/feedback'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -33,7 +35,7 @@ export async function getThreadFeedback(
   userId: string = 'anonymous',
 ): Promise<Record<string, 'up' | 'down'>> {
   const response = await fetch(
-    `/api/proxy/agent/feedback/${encodeURIComponent(threadId)}?user_id=${encodeURIComponent(userId)}`,
+    `${buildAgentApiUrl(`/feedback/${encodeURIComponent(threadId)}`)}?user_id=${encodeURIComponent(userId)}`,
     {
       credentials: 'include',
     },

--- a/src/frontend/services/logout.ts
+++ b/src/frontend/services/logout.ts
@@ -6,6 +6,11 @@ import { chatStorage } from './chatStorage';
 
 const AUTH_STORAGE_KEYS = ['access_token', 'refresh_token', 'id_token'] as const;
 
+function buildGatewayLoginUrl(): string {
+  const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}` || '/';
+  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+}
+
 export async function logout() {
   try {
     await fetch('/auth/logout', {
@@ -31,5 +36,5 @@ export async function logout() {
   store.dispatch(clearAllToasts());
   store.dispatch(resetPersonalization());
 
-  window.location.assign('/login');
+  globalThis.location.assign(buildGatewayLoginUrl());
 }

--- a/src/frontend/types/user.ts
+++ b/src/frontend/types/user.ts
@@ -20,6 +20,7 @@ export interface AppData {
   apiUrl: string;
   refreshableToken: string;
   agentName: string;
+  basePath?: string;
 }
 
 // Extend the Window interface to include USER_DATA and APP_DATA

--- a/src/server/controllers/v1/agent.ts
+++ b/src/server/controllers/v1/agent.ts
@@ -8,11 +8,23 @@ interface StreamRequest {
   user_id: string;
 }
 
+function headerValue(request: FastifyRequest, name: string): string | undefined {
+  const v = request.headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function resolveAccessToken(request: FastifyRequest): string | undefined {
+  return (
+    request.session?.token?.access_token ||
+    headerValue(request, "x-auth-access-token") ||
+    headerValue(request, "x-token")
+  );
+}
+
 export async function handleStreamPost(fastify: FastifyInstance, request: FastifyRequest<{ Body: StreamRequest }>, reply: FastifyReply) {
   const { message, thread_id, session_id, user_id } = request.body;
 
-  // Extract SSO access token from session
-  const accessToken = request.session?.token?.access_token;
+  const accessToken = resolveAccessToken(request);
   
   fastify.log.info(`Stream request - Thread: ${thread_id}, User: ${user_id}, Token: ${accessToken ? 'Present' : 'Missing'}`);
 
@@ -100,8 +112,7 @@ export async function handleStreamPost(fastify: FastifyInstance, request: Fastif
 export async function handleHistoryGet(fastify: FastifyInstance, request: FastifyRequest<{ Params: { threadId: string } }>, reply: FastifyReply) {
   const { threadId } = request.params;
   
-  // Extract SSO access token from session
-  const accessToken = request.session?.token?.access_token;
+  const accessToken = resolveAccessToken(request);
   
   fastify.log.info(`History request for thread: ${threadId}, Token: ${accessToken ? 'Present' : 'Missing'}`);
 

--- a/src/server/plugins/auth-check.plugin.ts
+++ b/src/server/plugins/auth-check.plugin.ts
@@ -22,37 +22,84 @@ declare module "fastify" {
     redirectUri?: string;
   }
 }
+function headerValue(request: FastifyRequest, name: string): string | undefined {
+  const v = request.headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
+
+function buildGatewayLoginUrl(request: FastifyRequest): string {
+  const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
+  const redirectPath = `${basePath}${request.url}` || "/";
+  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+}
+
+function shouldSkipAuth(request: FastifyRequest): boolean {
+  const path = request.url.split("?")[0];
+  return path === "/_health" || path.startsWith("/auth/") || path === "/login";
+}
+
 function authCheck(
   instance: FastifyInstance,
   _options: Record<string, unknown>,
   done: (err?: Error) => void
 ) {
   instance.addHook("preHandler", (request: FastifyRequest, reply: FastifyReply, next: () => void) => {
-    if (process.env.AUTH_ENABLED === "false") {
-      const dummyUser = {
-        accessToken: "access-token",
-        expiresAt: "2026-10-29T23:20:00.417Z",
-        cn: "John Wick",
-        displayName: "John",
-        email: "johnwick@redhat.com",
-        email_verified: false,
-        family_name: "Wick",
-        givenName: "John",
-        given_name: "John",
-        mail: "johnwick@redhat.com",
-        name: "John Wick",
-        preferred_username: "johnwick",
-        rhatUUID: "asdsadsad-e194-11ef-a0f1-safdsfds",
-        sn: "Wick",
-        sub: "1sdsd1ef7-7e0c-4c45-a250-dssdsd"
-      };
+    if (shouldSkipAuth(request)) {
+      next();
+      return;
+    }
 
-      request.session.user = dummyUser;
+    if (process.env.AUTH_ENABLED === "false") {
+      const gwEmail = headerValue(request, "x-auth-user-email");
+      const gwName = headerValue(request, "x-auth-user-name");
+      const gwSub = headerValue(request, "x-auth-user-sub");
+      const gwToken = headerValue(request, "x-auth-access-token") || headerValue(request, "x-token");
+
+      if (gwEmail) {
+        request.session.user = {
+          email: gwEmail,
+          email_verified: true,
+          family_name: gwName?.split(" ").pop() || "",
+          given_name: gwName?.split(" ")[0] || "",
+          name: gwName || gwEmail,
+          preferred_username: gwEmail.split("@")[0],
+          sub: gwSub || gwEmail,
+        };
+      } else {
+        const dummyUser = {
+          accessToken: "access-token",
+          expiresAt: "2026-10-29T23:20:00.417Z",
+          cn: "John Wick",
+          displayName: "John",
+          email: "johnwick@redhat.com",
+          email_verified: false,
+          family_name: "Wick",
+          givenName: "John",
+          given_name: "John",
+          mail: "johnwick@redhat.com",
+          name: "John Wick",
+          preferred_username: "johnwick",
+          rhatUUID: "asdsadsad-e194-11ef-a0f1-safdsfds",
+          sn: "Wick",
+          sub: "1sdsd1ef7-7e0c-4c45-a250-dssdsd"
+        };
+        request.session.user = dummyUser;
+      }
+
+      if (gwToken) {
+        request.session.token = {
+          access_token: gwToken,
+          expires_at: Date.now() + 3600_000,
+          id_token: "",
+          refresh_token: "",
+          scope: "openid",
+        };
+      }
     }
 
     if (!request.session?.user) {
       request.session.redirectUri = request.url;
-      reply.redirect("/login");
+      reply.redirect(buildGatewayLoginUrl(request));
     } else {
       next();
     }

--- a/src/server/router/client.router.ts
+++ b/src/server/router/client.router.ts
@@ -4,6 +4,12 @@ import authCheckPlugin from "../plugins/auth-check.plugin.js";
 import { getAgentName } from "../utils/config.js";
 
 const BUILD_VERSION = Date.now().toString(36);
+const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
+
+function headerValue(request: FastifyRequest, name: string): string | undefined {
+  const v = request.headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
 
 async function routes(fastify: FastifyInstance) {
   await fastify.register(authCheckPlugin);
@@ -24,15 +30,18 @@ async function routes(fastify: FastifyInstance) {
     const session = request.session;
     const { user, token } = session;
 
+    const sessionToken = token?.access_token || headerValue(request, "x-auth-access-token") || headerValue(request, "x-token");
+
     const userData = {
       ...user,
-      accessToken: token?.access_token,
+      accessToken: sessionToken,
       expiresAt: token?.expires_at,
     };
 
     const agentName = await getAgentName();
     const appData = {
-      apiUrl: "",
+      apiUrl: basePath ? `${basePath}/api/proxy/agent` : "",
+      basePath: basePath || "/",
       refreshableToken: "",
       agentName,
     };
@@ -44,7 +53,7 @@ async function routes(fastify: FastifyInstance) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>${agentName}</title>
-    <link rel="stylesheet" href="/dist/frontend/template-ui.css">
+    <link rel="stylesheet" href="${basePath}/dist/frontend/template-ui.css">
     <style>
     /* PF6/Tailwind v4 co-existence: inline to bypass Vite CSS purging */
     .pf-v6-c-button{--pf-v6-c-button--AlignItems:center}
@@ -64,7 +73,7 @@ async function routes(fastify: FastifyInstance) {
     window.USER_DATA = ${JSON.stringify(userData || {})}
     window.APP_DATA = ${JSON.stringify(appData)}
     </script>
-    <script src="/dist/frontend/main.umd.js?v=${BUILD_VERSION}"></script>
+    <script src="${basePath}/dist/frontend/main.umd.js?v=${BUILD_VERSION}"></script>
 </body>
 </html>`);
   });


### PR DESCRIPTION
## Summary

- Add first-class support for agents served under an org-scoped path prefix (e.g. `/imrankha/dataverseprod1`) on a shared platform host.
- Integrate with platform gateway SSO: when `AUTH_ENABLED=false`, populate session user and access token from `X-Auth-*` headers injected by ingress.
- Forward gateway tokens to the agent backend on stream, history, and proxy requests so MCP and authenticated agent APIs work behind centralized auth.
- Centralize frontend path and API URL construction in `app-paths.ts` so chat navigation, health checks, streaming, and feedback use the correct prefixed routes.

## Test plan

- [ ] Deploy agent UI with `BASE_PATH=/imrankha/<agent>` and `AUTH_ENABLED=false`.
- [ ] Open `http://127.0.0.1:8080/imrankha/<agent>/` — page loads, CSS/JS assets resolve under prefix.
- [ ] Confirm `window.APP_DATA.basePath` and `apiUrl` in rendered HTML.
- [ ] New chat URL is `/imrankha/<agent>/chat/{id}`, not `/chat/{id}`.
- [ ] Agent health badge calls `/imrankha/<agent>/api/health/agent` and shows healthy.
- [ ] Send a chat message — stream completes; agent receives `Authorization` when gateway SSO is active.
- [ ] MCP-backed questions work when agent declares MCP servers (with template-agent companion change).
- [ ] Standalone UI OIDC still works when `AUTH_ENABLED=true` (no gateway headers).