### PR TITLE
FEAT: Auth fixes + claude streaming fixes

### DIFF
--- a/env.template
+++ b/env.template
@@ -5,6 +5,7 @@ COOKIE_SIGN=your-secret-with-minimum-length-of-32-characters
 AUTH_ENABLED=false
 SSO_CLIENT_ID=your-sso-client-id
 SSO_CLIENT_SECRET=your-sso-client-secret
+# Also used to derive CSP connect_src (browser must be allowed to reach SSO)
 SSO_ISSUER_HOST=https://your-sso-provider.com
 SSO_CALLBACK_URL=http://localhost:5003/auth/callback/oidc
 

--- a/src/frontend/components/SessionExpiredModal.tsx
+++ b/src/frontend/components/SessionExpiredModal.tsx
@@ -13,7 +13,7 @@ export interface SessionExpiredModalProps {
 
 function buildGatewayLoginUrl(): string {
   const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}` || '/';
-  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+  return `/login?redirect=${encodeURIComponent(redirectPath)}`;
 }
 
 export function SessionExpiredModal({ isOpen }: Readonly<SessionExpiredModalProps>) {

--- a/src/frontend/services/logout.ts
+++ b/src/frontend/services/logout.ts
@@ -8,7 +8,7 @@ const AUTH_STORAGE_KEYS = ['access_token', 'refresh_token', 'id_token'] as const
 
 function buildGatewayLoginUrl(): string {
   const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}` || '/';
-  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+  return `/login?redirect=${encodeURIComponent(redirectPath)}`;
 }
 
 export async function logout() {

--- a/src/server/plugins/auth-check.plugin.ts
+++ b/src/server/plugins/auth-check.plugin.ts
@@ -30,7 +30,7 @@ function headerValue(request: FastifyRequest, name: string): string | undefined 
 function buildGatewayLoginUrl(request: FastifyRequest): string {
   const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
   const redirectPath = `${basePath}${request.url}` || "/";
-  return `/auth/login?redirect=${encodeURIComponent(redirectPath)}`;
+  return `/login?redirect=${encodeURIComponent(redirectPath)}`;
 }
 
 function shouldSkipAuth(request: FastifyRequest): boolean {

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -107,82 +107,132 @@ function translateMessageEvent(
   chunkId: number,
   prevPartial: string,
   sentMsgIds: Set<string>,
-): [{ type: string; content: unknown; chunk_id: number } | null, string] {
-  if (!Array.isArray(payload) || payload.length === 0) return [null, prevPartial];
-  const [msg] = payload;
-  if (!msg || typeof msg !== 'object') return [null, prevPartial];
+): [Array<{ type: string; content: unknown }>, string] {
+  // ── Handle 'updates' events (complete node outputs with full args) ──
+  if (sseType === 'updates') {
+    const data = payload as Record<string, any> | null;
+    if (!data || typeof data !== 'object') return [[], prevPartial];
 
+    const chunks: Array<{ type: string; content: unknown }> = [];
+
+    // updates payload varies: { nodeName: { messages: [...] } } or { nodeName: [...] }
+    const messageLists: any[][] = [];
+    for (const value of Object.values(data)) {
+      if (Array.isArray(value)) {
+        messageLists.push(value);
+      } else if (value && typeof value === 'object' && Array.isArray((value as any).messages)) {
+        messageLists.push((value as any).messages);
+      }
+    }
+
+    for (const messages of messageLists) {
+      for (const msg of messages) {
+        if (!msg || typeof msg !== 'object') continue;
+        const msgType = (msg.type ?? '').toString().toLowerCase();
+
+        // AI messages with tool calls — emit with complete args
+        if ((msgType === 'ai' || msgType === 'aimessage') && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+          const msgId = msg.id ?? `ai-upd-${chunkId}`;
+          if (sentMsgIds.has(msgId)) continue;
+          sentMsgIds.add(msgId);
+          const toolCalls = extractToolCalls(msg);
+          chunks.push({
+            type: 'message',
+            content: { type: 'ai', content: '', tool_calls: toolCalls, id: msgId },
+          });
+        }
+
+        // Tool result messages
+        if (msgType === 'tool' || msgType === 'toolmessage') {
+          const toolCallId = msg.tool_call_id ?? '';
+          const dedupKey = `tool-${toolCallId}`;
+          if (!sentMsgIds.has(dedupKey)) {
+            sentMsgIds.add(dedupKey);
+            chunks.push({
+              type: 'message',
+              content: {
+                type: 'tool',
+                content: extractText(msg.content) || JSON.stringify(msg.content),
+                tool_call_id: toolCallId,
+                name: msg.name ?? 'unknown',
+              },
+            });
+          }
+        }
+      }
+    }
+
+    return [chunks, prevPartial];
+  }
+
+  // ── Handle 'messages/partial' (text token streaming only) ──
   if (sseType === 'messages/partial') {
+    if (!Array.isArray(payload) || payload.length === 0) return [[], prevPartial];
+    const [msg] = payload;
+    if (!msg || typeof msg !== 'object') return [[], prevPartial];
+
     const raw = msg as Record<string, any>;
     const toolCalls = extractToolCalls(raw);
 
+    // Skip partials that have tool calls — we get complete data from 'updates'
     if (toolCalls.length > 0) {
-      const msgId = raw.id ?? `ai-tc-${chunkId}`;
-      if (!sentMsgIds.has(msgId)) {
-        sentMsgIds.add(msgId);
-        return [{
-          type: 'message',
-          content: {
-            type: 'ai',
-            content: '',
-            tool_calls: toolCalls,
-            id: msgId,
-          },
-          chunk_id: chunkId,
-        }, ''];
-      }
-      return [null, prevPartial];
+      const fullText = extractText(raw.content);
+      return [[], fullText || prevPartial];
     }
 
     const fullText = extractText(raw.content);
-    return [null, fullText];
+    return [[], fullText];
   }
 
+  // ── Handle 'messages/complete' (tool results as fallback) ──
   if (sseType === 'messages/complete') {
+    if (!Array.isArray(payload) || payload.length === 0) return [[], prevPartial];
+    const [msg] = payload;
+    if (!msg || typeof msg !== 'object') return [[], prevPartial];
+
     const raw = msg as Record<string, any>;
     const msgType = (raw.type ?? '').toString().toLowerCase();
 
+    // AI messages with tool calls — emit if not already sent via updates
     const toolCalls = extractToolCalls(raw);
     if ((msgType === 'ai' || msgType === 'aimessage' || !msgType) && toolCalls.length > 0) {
       const msgId = raw.id ?? `ai-${chunkId}`;
       if (!sentMsgIds.has(msgId)) {
         sentMsgIds.add(msgId);
-        return [{
+        return [[{
           type: 'message',
-          content: {
-            type: 'ai',
-            content: '',
-            tool_calls: toolCalls,
-            id: msgId,
-          },
-          chunk_id: chunkId,
-        }, ''];
+          content: { type: 'ai', content: '', tool_calls: toolCalls, id: msgId },
+        }], prevPartial];
       }
-      return [null, ''];
+      return [[], prevPartial];
     }
 
+    // Tool results — emit if not already sent via updates
     if (msgType === 'tool' || msgType === 'toolmessage') {
-      return [{
+      const toolCallId = raw.tool_call_id ?? '';
+      const dedupKey = `tool-${toolCallId}`;
+      if (sentMsgIds.has(dedupKey)) return [[], prevPartial];
+      sentMsgIds.add(dedupKey);
+      return [[{
         type: 'message',
         content: {
           type: 'tool',
           content: extractText(raw.content) || JSON.stringify(raw.content),
-          tool_call_id: raw.tool_call_id ?? '',
+          tool_call_id: toolCallId,
           name: raw.name ?? 'unknown',
         },
-        chunk_id: chunkId,
-      }, ''];
+      }], prevPartial];
     }
 
     if (msgType === 'ai' || msgType === 'aimessage') {
       const fullText = extractText(raw.content);
       if (fullText.length > 0) {
-        return [null, fullText];
+        return [[], fullText];
       }
     }
   }
 
-  return [null, prevPartial];
+  return [[], prevPartial];
 }
 
 interface TokenPair {
@@ -317,7 +367,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
 
         const runBody: Record<string, unknown> = {
           assistant_id: 'agent',
-          stream_mode: ['messages'],
+          stream_mode: ['messages', 'updates'],
         };
         if (isResume) {
           runBody.command = { resume: message };
@@ -445,7 +495,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   continue;
                 }
 
-                const [uiChunk, nextPartial] = translateMessageEvent(
+                const [uiChunks, nextPartial] = translateMessageEvent(
                   sseType,
                   parsed,
                   chunkId,
@@ -453,7 +503,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   sentMsgIds,
                 );
 
-                if (nextPartial.length > prevPartial.length && !uiChunk) {
+                if (nextPartial.length > prevPartial.length && uiChunks.length === 0) {
                   const isEchoOfPrior = completedTexts.some(
                     (ct) => nextPartial.length <= ct.length && ct.startsWith(nextPartial),
                   );
@@ -465,13 +515,13 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   }
                 }
 
-                if (sseType === 'messages/complete' && !uiChunk && nextPartial.length > 0) {
+                if (sseType === 'messages/complete' && uiChunks.length === 0 && nextPartial.length > 0) {
                   completedTexts.push(nextPartial);
                 }
 
                 prevPartial = nextPartial;
-                if (uiChunk) {
-                  reply.raw.write(`data: ${JSON.stringify(uiChunk)}\n\n`);
+                for (const chunk of uiChunks) {
+                  reply.raw.write(`data: ${JSON.stringify({ ...chunk, chunk_id: chunkId })}\n\n`);
                   chunkId++;
                 }
               } catch {

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -155,5 +155,17 @@ export function getSettings(): UISettings {
     ? deepMerge(DEFAULTS as unknown as Record<string, unknown>, fromFile) as unknown as UISettings
     : { ...DEFAULTS };
 
+  if (process.env.SSO_ISSUER_HOST) {
+    try {
+      const ssoOrigin = new URL(process.env.SSO_ISSUER_HOST).origin;
+      const connectSrc = _settings.security.helmet.csp.connect_src;
+      if (!connectSrc.includes(ssoOrigin)) {
+        connectSrc.push(ssoOrigin);
+      }
+    } catch {
+      /* invalid URL — skip */
+    }
+  }
+
   return _settings;
 }


### PR DESCRIPTION
- Fix authentication redirect URLs by removing the /auth prefix from login paths (/auth/login → /login) across frontend and server
- Add https://auth.redhat.com to the CSP connect-src directive to allow SSO token refresh calls
- Rework SSE streaming proxy to consume updates events alongside messages, providing complete tool call arguments instead of partial/incomplete ones (This fixes claude's tool call and subagent call streaming)

### Changes
**Auth fixes:**
1. SessionExpiredModal.tsx, logout.ts, auth-check.plugin.ts — update gateway login URL from /auth/login to /login
2. settings.ts — allow connect-src to https://auth.redhat.com

**Streaming improvements (proxy.router.ts):**
1. Subscribe to stream_mode: ['messages', 'updates'] instead of just ['messages']
2. Handle updates SSE events which carry complete tool call args and tool results
3. translateMessageEvent now returns an array of chunks (multiple tool calls per event)
4. Deduplicate tool results across updates and messages/complete using sentMsgIds
5. Skip emitting partial tool calls from messages/partial (rely on updates for complete data)
