### PR TITLE
Fix: register auth-check plugin on proxy routes

### DIFF
--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyReply } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import { agentHost } from '../utils/config.js';
+import authCheckPlugin from '../plugins/auth-check.plugin.js';
 
 /** In-memory LRU cache for thread state responses (avoids repeated LangGraph deserialization). */
 const THREAD_STATE_CACHE = new Map<string, { body: string; ts: number }>();
@@ -253,6 +254,8 @@ function buildForwardedQueryString(query: Record<string, unknown>): string {
 }
 
 async function proxyRoutes(fastify: FastifyInstance) {
+  await fastify.register(authCheckPlugin);
+
   /**
    * Streaming endpoint — translates between the UI's simple
    * {message, thread_id, user_id} payload and Aegra's LangGraph


### PR DESCRIPTION
## Description

Fix "session expired" error on all agent API calls when `AUTH_ENABLED=false`. The `authCheckPlugin` — which reads gateway-forwarded auth headers (`X-Token`, `X-Auth-User-Email`) and populates `request.session` — was registered on `clientRoutes` (page serving) but missing from `proxyRoutes` (API proxying). Without it, `ensureFreshTokens()` returns null, and the agent receives no valid Authorization header.

## Changes

- Import `authCheckPlugin` in `proxy.router.ts`
- Register `authCheckPlugin` at the start of `proxyRoutes()` so session token is populated before any proxy handler runs

## AI Disclosure

- **AI used**: Yes
- **Tool(s)**: Cursor (Claude Opus 4)
- **Scope**: Full PR — root cause diagnosis and fix
- **Human verification**: Hotfix validated on live preprod UI pod via ConfigMap mount before committing

## Checklist

- [x] I have reviewed my own diff
- [ ] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

**Deployment**: No new env vars or config. UI pod rebuild required. Zero downtime — rolling restart safe.

**Security**: Ensures the access token from the Nginx gateway auth check is properly forwarded to the agent backend on all proxy API calls. Does not change the auth flow — just ensures the existing `auth-check.plugin` runs on proxy routes in addition to client routes.

## Reviewer Notes

- The `auth-check.plugin` was already registered on `clientRoutes` in the server setup — this adds the same registration to `proxyRoutes`
- This is only needed when `AUTH_ENABLED=false` (the full SSO plugin handles session population when enabled)
- Hotfix was validated on preprod before this PR