### PR TITLE
fix: prevent blocking for human-in-loop feature for subagent tools

### DIFF
--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -146,6 +146,7 @@ export function useStreamingAPI(threadId: string) {
   const isStreamingTokensRef = useRef<boolean>(false);
   const isActiveRef = useRef(true);
   const userCancelledRef = useRef(false);
+  const streamEndedWithInterruptRef = useRef(false);
   const lastStreamErrorRef = useRef<Error | null>(null);
   const lastTokenTimeRef = useRef<number>(0);
   const staleIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -310,6 +311,7 @@ export function useStreamingAPI(threadId: string) {
           };
 
           lastStreamErrorRef.current = null;
+          streamEndedWithInterruptRef.current = false;
 
           const callbacks: StreamCallback = {
             onToken(content) {
@@ -380,6 +382,7 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onInterrupt(interrupt) {
+              streamEndedWithInterruptRef.current = true;
               dispatch(
                 updateStreamingState({
                   chatId: threadId,
@@ -452,7 +455,9 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onDone() {
-              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              if (!streamEndedWithInterruptRef.current) {
+                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              }
               finish('success');
             },
             onMcpStatus(evt) {
@@ -465,7 +470,9 @@ export function useStreamingAPI(threadId: string) {
 
           manager.stream(streamRequest, callbacks).then(() => {
             if (!settled) {
-              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              if (!streamEndedWithInterruptRef.current) {
+                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              }
               finish('success');
             }
           });
@@ -553,6 +560,8 @@ export function useStreamingAPI(threadId: string) {
         resumeDecisions: decisions,
       };
 
+      let resumeStreamHadInterrupt = false;
+
       const callbacks: StreamCallback = {
         onToken(content) {
           lastTokenTimeRef.current = Date.now();
@@ -582,6 +591,7 @@ export function useStreamingAPI(threadId: string) {
           }
         },
         onInterrupt(interrupt) {
+          resumeStreamHadInterrupt = true;
           dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: interrupt } }));
         },
         onError(error) {
@@ -600,7 +610,9 @@ export function useStreamingAPI(threadId: string) {
           if (partial) dispatch(updateStreamingState({ chatId: threadId, state: partial }));
         },
         onDone() {
-          dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+          if (!resumeStreamHadInterrupt) {
+            dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+          }
         },
         onMcpStatus(evt) {
           setMcpEvents((prev) => [...prev, evt]);


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Fixes a race condition in the streaming hook where pending tool calls were being resolved prematurely when a stream ended with a human-in-the-loop (HITL) interrupt. Previously, `resolveAllPendingToolCalls` was dispatched unconditionally in `onDone` and the `.then()` fallback path, which would clear tool call state that the HITL flow still needed for subagent internal tools. This adds interrupt-tracking refs to gate the resolve dispatch correctly.

## Changes

- Added `streamEndedWithInterruptRef` ref in `useStreamingAPI` to track whether the initial stream ended via an interrupt
- Added `resumeStreamHadInterrupt` local flag for the resume-stream path
- Set both flags to `true` inside `onInterrupt` callbacks (initial and resume streams)
- Guarded all `resolveAllPendingToolCalls` dispatches (3 call sites) behind a check that skips resolution when the stream ended with an interrupt

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: debugging, pointed at issues and where to fix
- **Human verification**: Reviewed diff logic, verified all three call sites are guarded consistently, confirmed ref reset on new stream start

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

<!-- What to focus on. -->

Focus on the three guarded call sites in `useStreamingAPI.ts`:
1. `onDone` in the initial stream callbacks (~line 455)
2. The `.then()` fallback path after `manager.stream(...)` (~line 470)
3. `onDone` in the resume stream callbacks (~line 610)

Ensure the ref is always reset to `false` at the start of a new stream (line ~312) so stale interrupt state from a previous turn does not suppress resolution incorrectly.