### PR TITLE
feat: add MCP OAuth precheck and auth interrupt resume flow

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -15,7 +15,7 @@ import type { RootState, AppDispatch } from './redux/store';
 
 export default function App() {
   const dispatch = useDispatch<AppDispatch>();
-  const { branding, features, loading, error } = useSelector((state: RootState) => state.config);
+  const { branding, loading, error } = useSelector((state: RootState) => state.config);
   const theme = useSelector((state: RootState) => state.userSettings.theme);
 
   useThemeSync();

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -493,8 +493,6 @@ export function AIMessageRenderer({ message }: { message: Message }) {
             <SubAgentIndicator
               key={`${message.id}-sa-${idx}`}
               toolCall={toolCall as any}
-              messageId={message.id ?? ''}
-              index={idx}
             />
           ))}
 

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   Button,
   TextInput,
 } from '@patternfly/react-core';
-import { CheckCircle, XCircle } from 'lucide-react';
+import { CheckCircle, Link2, XCircle } from 'lucide-react';
+import { buildAgentApiUrl } from '../lib/app-paths';
 import type { InterruptInfo } from '../types/deep-agent';
 
 interface InterruptBannerProps {
@@ -20,8 +21,115 @@ function isToolApproval(value: string): boolean {
     || lower.includes('allow') || lower.includes('proceed');
 }
 
+function parseMcpAuthPayload(interrupt: InterruptInfo): InterruptInfo['payload'] | null {
+  if (interrupt.payload?.type === 'mcp_auth_required') {
+    return interrupt.payload;
+  }
+  try {
+    const parsed = JSON.parse(interrupt.value) as unknown;
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && (parsed as { type?: string }).type === 'mcp_auth_required'
+    ) {
+      return parsed as InterruptInfo['payload'];
+    }
+  } catch {
+    // not JSON — fall through
+  }
+  return null;
+}
+
 export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBannerProps) {
   const [response, setResponse] = useState('');
+  const [oauthReady, setOauthReady] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  const mcpAuth = parseMcpAuthPayload(interrupt);
+
+  useEffect(() => {
+    if (!mcpAuth) return undefined;
+
+    const handler = (event: MessageEvent) => {
+      const data = event.data as { type?: string; mcp_name?: string } | null;
+      if (data?.type === 'mcp_oauth_done' && data.mcp_name === mcpAuth.mcp_name) {
+        setOauthReady(true);
+        setConnectError(null);
+      }
+    };
+
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [mcpAuth]);
+
+  const handleConnect = useCallback(async () => {
+    if (!mcpAuth) return;
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const connectUrl = buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpAuth.mcp_name)}/connect`);
+      const resp = await fetch(connectUrl, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(text || `Connect failed (${resp.status})`);
+      }
+      const body = (await resp.json()) as { authorize_url?: string };
+      if (!body.authorize_url) {
+        throw new Error('No authorize_url returned');
+      }
+      window.open(body.authorize_url, 'mcp-oauth', 'width=600,height=700');
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : 'Connect failed');
+    } finally {
+      setConnecting(false);
+    }
+  }, [mcpAuth]);
+
+  if (mcpAuth) {
+    return (
+      <div className="mx-4 mb-3" role="alert">
+        <Alert
+          variant="warning"
+          title="MCP Connection Required"
+          isInline
+          actionClose={<AlertActionCloseButton onClose={onDismiss} />}
+        >
+          <p className="text-sm mb-3 whitespace-pre-wrap">{mcpAuth.message}</p>
+          {connectError && (
+            <p className="text-sm text-red-600 mb-2">{connectError}</p>
+          )}
+          <div className="flex items-center gap-2">
+            {!oauthReady ? (
+              <Button
+                variant="primary"
+                size="sm"
+                icon={<Link2 className="w-3.5 h-3.5" />}
+                isLoading={connecting}
+                onClick={() => void handleConnect()}
+              >
+                Connect
+              </Button>
+            ) : (
+              <Button
+                variant="primary"
+                size="sm"
+                icon={<CheckCircle className="w-3.5 h-3.5" />}
+                onClick={() => onResume('continue')}
+              >
+                Continue
+              </Button>
+            )}
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
   const approval = isToolApproval(interrupt.value);
 
   if (approval) {

--- a/src/frontend/components/McpOAuthPrecheck.tsx
+++ b/src/frontend/components/McpOAuthPrecheck.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, Button } from '@patternfly/react-core';
+import { Link2 } from 'lucide-react';
+import { buildAgentApiUrl } from '../lib/app-paths';
+
+interface McpOAuthPrecheckProps {
+  readonly onConnected: () => void;
+}
+
+const OAUTH_STATUS_RETRY_MS = 400;
+const OAUTH_STATUS_MAX_RETRIES = 6;
+
+async function fetchDisconnectedMcps(): Promise<string[]> {
+  const infoResp = await fetch(buildAgentApiUrl('/info'), { credentials: 'include' });
+  if (!infoResp.ok) return [];
+
+  const info = (await infoResp.json()) as { oauth_mcps?: string[] };
+  const oauthMcps = info.oauth_mcps ?? [];
+  if (oauthMcps.length === 0) return [];
+
+  const pending: string[] = [];
+  await Promise.all(
+    oauthMcps.map(async (name) => {
+      const statusResp = await fetch(
+        buildAgentApiUrl(`/mcp/${encodeURIComponent(name)}/status`),
+        { credentials: 'include' },
+      );
+      if (!statusResp.ok) {
+        pending.push(name);
+        return;
+      }
+      const body = (await statusResp.json()) as { connected?: boolean };
+      if (!body.connected) {
+        pending.push(name);
+      }
+    }),
+  );
+  return pending;
+}
+
+export function McpOAuthPrecheck({ onConnected }: McpOAuthPrecheckProps) {
+  const [disconnected, setDisconnected] = useState<string[]>([]);
+  const [connecting, setConnecting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const hadPendingRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const pending = await fetchDisconnectedMcps();
+      setDisconnected(pending);
+    } catch {
+      // non-fatal — precheck is best-effort
+    }
+  }, []);
+
+  /** Re-fetch until *mcpName* reports connected (token may lag after callback). */
+  const refreshAfterOAuth = useCallback(async (mcpName: string) => {
+    for (let attempt = 0; attempt < OAUTH_STATUS_MAX_RETRIES; attempt++) {
+      try {
+        const pending = await fetchDisconnectedMcps();
+        setDisconnected(pending);
+        if (!pending.includes(mcpName)) {
+          return;
+        }
+      } catch {
+        // retry
+      }
+      if (attempt < OAUTH_STATUS_MAX_RETRIES - 1) {
+        await new Promise((resolve) => setTimeout(resolve, OAUTH_STATUS_RETRY_MS));
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const onOAuthDone = (event: MessageEvent) => {
+      const data = event.data as { type?: string; mcp_name?: string } | null;
+      if (data?.type !== 'mcp_oauth_done' || !data.mcp_name) return;
+      setError(null);
+      // Optimistic: drop this MCP from the list immediately.
+      setDisconnected((prev) => prev.filter((name) => name !== data.mcp_name));
+      void refreshAfterOAuth(data.mcp_name);
+    };
+
+    const onFocus = () => {
+      void refresh();
+    };
+
+    window.addEventListener('message', onOAuthDone);
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('message', onOAuthDone);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [refresh, refreshAfterOAuth]);
+
+  // Notify parent once when all required MCPs are connected.
+  useEffect(() => {
+    if (disconnected.length > 0) {
+      hadPendingRef.current = true;
+      return;
+    }
+    if (hadPendingRef.current) {
+      hadPendingRef.current = false;
+      onConnected();
+    }
+  }, [disconnected.length, onConnected]);
+
+  const handleConnect = useCallback(async (mcpName: string) => {
+    setConnecting(mcpName);
+    setError(null);
+    try {
+      const resp = await fetch(
+        buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpName)}/connect`),
+        { method: 'POST', credentials: 'include' },
+      );
+      if (!resp.ok) {
+        throw new Error(await resp.text());
+      }
+      const body = (await resp.json()) as { authorize_url?: string };
+      if (!body.authorize_url) {
+        throw new Error('No authorize_url returned');
+      }
+      window.open(body.authorize_url, 'mcp-oauth', 'width=600,height=700');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Connect failed');
+    } finally {
+      setConnecting(null);
+    }
+  }, []);
+
+  if (disconnected.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mx-4 mb-3" role="alert">
+      <Alert variant="warning" title="MCP connections required" isInline>
+        <p className="text-sm mb-2">
+          Connect to the following MCP servers before using their tools:
+        </p>
+        <ul className="text-sm mb-3 list-disc pl-5">
+          {disconnected.map((name) => (
+            <li key={name}>{name}</li>
+          ))}
+        </ul>
+        {error && <p className="text-sm text-red-600 mb-2">{error}</p>}
+        <div className="flex flex-wrap gap-2">
+          {disconnected.map((name) => (
+            <Button
+              key={name}
+              variant="primary"
+              size="sm"
+              icon={<Link2 className="w-3.5 h-3.5" />}
+              isLoading={connecting === name}
+              onClick={() => void handleConnect(name)}
+            >
+              Connect {name}
+            </Button>
+          ))}
+        </div>
+      </Alert>
+    </div>
+  );
+}

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -41,6 +41,7 @@ function SidebarComponent({
   onNewChat,
   onSelectChat,
   onDeleteChat,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onDeleteAllChats,
   onRenameChat,
 }: SidebarProps) {

--- a/src/frontend/components/SubAgentIndicator.tsx
+++ b/src/frontend/components/SubAgentIndicator.tsx
@@ -12,8 +12,6 @@ import { extractSubAgentName } from '../types/deep-agent';
 
 interface SubAgentIndicatorProps {
   readonly toolCall: ToolCallWithContent;
-  readonly messageId: string;
-  readonly index: number;
 }
 
 type VisualStatus = 'delegating' | 'complete' | 'error';
@@ -35,7 +33,7 @@ const STATUS_CONFIG: Record<VisualStatus, {
   error:      { label: 'Error', color: 'red', icon: AlertCircle, animate: false },
 };
 
-export function SubAgentIndicator({ toolCall, messageId, index }: SubAgentIndicatorProps) {
+export function SubAgentIndicator({ toolCall }: SubAgentIndicatorProps) {
   const [expanded, setExpanded] = useState(false);
   const name = extractSubAgentName(toolCall);
   const status = deriveStatus(toolCall);

--- a/src/frontend/components/layout/ThemeToggle.tsx
+++ b/src/frontend/components/layout/ThemeToggle.tsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
         id="theme-toggle"
         aria-label="Toggle dark mode"
         isChecked={isDark}
-        onChange={(_event, _checked) => {
+        onChange={() => {
           dispatch(toggleTheme());
         }}
         isReversed

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -4,6 +4,7 @@ import type { AIMessage, Message } from '@langchain/langgraph-sdk';
 import type { StreamEvent } from '@/hooks/useDataStream';
 import {
   StreamingManager,
+  type InterruptPayload,
   type StreamCallback,
   type StreamStatus,
 } from '@/lib/streaming/StreamingManager';
@@ -23,6 +24,26 @@ import { chatStorage } from '@/services/chatStorage';
 import { buildAgentApiUrl } from '@/lib/app-paths';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
+import type { InterruptInfo } from '@/types/deep-agent';
+
+function enrichInterrupt(interrupt: InterruptPayload): InterruptInfo {
+  try {
+    const parsed = JSON.parse(interrupt.value) as unknown;
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && (parsed as { type?: string }).type === 'mcp_auth_required'
+    ) {
+      return {
+        ...interrupt,
+        payload: parsed as NonNullable<InterruptInfo['payload']>,
+      };
+    }
+  } catch {
+    // plain-text interrupt
+  }
+  return interrupt;
+}
 
 function cloneMessages(messages: Message[]): Message[] {
   return messages.map((m) => JSON.parse(JSON.stringify(m)) as Message);
@@ -377,7 +398,7 @@ export function useStreamingAPI(threadId: string) {
               dispatch(
                 updateStreamingState({
                   chatId: threadId,
-                  state: { pendingInterrupt: interrupt },
+                  state: { pendingInterrupt: enrichInterrupt(interrupt) },
                 }),
               );
             },
@@ -486,6 +507,91 @@ export function useStreamingAPI(threadId: string) {
     [dispatch, threadId, memories, activeRules, handleStreamActivityStatus],
   );
 
+  const resumeInterrupt = useCallback(
+    async (response: string) => {
+      const manager = managerRef.current;
+      if (!manager || !threadId) return;
+
+      dispatch(
+        updateStreamingState({
+          chatId: threadId,
+          state: { pendingInterrupt: null, isLoading: true, error: null },
+        }),
+      );
+
+      const token = typeof window.USER_DATA.accessToken === 'string' ? window.USER_DATA.accessToken : undefined;
+      const userId =
+        typeof window.USER_DATA.preferred_username === 'string'
+          ? window.USER_DATA.preferred_username
+          : '';
+      const apiUrl = typeof window.APP_DATA?.apiUrl === 'string' ? window.APP_DATA.apiUrl : '';
+
+      const streamRequest = {
+        message: response,
+        threadId,
+        userId,
+        apiUrl,
+        token,
+        resume: true,
+        memories: memories.map((m) => m.content),
+        rules: activeRules.map((r) => r.content),
+      };
+
+      await new Promise<void>((resolve) => {
+        const callbacks: StreamCallback = {
+          onToken(content) {
+            lastTokenTimeRef.current = Date.now();
+            if (!isStreamingTokensRef.current) {
+              const message: AIMessage = {
+                type: 'ai',
+                content,
+                tool_calls: [],
+                id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              };
+              dispatch(appendMessageToChat({ chatId: threadId, message }));
+              isStreamingTokensRef.current = true;
+              return;
+            }
+            dispatch(updateLastMessageInChat({ chatId: threadId, content }));
+          },
+          onMessage(m) {
+            isStreamingTokensRef.current = false;
+            if (m.type !== 'human') {
+              dispatch(appendMessageToChat({ chatId: threadId, message: m }));
+            }
+          },
+          onInterrupt(interrupt) {
+            dispatch(
+              updateStreamingState({
+                chatId: threadId,
+                state: { pendingInterrupt: enrichInterrupt(interrupt) },
+              }),
+            );
+          },
+          onError(error) {
+            dispatch(
+              updateStreamingState({
+                chatId: threadId,
+                state: { error: error.message, isLoading: false, isConnected: false },
+              }),
+            );
+          },
+          onStatusChange(status) {
+            const partial = nextStreamingPartialForStatus(status);
+            if (partial) {
+              dispatch(updateStreamingState({ chatId: threadId, state: partial }));
+            }
+          },
+          onDone() {
+            resolve();
+          },
+        };
+        void manager.stream(streamRequest, callbacks);
+      });
+    },
+    [dispatch, threadId, memories, activeRules],
+  );
+
   const stop = useCallback(() => {
     userCancelledRef.current = true;
     managerRef.current?.cancel();
@@ -508,6 +614,7 @@ export function useStreamingAPI(threadId: string) {
     pendingInterrupt: streamingState.pendingInterrupt,
     taskSteps: streamingState.taskSteps,
     submit,
+    resumeInterrupt,
     stop,
     setMessages,
     retryCount,

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -14,6 +14,7 @@ export interface StreamRequest {
   token?: string;
   memories?: string[];
   rules?: string[];
+  resume?: boolean;
 }
 
 export type StreamStatus = 'idle' | 'connecting' | 'streaming' | 'error' | 'cancelled';
@@ -131,6 +132,9 @@ export class StreamingManager {
         user_id: request.userId,
         stream_tokens: true,
       };
+      if (request.resume) {
+        body.resume = true;
+      }
       if (request.memories?.length) body.memories = request.memories;
       if (request.rules?.length) body.rules = request.rules;
 

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -20,6 +20,7 @@ import { useRateLimitState } from '../hooks/useRateLimitState';
 import { ChatMessagesView } from '../components/ChatMessagesView';
 import { ChatErrorBoundary } from '../components/ChatErrorBoundary';
 import { InterruptBanner } from '../components/InterruptBanner';
+import { McpOAuthPrecheck } from '../components/McpOAuthPrecheck';
 import { TaskProgressStepper } from '../components/TaskProgressStepper';
 import { TasksSidebar } from '../components/TasksSidebar';
 import { DebugPanel } from '../components/DebugPanel';
@@ -302,19 +303,8 @@ export function ChatPage({ threadId }: { threadId: string }) {
   const handleInterruptResume = useCallback(
     async (response: string) => {
       if (!threadId || !currentChat) return;
-      dispatch(
-        updateStreamingState({
-          chatId: threadId,
-          state: { pendingInterrupt: null },
-        }),
-      );
-      const resumeMessage: Message = {
-        id: `msg-${Date.now()}`,
-        type: 'human',
-        content: response,
-      };
       try {
-        await thread.submit({ messages: [...thread.messages, resumeMessage] });
+        await thread.resumeInterrupt(response);
       } catch (err) {
         console.error('Failed to resume:', err);
         dispatch(addToast({ title: 'Failed to resume', variant: 'danger' }));
@@ -331,6 +321,16 @@ export function ChatPage({ threadId }: { threadId: string }) {
       }),
     );
   }, [dispatch, threadId]);
+
+  const handleMcpConnected = useCallback(() => {
+    dispatch(
+      addToast({
+        title: 'MCP connected',
+        message: 'Tools are ready. Send a message to use them.',
+        variant: 'success',
+      }),
+    );
+  }, [dispatch]);
 
   const handleNewChat = useCallback(() => {
     navigate('/');
@@ -406,6 +406,9 @@ export function ChatPage({ threadId }: { threadId: string }) {
         <div className="flex-1 flex flex-col min-w-0">
           {hasToolCalls && (
             <TaskProgressStepper messages={thread.messages} isLoading={thread.isLoading} />
+          )}
+          {!thread.pendingInterrupt && (
+            <McpOAuthPrecheck onConnected={handleMcpConnected} />
           )}
           {thread.pendingInterrupt && (
             <InterruptBanner

--- a/src/frontend/types/deep-agent.ts
+++ b/src/frontend/types/deep-agent.ts
@@ -17,6 +17,12 @@ export interface ToolCallWithContent {
 export interface InterruptInfo {
   value: string;
   resumable: boolean;
+  payload?: {
+    type: 'mcp_auth_required';
+    mcp_name: string;
+    connect_url: string;
+    message: string;
+  };
 }
 
 export interface TaskStep {
@@ -73,7 +79,7 @@ export function extractTodosFromMessages(messages: { type: string; tool_calls?: 
 }
 
 const CODE_FENCE_RE = /```[\s\S]*?```/;
-const JSON_START_RE = /^\s*[{\[]/;
+const JSON_START_RE = /^\s*[{[]/;
 
 export type ArtifactKind = 'code' | 'json' | 'markdown' | 'text';
 

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -81,7 +81,7 @@ async function routes(fastify: FastifyInstance) {
       await fastify.redhatSSO.userinfo(token.access_token);
 
       return reply.send({ message: "ValidToken" });
-    } catch (error: unknown) {
+    } catch {
       try {
         const newAccessToken =
           await fastify.redhatSSO.getNewAccessTokenUsingRefreshToken(token, {});

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -47,10 +47,6 @@ interface StreamRequestBody {
   rules?: string[];
 }
 
-interface ProxyRequestBody {
-  [key: string]: unknown;
-}
-
 /**
  * Extract text from a LangGraph message content field, which may be
  * a plain string OR an array of typed blocks [{type:"text", text:"..."}].


### PR DESCRIPTION
Add proactive OAuth banner via /info and /mcp/{name}/status, handle mcp_auth_required interrupts in the chat UI, and wire resumeInterrupt through the streaming API.

## Summary
- Add `McpOAuthPrecheck` banner for enabled OAuth/DCR MCPs (via `/info` + `/mcp/{name}/status`)
- Handle `mcp_auth_required` interrupts in `InterruptBanner` with connect/resume flow
- Wire `resumeInterrupt` through `useStreamingAPI` and `StreamingManager`
- Minor ESLint fixes in App, Sidebar, ThemeToggle, and proxy router