### PR TITLE
fix(ui): guard against invalid timestamps causing RangeError

### DIFF
--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -44,6 +44,23 @@ import { setAuthExpiredCallback } from '../../services/authenticated-fetch';
 import { markChatAsClientCreated, isClientCreatedChat } from '../../services/newChatTracker';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 
+function toSafeDate(value: unknown): Date {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value === 'string' && value) {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  if (typeof value === 'number') {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date();
+}
+
+function toSafeISOString(value: unknown): string {
+  return toSafeDate(value).toISOString();
+}
+
 interface AppLayoutProps {
   children: React.ReactNode;
 }
@@ -84,10 +101,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     if (loadedChats.length > 0) {
       const mapped: ChatItem[] = loadedChats.map((c) => ({
         ...c,
-        timestamp:
-          typeof c.timestamp === 'string'
-            ? c.timestamp
-            : new Date(c.timestamp ?? Date.now()).toISOString(),
+        timestamp: toSafeISOString(c.timestamp),
         historicalActivities: c.historicalActivities ?? {},
         feedback: c.feedback ?? {},
       }));
@@ -113,7 +127,10 @@ export function AppLayout({ children }: AppLayoutProps) {
           history.filter((t) => t.title).map((t) => [t.id, t.title]),
         );
         const backendTimestampMap = new Map(
-          history.map((t) => [t.id, t.updatedAt || '']),
+          history.reduce<[string, string][]>((acc, t) => {
+            if (t.updatedAt) acc.push([t.id, t.updatedAt]);
+            return acc;
+          }, []),
         );
 
         const survivingWithTitles = surviving.map((c) => {
@@ -206,7 +223,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       chats.map((chat) => ({
         id: chat.id,
         title: chat.title,
-        timestamp: new Date(chat.timestamp),
+        timestamp: toSafeDate(chat.timestamp),
         preview:
           chat.messages.length > 0
             ? (chat.messages[0].content as string).substring(0, 60) + '...'


### PR DESCRIPTION
## Description

Fixes `RangeError: Invalid time value` crash in AppLayout when processing thread timestamps. Error seen in production on the agent chat UI.

## Changes

- Added `toSafeDate()` / `toSafeISOString()` helpers that validate Date via `Number.isNaN(d.getTime())` before returning, falling back to `new Date()` for invalid input
- Changed localStorage chat loading to use `toSafeISOString()` instead of raw `new Date(c.timestamp).toISOString()`
- Changed sidebar chat mapping to use `toSafeDate()` instead of raw `new Date(chat.timestamp)`
- Changed `backendTimestampMap` to filter out threads without `updatedAt` instead of mapping them to empty string `""`

## AI Disclosure

- **AI used**: Yes
- **Tool(s)**: Cursor (Opus 4.6)
- **Scope**: Full diagnosis (via minified bundle inspection in production pod) and fix implementation
- **Human verification**: Verified `toSafeDate("")`, `toSafeDate(null)`, `toSafeDate(undefined)`, `toSafeDate(new Date("invalid"))` all return valid Date

## Checklist

- [x] I have reviewed my own diff
- [ ] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

**Deployment**: No env vars or config changes. Frontend-only change. Rollback: revert commit and rebuild UI image.

**Security**: No auth, endpoint, or data handling changes. The helpers only affect date formatting for display purposes.

## Reviewer Notes

- Root cause: `backendTimestampMap` defaulted missing `updatedAt` to `""`, and `new Date("")` creates an Invalid Date that throws on `.toISOString()`
- `toSafeDate` handles all input types (string, Date, number, null, undefined) defensively
- Uses `Number.isNaN` instead of global `isNaN` per linter rules