### PR TITLE
feat: OPA policy engine for UI config compliance

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,10 @@ FROM registry.access.redhat.com/ubi10/nodejs-24:10.1
 
 USER root
 
+ARG OPA_VERSION=1.4.2
+RUN curl -fsSL "https://github.com/open-policy-agent/opa/releases/download/v${OPA_VERSION}/opa_linux_amd64_static" \
+    -o /usr/local/bin/opa && chmod 755 /usr/local/bin/opa
+
 WORKDIR /opt/app-root/src
 
 COPY --chown=1001:0 package*.json ./

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev clean local deploy undeploy
+.PHONY: dev clean local deploy undeploy opa-build
 
 # OpenShift namespace (can be overridden: make deploy openshift NAMESPACE=my-project)
 NAMESPACE ?= $(shell oc project -q 2>/dev/null)
@@ -20,6 +20,11 @@ install:
 		echo ".env file already exists, skipping copy"; \
 	fi
 	@npm ci
+
+opa-check:
+	@which opa > /dev/null || (echo "Error: opa CLI not found. Install from https://www.openpolicyagent.org/docs/latest/#running-opa" && exit 1)
+	opa check config/compliance/
+	@echo "OPA policy syntax OK"
 
 clean:
 	rm -rf node_modules dist

--- a/config/compliance/data.json
+++ b/config/compliance/data.json
@@ -1,0 +1,8 @@
+{
+  "approved_auth_providers": [],
+  "internal_endpoint_suffixes": [],
+  "max_session_ttl_days": 0,
+  "restrict_debug_mode": false,
+  "restricted_features": [],
+  "max_rate_limit": 0
+}

--- a/config/compliance/policy.rego
+++ b/config/compliance/policy.rego
@@ -1,0 +1,59 @@
+package compliance.ui
+
+import rego.v1
+
+default allow := true
+
+deny contains msg if {
+	input.features.auth_enabled
+	input.platform.opa.approved_auth_providers
+	count(input.platform.opa.approved_auth_providers) > 0
+	not input.auth_provider in input.platform.opa.approved_auth_providers
+	msg := sprintf("auth provider '%s' is not in the approved list %v", [input.auth_provider, input.platform.opa.approved_auth_providers])
+}
+
+deny contains msg if {
+	input.agent.endpoint != ""
+	suffixes := input.platform.opa.internal_endpoint_suffixes
+	count(suffixes) > 0
+	not endpoint_allowed(input.agent.endpoint, suffixes)
+	msg := sprintf("agent endpoint '%s' does not match any approved internal suffix %v", [input.agent.endpoint, suffixes])
+}
+
+deny contains msg if {
+	max_days := input.platform.opa.max_session_ttl_days
+	max_days > 0
+	input.security.session.max_age_days > max_days
+	msg := sprintf("session TTL %d days exceeds maximum allowed %d days", [input.security.session.max_age_days, max_days])
+}
+
+deny contains msg if {
+	input.platform.opa.restrict_debug_mode
+	input.features.debug_mode_default
+	msg := "debug_mode_default cannot be enabled in this environment"
+}
+
+deny contains msg if {
+	restricted := input.platform.opa.restricted_features
+	some feature in restricted
+	input.features[feature]
+	msg := sprintf("feature '%s' is restricted by policy", [feature])
+}
+
+deny contains msg if {
+	max_rate := input.platform.opa.max_rate_limit
+	max_rate > 0
+	input.security.rate_limit.max > max_rate
+	msg := sprintf("rate limit %d exceeds policy maximum %d", [input.security.rate_limit.max, max_rate])
+}
+
+endpoint_allowed(endpoint, suffixes) if {
+	some suffix in suffixes
+	endswith(endpoint, suffix)
+}
+
+allow := false if {
+	count(deny) > 0
+}
+
+violations := deny

--- a/config/ui/settings.yaml
+++ b/config/ui/settings.yaml
@@ -22,3 +22,15 @@ agent:
   endpoint: ""
   timeout_ms: 30000
   streaming: true
+
+platform:
+  opa:
+    enabled: false
+    policy_path: ""                        # Path to .rego policy directory (default: config/compliance/)
+    fail_on_violation: false               # Block startup if policy violations are found
+    approved_auth_providers: []            # e.g. ["oidc", "saml"] — empty = allow all
+    internal_endpoint_suffixes: []         # e.g. [".internal.example.com", ".svc.cluster.local"]
+    max_session_ttl_days: 0               # 0 = no limit
+    restrict_debug_mode: false             # Deny debug_mode_default = true
+    restricted_features: []                # Feature flag keys that must be false
+    max_rate_limit: 0                      # 0 = no cap on rate_limit.max

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@fastify/url-data": "^6.0.3",
         "@langchain/core": "^0.3.55",
         "@langchain/langgraph-sdk": "^1.9.2",
+        "@open-policy-agent/opa-wasm": "^1.10.0",
         "@opentelemetry/auto-instrumentations-node": "^0.76.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
@@ -1732,6 +1733,25 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@open-policy-agent/opa-wasm": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@open-policy-agent/opa-wasm/-/opa-wasm-1.10.0.tgz",
+      "integrity": "sha512-ymR/nFS3nO9o24j9xowGGQaf+Gmb813QcxUpVZkfRlJkawKWqSIllnEH15agyWjijmOIyhA+OBErenx6N3jphw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "sprintf-js": "^1.1.2",
+        "yaml": "^1.10.2"
+      }
+    },
+    "node_modules/@open-policy-agent/opa-wasm/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -11802,6 +11822,12 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@fastify/url-data": "^6.0.3",
     "@langchain/core": "^0.3.55",
     "@langchain/langgraph-sdk": "^1.9.2",
+    "@open-policy-agent/opa-wasm": "^1.10.0",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,7 +37,7 @@ async function start() {
   // UI_CONFIG_PATH is set by deployer via ConfigMap mount, defaults to local path
   const configPath = process.env.UI_CONFIG_PATH || "config/ui/settings.yaml";
   try {
-    const stopWatcher = startConfigWatcher(configPath);
+    const stopWatcher = startConfigWatcher(configPath, fastify);
     console.log(`[Server] Config watcher started on ${configPath}`);
 
     // Cleanup watcher on shutdown

--- a/src/server/plugins/opa.plugin.ts
+++ b/src/server/plugins/opa.plugin.ts
@@ -1,0 +1,74 @@
+import fp from "fastify-plugin";
+import type { FastifyInstance } from "fastify";
+import { createOpaEngine, type OpaEngine, type PolicyViolation } from "../utils/opa.js";
+import { getSettings, type UISettings } from "../utils/settings.js";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    opa: {
+      evaluate(): PolicyViolation[];
+      engine: OpaEngine;
+    };
+  }
+}
+
+function buildInput(cfg: UISettings): Record<string, unknown> {
+  const opaCfg = cfg.platform.opa;
+  return {
+    branding: cfg.branding,
+    features: cfg.features,
+    agent: cfg.agent,
+    security: cfg.security,
+    auth_provider: process.env.SSO_AUTH_PROVIDER || "oidc",
+    platform: {
+      opa: {
+        approved_auth_providers: opaCfg.approved_auth_providers,
+        internal_endpoint_suffixes: opaCfg.internal_endpoint_suffixes,
+        max_session_ttl_days: opaCfg.max_session_ttl_days,
+        restrict_debug_mode: opaCfg.restrict_debug_mode,
+        restricted_features: opaCfg.restricted_features,
+        max_rate_limit: opaCfg.max_rate_limit,
+      },
+    },
+  };
+}
+
+export default fp(
+  async function opaPlugin(fastify: FastifyInstance) {
+    const cfg = getSettings();
+    const opaCfg = cfg.platform.opa;
+
+    const engine = await createOpaEngine(opaCfg.policy_path, {
+      info: (msg) => fastify.log.info(msg),
+      warn: (msg) => fastify.log.warn(msg),
+      error: (msg) => fastify.log.error(msg),
+    });
+
+    function evaluate(): PolicyViolation[] {
+      const currentCfg = getSettings();
+      const input = buildInput(currentCfg);
+      return engine.evaluate(input);
+    }
+
+    const initialViolations = evaluate();
+    if (initialViolations.length > 0) {
+      for (const v of initialViolations) {
+        fastify.log.warn(`OPA policy violation: ${v.message}`);
+      }
+      if (opaCfg.fail_on_violation) {
+        throw new Error(
+          `OPA policy check failed with ${initialViolations.length} violation(s) — set platform.opa.fail_on_violation=false to allow startup`,
+        );
+      }
+    } else if (engine.isLoaded()) {
+      fastify.log.info("OPA policy check passed — no violations");
+    }
+
+    fastify.decorate("opa", { evaluate, engine });
+
+    fastify.addHook("onClose", () => {
+      engine.destroy();
+    });
+  },
+  { name: "opa-plugin" },
+);

--- a/src/server/router/api.router.ts
+++ b/src/server/router/api.router.ts
@@ -48,6 +48,20 @@ async function apiRoutes(fastify: FastifyInstance) {
     return cfg.features;
   });
 
+  fastify.get("/config/compliance", async (_request, reply) => {
+    if (!fastify.hasDecorator("opa")) {
+      return { enabled: false, violations: [] };
+    }
+    const violations = fastify.opa.evaluate();
+    reply.header("Cache-Control", "no-store");
+    return {
+      enabled: true,
+      loaded: fastify.opa.engine.isLoaded(),
+      violations,
+      compliant: violations.length === 0,
+    };
+  });
+
   fastify.post("/v1/stream", async (request: FastifyRequest<{ Body: StreamRequest }>, reply: FastifyReply) => {
    handleStreamPost(fastify, request, reply);
   });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,7 @@ import { apiRoutes } from "./router/api.router.js";
 import { proxyRoutes } from "./router/proxy.router.js";
 import logoutPlugin from "./router/logout.router.js";
 import { authPlugin } from "./plugins/auth.plugin.js";
+import opaPlugin from "./plugins/opa.plugin.js";
 import { buildSessionStore, connectRedis } from "./utils/redis.js";
 import tracePlugin from "./plugins/trace.plugin.js";
 import { getSettings } from "./utils/settings.js";
@@ -112,6 +113,10 @@ export async function setupServer() {
 
   if (cfg.features.auth_enabled) {
     await fastify.register(authPlugin);
+  }
+
+  if (cfg.platform.opa.enabled) {
+    await fastify.register(opaPlugin);
   }
 
   await fastify.register(logoutPlugin);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -154,11 +154,11 @@ export async function setupServer(): Promise<FastifyInstance> {
   return fastify;
 }
 
-export function startConfigWatcher(configPath: string) {
+export function startConfigWatcher(configPath: string, server: FastifyInstance) {
+  const cfg = getSettings();
   const cleanup = watchConfig(configPath, (newSettings) => {
-    fastify.log.info('[ConfigWatcher] Settings reloaded');
+    server.log.info('[ConfigWatcher] Settings reloaded');
 
-    // Log which settings might require restart
     const restartRequired = [];
     if (newSettings.security.rate_limit.enabled !== cfg.security.rate_limit.enabled ||
         newSettings.security.rate_limit.max !== cfg.security.rate_limit.max ||
@@ -174,10 +174,9 @@ export function startConfigWatcher(configPath: string) {
     }
 
     if (restartRequired.length > 0) {
-      fastify.log.warn({ settings: restartRequired }, '[ConfigWatcher] The following settings changed but require server restart:');
+      server.log.warn({ settings: restartRequired }, '[ConfigWatcher] The following settings changed but require server restart:');
     }
 
-    // Settings that auto-apply without restart
     const autoApplied = [];
     if (newSettings.agent.timeout_ms !== cfg.agent.timeout_ms) {
       autoApplied.push(`agent.timeout_ms: ${cfg.agent.timeout_ms} → ${newSettings.agent.timeout_ms}`);
@@ -190,7 +189,7 @@ export function startConfigWatcher(configPath: string) {
     }
 
     if (autoApplied.length > 0) {
-      fastify.log.info({ settings: autoApplied }, '[ConfigWatcher] Settings applied without restart:');
+      server.log.info({ settings: autoApplied }, '[ConfigWatcher] Settings applied without restart:');
     }
   });
 

--- a/src/server/utils/configWatcher.ts
+++ b/src/server/utils/configWatcher.ts
@@ -23,7 +23,7 @@ export function watchConfig(
 
   console.log(`[ConfigWatcher] Starting watch on ${configPath}`);
 
-  watcher = watch(configPath, (eventType, filename) => {
+  watcher = watch(configPath, (eventType, _filename) => {
     if (eventType !== 'change') {
       return;
     }

--- a/src/server/utils/opa.ts
+++ b/src/server/utils/opa.ts
@@ -1,0 +1,154 @@
+import { readFileSync, readdirSync, existsSync, watch, mkdtempSync, rmSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { loadPolicy } from "@open-policy-agent/opa-wasm";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface PolicyViolation {
+  message: string;
+}
+
+export interface OpaEngine {
+  evaluate(input: Record<string, unknown>): PolicyViolation[];
+  reload(): Promise<void>;
+  isLoaded(): boolean;
+  destroy(): void;
+}
+
+type LoadedPolicy = Awaited<ReturnType<typeof loadPolicy>>;
+
+interface Logger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+function resolvePolicyDir(policyPath: string): string {
+  if (policyPath && !policyPath.startsWith("/")) {
+    return resolve(__dirname, "../../../", policyPath);
+  }
+  return policyPath || resolve(__dirname, "../../../config/compliance");
+}
+
+function hasRegoFiles(dir: string): boolean {
+  if (!existsSync(dir)) return false;
+  return readdirSync(dir).some((f) => f.endsWith(".rego"));
+}
+
+function compilePolicies(policyDir: string, log: Logger): Buffer | null {
+  if (!hasRegoFiles(policyDir)) {
+    return null;
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "opa-bundle-"));
+  const bundlePath = join(tmp, "bundle.tar.gz");
+
+  try {
+    execFileSync("opa", [
+      "build",
+      "-t", "wasm",
+      "-e", "compliance/ui/deny",
+      "-e", "compliance/ui/violations",
+      "-o", bundlePath,
+      policyDir,
+    ], { timeout: 30_000, stdio: "pipe" });
+
+    const bundle = readFileSync(bundlePath);
+    log.info(`OPA policies compiled from ${policyDir}`);
+    return bundle;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("ENOENT") || msg.includes("not found")) {
+      log.error("opa CLI not found — install OPA to enable policy compilation (https://www.openpolicyagent.org/docs/latest/#running-opa)");
+    } else {
+      log.error(`OPA compilation failed: ${msg}`);
+    }
+    return null;
+  } finally {
+    try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+  }
+}
+
+export async function createOpaEngine(
+  policyPath: string,
+  logger?: Logger,
+): Promise<OpaEngine> {
+  const policyDir = resolvePolicyDir(policyPath);
+  let policy: LoadedPolicy | null = null;
+  let watcher: ReturnType<typeof watch> | null = null;
+  let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+  const log = logger ?? { info: console.log, warn: console.warn, error: console.error };
+
+  async function compileAndLoad(): Promise<void> {
+    const bundle = compilePolicies(policyDir, log);
+    if (!bundle) {
+      policy = null;
+      return;
+    }
+    try {
+      policy = await loadPolicy(bundle);
+    } catch (err) {
+      log.error(`Failed to load compiled OPA bundle: ${err instanceof Error ? err.message : String(err)}`);
+      policy = null;
+    }
+  }
+
+  function evaluate(input: Record<string, unknown>): PolicyViolation[] {
+    if (!policy) return [];
+    try {
+      const resultSets = policy.evaluate(input);
+      if (!resultSets?.length) return [];
+
+      const first = resultSets[0]?.result;
+      if (!first) return [];
+
+      const denials: unknown[] = first.deny ?? first.violations ?? [];
+      if (!Array.isArray(denials)) return [];
+
+      return denials.map((d) => ({ message: String(d) }));
+    } catch (err) {
+      log.error(`OPA evaluation error: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  function startWatching(): void {
+    if (!existsSync(policyDir)) return;
+    try {
+      watcher = watch(policyDir, (eventType, filename) => {
+        if (!filename?.endsWith(".rego") && !filename?.endsWith(".json")) return;
+        if (reloadTimer) clearTimeout(reloadTimer);
+        reloadTimer = setTimeout(async () => {
+          log.info(`Policy file changed (${filename}) — recompiling`);
+          await compileAndLoad();
+        }, 500);
+      });
+      watcher.on("error", () => {});
+    } catch {}
+  }
+
+  function destroy(): void {
+    if (watcher) {
+      watcher.close();
+      watcher = null;
+    }
+    if (reloadTimer) {
+      clearTimeout(reloadTimer);
+      reloadTimer = null;
+    }
+    policy = null;
+  }
+
+  await compileAndLoad();
+  startWatching();
+
+  return {
+    evaluate,
+    reload: compileAndLoad,
+    isLoaded: () => policy !== null,
+    destroy,
+  };
+}

--- a/src/server/utils/opa.ts
+++ b/src/server/utils/opa.ts
@@ -68,7 +68,7 @@ function compilePolicies(policyDir: string, log: Logger): Buffer | null {
     }
     return null;
   } finally {
-    try { rmSync(tmp, { recursive: true, force: true }); } catch {}
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* cleanup is best-effort */ }
   }
 }
 
@@ -127,7 +127,7 @@ export async function createOpaEngine(
         }, 500);
       });
       watcher.on("error", () => {});
-    } catch {}
+    } catch { /* watcher setup is optional */ }
   }
 
   function destroy(): void {

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -45,6 +45,22 @@ interface OtelConfig {
   service_name: string;
 }
 
+interface PlatformOpaConfig {
+  enabled: boolean;
+  policy_path: string;
+  fail_on_violation: boolean;
+  approved_auth_providers: string[];
+  internal_endpoint_suffixes: string[];
+  max_session_ttl_days: number;
+  restrict_debug_mode: boolean;
+  restricted_features: string[];
+  max_rate_limit: number;
+}
+
+interface PlatformConfig {
+  opa: PlatformOpaConfig;
+}
+
 interface AnnouncementConfig {
   enabled: boolean;
   message: string;
@@ -103,6 +119,7 @@ export interface UISettings {
   security: SecurityConfig;
   otel: OtelConfig;
   announcement: AnnouncementConfig;
+  platform: PlatformConfig;
 }
 
 const DEFAULTS: UISettings = {
@@ -162,6 +179,19 @@ const DEFAULTS: UISettings = {
   },
   otel: { enabled: false, service_name: "template-ui" },
   announcement: { enabled: false, message: "", type: "info" },
+  platform: {
+    opa: {
+      enabled: false,
+      policy_path: "",
+      fail_on_violation: false,
+      approved_auth_providers: [],
+      internal_endpoint_suffixes: [],
+      max_session_ttl_days: 0,
+      restrict_debug_mode: false,
+      restricted_features: [],
+      max_rate_limit: 0,
+    },
+  },
 };
 
 function deepMerge<T extends Record<string, unknown>>(
@@ -300,6 +330,17 @@ function applyEnvOverrides(config: UISettings): void {
     if (!Number.isNaN(timeout)) {
       config.agent.timeout_ms = timeout;
     }
+  }
+
+  // Platform OPA overrides
+  if (process.env.PLATFORM_OPA_ENABLED !== undefined) {
+    config.platform.opa.enabled = process.env.PLATFORM_OPA_ENABLED === "true";
+  }
+  if (process.env.PLATFORM_OPA_POLICY_PATH) {
+    config.platform.opa.policy_path = process.env.PLATFORM_OPA_POLICY_PATH;
+  }
+  if (process.env.PLATFORM_OPA_FAIL_ON_VIOLATION !== undefined) {
+    config.platform.opa.fail_on_violation = process.env.PLATFORM_OPA_FAIL_ON_VIOLATION === "true";
   }
 }
 


### PR DESCRIPTION
## Summary
- Embeds OPA via `@open-policy-agent/opa-wasm` to evaluate UI configuration against Rego policies
- Compiles `.rego` files from `config/compliance/` at startup using the `opa` CLI — no manual build step
- Hot-reloads on `.rego`/`.json` file changes in the policy directory (500ms debounce)
- Gated behind `platform.opa.enabled` in `config/settings.yaml` — entirely skipped when disabled
- Missing compliance directory or absent `.rego` files are a silent no-op (no errors)

### Default policy bundle covers
- Approved auth providers
- Internal endpoint suffix restrictions
- Session TTL upper bounds
- Debug mode restrictions
- Feature flag restrictions
- Rate limit caps

### New files
| File | Purpose |
|---|---|
| `config/compliance/policy.rego` | Default Rego policies |
| `config/compliance/data.json` | Default policy data (all constraints disabled) |
| `src/server/utils/opa.ts` | OPA engine — compile, load, evaluate, watch |
| `src/server/plugins/opa.plugin.ts` | Fastify plugin — decorates `fastify.opa`, runs startup check |

### Modified files
- `config/ui/settings.yaml` — `platform.opa` section
- `src/server/utils/settings.ts` — interfaces, defaults, env overrides
- `src/server/server.ts` — registers OPA plugin when enabled
- `src/server/router/api.router.ts` — `GET /api/config/compliance` endpoint
- `Containerfile` — downloads `opa` static binary
- `Makefile` — `opa-check` target for local syntax validation
- `package.json` — `@open-policy-agent/opa-wasm@^1.10.0`

## Test plan
- [ ] Verify server starts cleanly with `platform.opa.enabled: false` (default)
- [ ] Verify server starts cleanly with OPA enabled but no `config/compliance/` directory
- [ ] Verify server starts cleanly with OPA enabled and default `.rego` files (requires `opa` CLI)
- [ ] Verify `GET /api/config/compliance` returns `{ enabled: false }` when OPA disabled
- [ ] Verify `GET /api/config/compliance` returns violations when policy constraints are configured
- [ ] Verify hot-reload triggers recompilation when `.rego` files are modified
- [ ] Verify `fail_on_violation: true` blocks startup when violations exist
- [ ] Container build includes `opa` binary and compiles policies at runtime