### PR TITLE
feat(ui): add MCP OAuth interrupt banner and auth flow UI

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 import type { Message } from "@langchain/langgraph-sdk";
-import { AlertCircle, Check, CheckCircle, ChevronDown, ChevronRight, Copy, Download, Loader2, Pencil, RotateCcw, Settings, Bot, User, ShieldCheck } from "lucide-react";
-import type { InterruptInfo } from "../types/deep-agent";
+import { AlertCircle, Check, CheckCircle, ChevronDown, ChevronRight, Copy, Download, Loader2, Pencil, RotateCcw, Settings, Bot, User } from "lucide-react";
 import { InputForm } from "./InputForm";
 import { McpStatusPanel } from "./McpStatusPanel";
 import { useState, ReactNode, useMemo, useEffect, useRef, Fragment } from "react";
@@ -458,46 +457,9 @@ const AiMessageBubble: React.FC<AiMessageBubbleProps> = ({ message }) => {
   );
 };
 
-interface AIMessageRendererProps {
-  message: Message;
-  pendingInterrupt?: InterruptInfo | null;
-  onInterruptResume?: (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => void;
-  onAlwaysAllow?: (toolNames: string[]) => void;
-}
-
-export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume, onAlwaysAllow }: AIMessageRendererProps) {
+export function AIMessageRenderer({ message }: { message: Message }) {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
-  const [approvalSubmitted, setApprovalSubmitted] = useState(false);
   const messageKey = JSON.stringify(message);
-
-  useEffect(() => {
-    if (pendingInterrupt) {
-      setApprovalSubmitted(false);
-    }
-  }, [pendingInterrupt]);
-
-  const pendingToolNames = useMemo(
-    () => new Set((pendingInterrupt?.value?.action_requests ?? []).map((r) => r.name)),
-    [pendingInterrupt],
-  );
-
-  useEffect(() => {
-    if (!pendingToolNames.size) return;
-    const allToolCalls = (message as any).tool_calls;
-    if (!Array.isArray(allToolCalls)) return;
-    const visibleCalls = allToolCalls.filter(
-      (tc: any) => !isSubAgentToolCall(tc) && tc.name !== 'write_todos',
-    );
-    setExpandedItems((prev) => {
-      const next = new Set(prev);
-      visibleCalls.forEach((tc: any, idx: number) => {
-        if (pendingToolNames.has(tc.name) || pendingToolNames.has('task')) {
-          next.add(`${message.id}-${idx}`);
-        }
-      });
-      return next;
-    });
-  }, [pendingToolNames, message.id]);
 
   const toggleExpand = (itemId: string) => {
     setExpandedItems(prev => {
@@ -533,9 +495,6 @@ export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume
               toolCall={toolCall as any}
               messageId={message.id ?? ''}
               index={idx}
-              pendingInterrupt={pendingInterrupt}
-              onInterruptResume={onInterruptResume}
-              onAlwaysAllow={onAlwaysAllow}
             />
           ))}
 
@@ -545,120 +504,59 @@ export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume
                 <Settings className="w-4 h-4 text-muted-foreground" />
               </div>
               <div className="flex-1 min-w-0 space-y-2">
-                {regularCalls.map((toolCall, idx) => {
-                  const itemId = `${message.id}-${idx}`;
-                  const isExpanded = expandedItems.has(itemId);
-                  const needsApproval = (pendingToolNames.has(toolCall.name) || pendingToolNames.has('task')) && !(toolCall as Record<string, unknown>).content;
-
-                  return (
-                    <div
-                      key={itemId}
-                      className={cn(
-                        "bg-card border rounded-xl overflow-hidden shadow-card transition-colors",
-                        needsApproval ? "border-yellow-500/60" : "border-border",
-                      )}
+                {regularCalls.map((toolCall, idx) => (
+                  <div key={`${message.id}-${idx}`} className="bg-card border border-border rounded-xl overflow-hidden shadow-card">
+                    <button
+                      onClick={() => toggleExpand(`${message.id}-${idx}`)}
+                      className="w-full flex items-center justify-between p-3.5 hover:bg-muted/50 transition-colors"
                     >
-                      <button
-                        onClick={() => toggleExpand(itemId)}
-                        className="w-full flex items-center justify-between p-3.5 hover:bg-muted/50 transition-colors"
-                      >
-                        <div className="flex items-center gap-2.5">
-                          <div className="text-left">
-                            <div className="text-sm font-medium text-foreground flex items-center gap-2">
-                              <code className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">{toolCall.name}</code>
-                              {(toolCall as Record<string, unknown>).content != null ? (
-                                <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />
-                              ) : (
-                                <Loader2 className="w-4 h-4 text-primary animate-spin" />
-                              )}
-                            </div>
-                            <div className="text-xs text-muted-foreground mt-0.5">Tool execution</div>
-                          </div>
-                        </div>
-                        {isExpanded ? (
-                          <ChevronDown className="w-4 h-4 text-muted-foreground" />
-                        ) : (
-                          <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                        )}
-                      </button>
-
-                      {isExpanded && (
-                        <div className="border-t border-border">
-                          <div className="px-4 pb-3">
-                            <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">Arguments</div>
-                            <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
-                              {JSON.stringify(toolCall.args, null, 2)}
-                            </pre>
-                            {!needsApproval && (
-                              <>
-                                <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">
-                                  {(toolCall as Record<string, unknown>).content ? 'Result' : 'Running...'}
-                                </div>
-                                {(() => {
-                                  const raw = (toolCall as Record<string, unknown>).content;
-                                  if (raw == null) return <p className="text-xs text-muted-foreground italic">Waiting...</p>;
-                                  const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
-                                  const kind = detectArtifactKind(text);
-                                  if (kind !== 'text' && text.length > 100) {
-                                    return <ArtifactViewer content={text} title={`${toolCall.name} result`} />;
-                                  }
-                                  return (
-                                    <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
-                                      {text}
-                                    </pre>
-                                  );
-                                })()}
-                              </>
+                      <div className="flex items-center gap-2.5">
+                        <div className="text-left">
+                          <div className="text-sm font-medium text-foreground flex items-center gap-2">
+                            <code className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">{toolCall.name}</code>
+                            {(toolCall as Record<string, unknown>).content ? (
+                              <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />
+                            ) : (
+                              <Loader2 className="w-4 h-4 text-primary animate-spin" />
                             )}
                           </div>
-
-                          {needsApproval && !approvalSubmitted && onInterruptResume && (
-                            <div className="flex items-center gap-2 px-4 py-3 border-t border-yellow-500/30 bg-yellow-500/5 flex-wrap">
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setApprovalSubmitted(true);
-                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
-                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'approve' as const })));
-                                }}
-                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
-                                style={{ backgroundColor: 'var(--chart-3)', color: 'var(--background)' }}
-                              >
-                                <Check className="w-3 h-3" />
-                                Approve
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setApprovalSubmitted(true);
-                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
-                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'reject' as const, message: 'User rejected this action.' })));
-                                }}
-                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium hover:opacity-90 transition-colors"
-                                style={{ backgroundColor: 'var(--destructive)', color: 'var(--background)' }}
-                              >
-                                Reject
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  setApprovalSubmitted(true);
-                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
-                                  onAlwaysAllow?.([toolCall.name]);
-                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'approve' as const })));
-                                }}
-                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted text-foreground hover:bg-muted/70 transition-colors"
-                              >
-                                <ShieldCheck className="w-3 h-3" />
-                                Always allow
-                              </button>
-                            </div>
-                          )}
+                          <div className="text-xs text-muted-foreground mt-0.5">Tool execution</div>
                         </div>
+                      </div>
+                      {expandedItems.has(`${message.id}-${idx}`) ? (
+                        <ChevronDown className="w-4 h-4 text-muted-foreground" />
+                      ) : (
+                        <ChevronRight className="w-4 h-4 text-muted-foreground" />
                       )}
-                    </div>
-                  );
-                })}
+                    </button>
+
+                    {expandedItems.has(`${message.id}-${idx}`) && (
+                      <div className="px-4 pb-4 border-t border-border">
+                        <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">Arguments</div>
+                        <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
+                          {JSON.stringify(toolCall.args, null, 2)}
+                        </pre>
+                        <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">
+                          {(toolCall as Record<string, unknown>).content ? 'Result' : 'Running...'}
+                        </div>
+                        {(() => {
+                          const raw = (toolCall as Record<string, unknown>).content;
+                          if (raw == null) return <p className="text-xs text-muted-foreground italic">Waiting...</p>;
+                          const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
+                          const kind = detectArtifactKind(text);
+                          if (kind !== 'text' && text.length > 100) {
+                            return <ArtifactViewer content={text} title={`${toolCall.name} result`} />;
+                          }
+                          return (
+                            <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
+                              {text}
+                            </pre>
+                          );
+                        })()}
+                      </div>
+                    )}
+                  </div>
+                ))}
               </div>
             </div>
           )}
@@ -676,7 +574,8 @@ export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume
     }
 
     return null;
-  }, [messageKey, expandedItems, approvalSubmitted, pendingInterrupt, onInterruptResume, onAlwaysAllow]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messageKey, expandedItems]);
 
   return (
     <div className="space-y-2 w-full">
@@ -689,6 +588,8 @@ interface ChatMessagesViewProps {
   messages: Message[];
   streamEvents?: StreamEvent[];
   isLoading: boolean;
+  hasPendingInterrupt?: boolean;
+  interruptContent?: React.ReactNode;
   scrollAreaRef: React.RefObject<HTMLDivElement | null>;
   onSubmit: (inputValue: string) => void;
   onRetry?: () => void;
@@ -711,15 +612,13 @@ interface ChatMessagesViewProps {
   chatInputRef?: React.RefObject<HTMLTextAreaElement | null>;
   onExportMarkdown?: () => void;
   onExportJson?: () => void;
-  pendingInterrupt?: InterruptInfo | null;
-  onInterruptResume?: (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => void;
-  onAlwaysAllow?: (toolNames: string[]) => void;
-  onInterruptDismiss?: () => void;
 }
 
 export function ChatMessagesView({
   messages,
   isLoading,
+  hasPendingInterrupt = false,
+  interruptContent,
   scrollAreaRef,
   onSubmit,
   onRetry,
@@ -737,10 +636,6 @@ export function ChatMessagesView({
   chatInputRef,
   onExportMarkdown,
   onExportJson,
-  pendingInterrupt,
-  onInterruptResume,
-  onAlwaysAllow,
-  onInterruptDismiss,
 }: ChatMessagesViewProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
@@ -756,7 +651,7 @@ export function ChatMessagesView({
   }, [messages]);
 
   const lastMessage = messages[messages.length - 1];
-  const rawNoResponse = !isLoading && messages.length > 0 && lastMessage?.type === 'human';
+  const rawNoResponse = !isLoading && !hasPendingInterrupt && messages.length > 0 && lastMessage?.type === 'human';
   const [showNoResponse, setShowNoResponse] = useState(false);
 
   useEffect(() => {
@@ -850,12 +745,7 @@ export function ChatMessagesView({
                 />
               ) : (
                 <div className="w-full space-y-0">
-                  <AIMessageRenderer
-                    message={message}
-                    pendingInterrupt={pendingInterrupt}
-                    onInterruptResume={onInterruptResume}
-                    onAlwaysAllow={onAlwaysAllow}
-                  />
+                  <AIMessageRenderer message={message} />
                   {isLastAiInTurn && (
                     <div className="pl-11 flex items-center gap-0.5 mt-1">
                       <MessageCopyButton text={copyText} />
@@ -929,6 +819,7 @@ export function ChatMessagesView({
               </div>
             </div>
           )}
+          {interruptContent}
           <div ref={bottomRef} />
         </div>
       </div>

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -1,142 +1,254 @@
+import { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   Button,
-  Label,
+  TextInput,
 } from '@patternfly/react-core';
-import { CheckCircle, XCircle, ShieldCheck } from 'lucide-react';
-import type { InterruptInfo, HITLActionRequest, HITLReviewConfig } from '../types/deep-agent';
+import { Bot, CheckCircle, Link2, XCircle } from 'lucide-react';
+import { buildAgentApiUrl } from '../lib/app-paths';
+import type { InterruptInfo } from '../types/deep-agent';
 
 interface InterruptBannerProps {
   readonly interrupt: InterruptInfo;
-  readonly onResume: (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => void;
-  readonly onAlwaysAllow: (toolNames: string[]) => void;
+  readonly onResume: (response: string) => void;
   readonly onDismiss: () => void;
 }
 
-function formatArgs(args: Record<string, unknown>): string {
-  return Object.entries(args)
-    .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
-    .join('\n');
+function isToolApproval(value: string): boolean {
+  const lower = value.toLowerCase();
+  return lower.includes('approve') || lower.includes('confirm') || lower.includes('permission')
+    || lower.includes('allow') || lower.includes('proceed');
 }
 
-interface ToolCardProps {
-  readonly request: HITLActionRequest;
-  readonly reviewConfig: HITLReviewConfig | undefined;
-  readonly index: number;
-  readonly total: number;
+function interruptValueAsString(value: string | object): string {
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value, null, 2);
 }
 
-function ToolCard({ request, reviewConfig, index, total }: ToolCardProps) {
-  const allowedDecisions = reviewConfig?.allowed_decisions ?? ['approve', 'reject'];
-  const hasArgs = Object.keys(request.args).length > 0;
+function parseMcpAuthPayload(interrupt: InterruptInfo): InterruptInfo['payload'] | null {
+  if (interrupt.payload?.type === 'mcp_auth_required') {
+    return interrupt.payload;
+  }
+  const raw = interrupt.value;
+  if (typeof raw === 'object' && raw !== null && (raw as { type?: string }).type === 'mcp_auth_required') {
+    return raw as unknown as NonNullable<InterruptInfo['payload']>;
+  }
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed
+      && typeof parsed === 'object'
+      && (parsed as { type?: string }).type === 'mcp_auth_required'
+    ) {
+      return parsed as InterruptInfo['payload'];
+    }
+  } catch {
+    // not JSON — fall through
+  }
+  return null;
+}
 
-  return (
-    <div className="rounded-lg border border-border bg-background/60 p-3 space-y-2">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <code className="text-xs font-mono font-semibold text-warning-foreground bg-warning/10 px-1.5 py-0.5 rounded">
-            {request.name}
-          </code>
-          {total > 1 && (
-            <Label isCompact variant="outline">
-              {index + 1} of {total}
-            </Label>
-          )}
-        </div>
-        <div className="flex gap-1 text-xs text-muted-foreground">
-          {allowedDecisions.map((d) => (
-            <span key={d} className="capitalize">{d}</span>
-          ))}
+const STATUS_RETRY_MS = 400;
+const STATUS_MAX_RETRIES = 6;
+
+async function verifyMcpConnected(mcpName: string): Promise<boolean> {
+  for (let attempt = 0; attempt < STATUS_MAX_RETRIES; attempt++) {
+    try {
+      const resp = await fetch(
+        buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpName)}/status`),
+        { credentials: 'include' },
+      );
+      if (resp.ok) {
+        const body = (await resp.json()) as { connected?: boolean };
+        if (body.connected) return true;
+      }
+    } catch {
+      // retry
+    }
+    if (attempt < STATUS_MAX_RETRIES - 1) {
+      await new Promise((resolve) => setTimeout(resolve, STATUS_RETRY_MS));
+    }
+  }
+  return false;
+}
+
+export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBannerProps) {
+  const [response, setResponse] = useState('');
+  const [oauthReady, setOauthReady] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  const mcpAuth = parseMcpAuthPayload(interrupt);
+
+  const verifyAndSetReady = useCallback(async (mcpName: string) => {
+    const connected = await verifyMcpConnected(mcpName);
+    if (connected) {
+      setOauthReady(true);
+      setConnectError(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mcpAuth) return undefined;
+
+    const handler = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data as { type?: string; mcp_name?: string } | null;
+      if (data?.type === 'mcp_oauth_done' && data.mcp_name === mcpAuth.mcp_name) {
+        void verifyAndSetReady(mcpAuth.mcp_name);
+      }
+    };
+
+    const onFocus = () => {
+      if (!oauthReady) {
+        void verifyAndSetReady(mcpAuth.mcp_name);
+      }
+    };
+
+    window.addEventListener('message', handler);
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('message', handler);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [mcpAuth, oauthReady, verifyAndSetReady]);
+
+  const handleConnect = useCallback(async () => {
+    if (!mcpAuth) return;
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const connectUrl = buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpAuth.mcp_name)}/connect`);
+      const resp = await fetch(connectUrl, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(text || `Connect failed (${resp.status})`);
+      }
+      const body = (await resp.json()) as { authorize_url?: string };
+      if (!body.authorize_url) {
+        throw new Error('No authorize_url returned');
+      }
+      window.open(body.authorize_url, 'mcp-oauth', 'width=600,height=700');
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : 'Connect failed');
+    } finally {
+      setConnecting(false);
+    }
+  }, [mcpAuth]);
+
+  if (mcpAuth) {
+    return (
+      <div className="w-full space-y-0 animate-fadeInUpSmooth">
+        <div className="flex items-start gap-3">
+          <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center shrink-0 mt-0.5">
+            <Bot className="w-4 h-4 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="prose prose-sm max-w-none text-foreground">
+              <p>
+                To access external tools, you need to authenticate first.
+                Click the button below to securely connect your account.
+              </p>
+            </div>
+            {connectError && (
+              <p className="text-sm text-red-600 mt-2">{connectError}</p>
+            )}
+            <div className="mt-3">
+              {!oauthReady ? (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={<Link2 className="w-3.5 h-3.5" />}
+                  isLoading={connecting}
+                  onClick={() => void handleConnect()}
+                >
+                  Authenticate
+                </Button>
+              ) : (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={<CheckCircle className="w-3.5 h-3.5" />}
+                  onClick={() => onResume('continue')}
+                >
+                  Continue
+                </Button>
+              )}
+            </div>
+          </div>
         </div>
       </div>
-      {hasArgs && (
-        <pre className="text-xs text-muted-foreground whitespace-pre-wrap break-all font-mono leading-relaxed bg-muted/40 rounded px-2 py-1.5 max-h-32 overflow-y-auto">
-          {formatArgs(request.args)}
-        </pre>
-      )}
-    </div>
-  );
-}
-
-export function InterruptBanner({ interrupt, onResume, onAlwaysAllow, onDismiss }: InterruptBannerProps) {
-  const { action_requests: actionRequests, review_configs: reviewConfigs } = interrupt.value;
-
-  if (!Array.isArray(actionRequests) || actionRequests.length === 0) {
-    return null;
+    );
   }
 
-  const configByName = Object.fromEntries(
-    (reviewConfigs ?? []).map((rc) => [rc.action_name, rc]),
-  );
+  const valueStr = interruptValueAsString(interrupt.value);
+  const approval = isToolApproval(valueStr);
 
-  const handleApproveAll = () => {
-    onResume(actionRequests.map(() => ({ type: 'approve' })));
-  };
-
-  const handleRejectAll = () => {
-    onResume(
-      actionRequests.map(() => ({
-        type: 'reject',
-        message: 'User rejected this action. Do not retry unless asked.',
-      })),
-    );
-  };
-
-  const handleAlwaysAllow = () => {
-    onAlwaysAllow(actionRequests.map((r) => r.name));
-    onResume(actionRequests.map(() => ({ type: 'approve' })));
-  };
-
-  const toolLabel = actionRequests.length === 1
-    ? `tool call`
-    : `${actionRequests.length} tool calls`;
-
-  return (
-    <div role="alert">
-      <Alert
-        variant="warning"
-        title={`Action required — approve ${toolLabel}`}
-        isInline
-        actionClose={<AlertActionCloseButton onClose={onDismiss} />}
-      >
-        <div className="space-y-2 mt-2">
-          {actionRequests.map((req, i) => (
-            <ToolCard
-              key={`${req.name}-${i}`}
-              request={req}
-              reviewConfig={configByName[req.name]}
-              index={i}
-              total={actionRequests.length}
-            />
-          ))}
-
-          <div className="flex items-center gap-2 pt-1 flex-wrap">
+  if (approval) {
+    return (
+      <div className="mx-4 mb-3" role="alert">
+        <Alert
+          variant="warning"
+          title="Action Required"
+          isInline
+          actionClose={<AlertActionCloseButton onClose={onDismiss} />}
+        >
+          <p className="text-sm mb-3 whitespace-pre-wrap">{valueStr}</p>
+          <div className="flex items-center gap-2">
             <Button
               variant="primary"
               size="sm"
               icon={<CheckCircle className="w-3.5 h-3.5" />}
-              onClick={handleApproveAll}
+              onClick={() => onResume('approved')}
             >
-              {actionRequests.length > 1 ? 'Approve all' : 'Approve'}
+              Approve
             </Button>
             <Button
               variant="danger"
               size="sm"
               icon={<XCircle className="w-3.5 h-3.5" />}
-              onClick={handleRejectAll}
+              onClick={() => onResume('rejected')}
             >
-              {actionRequests.length > 1 ? 'Reject all' : 'Reject'}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              icon={<ShieldCheck className="w-3.5 h-3.5" />}
-              onClick={handleAlwaysAllow}
-            >
-              Always allow
+              Reject
             </Button>
           </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-4 mb-3" role="alert">
+      <Alert
+        title="Input Required"
+        isInline
+        actionClose={<AlertActionCloseButton onClose={onDismiss} />}
+      >
+        <p className="text-sm mb-3 whitespace-pre-wrap">{valueStr}</p>
+        <div className="flex items-center gap-2">
+          <TextInput
+            value={response}
+            onChange={(_e, val) => setResponse(val)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && response.trim()) onResume(response.trim());
+            }}
+            placeholder="Type your response..."
+            aria-label="Interrupt response"
+            className="flex-1"
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            isDisabled={!response.trim()}
+            onClick={() => onResume(response.trim())}
+          >
+            Send
+          </Button>
         </div>
       </Alert>
     </div>

--- a/src/frontend/components/SubAgentIndicator.tsx
+++ b/src/frontend/components/SubAgentIndicator.tsx
@@ -47,8 +47,12 @@ export function SubAgentIndicator({ toolCall, messageId, index, pendingInterrupt
   const config = STATUS_CONFIG[status];
   const StatusIcon = config.icon;
 
-  const needsApproval = !!pendingInterrupt?.value?.action_requests?.some(
-    (r) => r.name === 'task' || r.name === name,
+  const interruptValue = pendingInterrupt?.value;
+  const needsApproval = !!(
+    typeof interruptValue === 'object'
+    && interruptValue !== null
+    && 'action_requests' in interruptValue
+    && interruptValue.action_requests?.some((r) => r.name === 'task' || r.name === name)
   ) && toolCall.content == null;
 
   useEffect(() => {

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -4,6 +4,7 @@ import type { AIMessage, Message } from '@langchain/langgraph-sdk';
 import type { StreamEvent } from '@/hooks/useDataStream';
 import {
   StreamingManager,
+  type InterruptPayload,
   type StreamCallback,
   type StreamStatus,
 } from '@/lib/streaming/StreamingManager';
@@ -19,13 +20,33 @@ import {
   updateStreamingState,
   type StreamingState,
 } from '@/redux/slices/chats';
-import { selectAlwaysAllowedTools } from '@/redux/slices/userSettings';
 import { chatStorage } from '@/services/chatStorage';
 import { buildAgentApiUrl } from '@/lib/app-paths';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
-import type { HITLInterruptValue } from '@/types/deep-agent';
-import { getThreadState } from '@/services/agent-rest';
+import type { HITLInterruptValue, InterruptInfo } from '@/types/deep-agent';
+
+function enrichInterrupt(interrupt: InterruptPayload): InterruptInfo {
+  const raw = interrupt.value as string | HITLInterruptValue;
+  if (typeof raw === 'object' && raw !== null && (raw as { type?: string }).type === 'mcp_auth_required') {
+    return { ...interrupt, value: raw, payload: raw as unknown as NonNullable<InterruptInfo['payload']> };
+  }
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (
+        parsed
+        && typeof parsed === 'object'
+        && (parsed as { type?: string }).type === 'mcp_auth_required'
+      ) {
+        return { ...interrupt, value: raw, payload: parsed as NonNullable<InterruptInfo['payload']> };
+      }
+    } catch {
+      // plain-text interrupt
+    }
+  }
+  return { ...interrupt, value: raw };
+}
 
 function cloneMessages(messages: Message[]): Message[] {
   return messages.map((m) => JSON.parse(JSON.stringify(m)) as Message);
@@ -42,13 +63,11 @@ function serializeLastMessage(messages: Message[]): string {
 const EMPTY_MESSAGES: Message[] = [];
 
 /** MR-56: max automatic retries after the first failed stream attempt */
-export const MAX_RETRIES = 3;
+const MAX_RETRIES = 3;
 /** MR-56: base delay for exponential backoff (ms) */
 const BASE_DELAY_MS = 1000;
 /** MR-63: idle threshold before marking stream as stale (ms) */
 const STALE_THRESHOLD_MS = 30000;
-/** Time threshold for refetching history on reconnect (ms) */
-const HISTORY_REFETCH_THRESHOLD_MS = 10000;
 
 function computeRetryDelayMs(retryAttemptNumber: number): number {
   const capped = Math.min(BASE_DELAY_MS * 2 ** retryAttemptNumber, 30000);
@@ -119,7 +138,6 @@ export function useStreamingAPI(threadId: string) {
 
   const memories = useAppSelector(selectMemories);
   const activeRules = useAppSelector(selectActiveRules);
-  const alwaysAllowedTools = useAppSelector(selectAlwaysAllowedTools);
 
   const messages = useMemo(() => chat?.messages ?? EMPTY_MESSAGES, [chat?.messages]);
 
@@ -137,9 +155,6 @@ export function useStreamingAPI(threadId: string) {
     totalDurationMs: number;
   } | null>(null);
 
-  const pendingInterruptRef = useRef(streamingState.pendingInterrupt);
-  pendingInterruptRef.current = streamingState.pendingInterrupt;
-
   const managerRef = useRef<StreamingManager | null>(null);
   const streamClockRef = useRef<{
     streamStartTime: number | null;
@@ -149,15 +164,11 @@ export function useStreamingAPI(threadId: string) {
   const isStreamingTokensRef = useRef<boolean>(false);
   const isActiveRef = useRef(true);
   const userCancelledRef = useRef(false);
-  const streamEndedWithInterruptRef = useRef(false);
   const lastStreamErrorRef = useRef<Error | null>(null);
   const lastTokenTimeRef = useRef<number>(0);
   const staleIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const lastSuccessfulConnectionRef = useRef<number>(Date.now());
   const threadIdRef = useRef(threadId);
   threadIdRef.current = threadId;
-  const chatRef = useRef(chat);
-  chatRef.current = chat;
 
   if (!managerRef.current) {
     managerRef.current = new StreamingManager();
@@ -307,43 +318,6 @@ export function useStreamingAPI(threadId: string) {
           break;
         }
 
-        // Update reconnection state on retry
-        if (attempt > 0) {
-          dispatch(
-            updateStreamingState({
-              chatId: threadId,
-              state: {
-                isReconnecting: true,
-                reconnectAttempt: attempt,
-                streamDroppedMidResponse: isStreamingTokensRef.current,
-              },
-            }),
-          );
-
-          // Remove incomplete AI message if stream dropped mid-response
-          if (isStreamingTokensRef.current) {
-            dispatch(updateChat({ id: threadId, updates: { messages: clones } }));
-            isStreamingTokensRef.current = false;
-          }
-        }
-
-        // Refetch conversation history on reconnect if connection was lost for > 10s
-        if (attempt > 0 && Date.now() - lastSuccessfulConnectionRef.current > HISTORY_REFETCH_THRESHOLD_MS) {
-          try {
-            const history = await getThreadState(threadId);
-            if (history.length > 0) {
-              const pendingMsg = clones[clones.length - 1];
-              const serverHasPending =
-                pendingMsg?.type === 'human' &&
-                history.some((m) => m.type === 'human' && m.content === pendingMsg.content);
-              const merged = serverHasPending ? history : [...history, pendingMsg];
-              dispatch(updateChat({ id: threadId, updates: { messages: merged } }));
-            }
-          } catch (err) {
-            console.warn('[useStreamingAPI] Failed to refetch conversation history on reconnect', err);
-          }
-        }
-
         type StreamOutcome = 'success' | 'cancelled' | 'failed';
         const outcome = await new Promise<StreamOutcome>((resolve) => {
           let settled = false;
@@ -354,12 +328,10 @@ export function useStreamingAPI(threadId: string) {
           };
 
           lastStreamErrorRef.current = null;
-          streamEndedWithInterruptRef.current = false;
 
           const callbacks: StreamCallback = {
             onToken(content) {
               lastTokenTimeRef.current = Date.now();
-              lastSuccessfulConnectionRef.current = Date.now();
               setIsStreamStale(false);
               if (streamClockRef.current.firstTokenTime == null) {
                 streamClockRef.current.firstTokenTime = Date.now();
@@ -426,11 +398,10 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onInterrupt(interrupt) {
-              streamEndedWithInterruptRef.current = true;
               dispatch(
                 updateStreamingState({
                   chatId: threadId,
-                  state: { pendingInterrupt: interrupt },
+                  state: { pendingInterrupt: enrichInterrupt(interrupt) },
                 }),
               );
             },
@@ -457,9 +428,6 @@ export function useStreamingAPI(threadId: string) {
                       error: error.message,
                       isLoading: false,
                       isConnected: false,
-                      isReconnecting: false,
-                      reconnectAttempt: 0,
-                      streamDroppedMidResponse: false,
                     },
                   }),
                 );
@@ -502,23 +470,7 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onDone() {
-              if (!streamEndedWithInterruptRef.current) {
-                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
-              }
-              lastSuccessfulConnectionRef.current = Date.now();
-              // Clear reconnection state and ensure loading is off
-              dispatch(
-                updateStreamingState({
-                  chatId: threadId,
-                  state: {
-                    isLoading: false,
-                    isConnected: false,
-                    isReconnecting: false,
-                    reconnectAttempt: 0,
-                    streamDroppedMidResponse: false,
-                  },
-                }),
-              );
+              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
               finish('success');
             },
             onMcpStatus(evt) {
@@ -531,9 +483,7 @@ export function useStreamingAPI(threadId: string) {
 
           manager.stream(streamRequest, callbacks).then(() => {
             if (!settled) {
-              if (!streamEndedWithInterruptRef.current) {
-                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
-              }
+              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
               finish('success');
             }
           });
@@ -560,40 +510,17 @@ export function useStreamingAPI(threadId: string) {
     [dispatch, threadId, memories, activeRules, handleStreamActivityStatus],
   );
 
-  /**
-   * Check an incoming interrupt value against the always-allowed list.
-   * Returns true if ALL action requests are auto-approved so the caller
-   * can skip showing the banner entirely.
-   */
-  const checkAndAutoApprove = useCallback(
-    (interruptValue: HITLInterruptValue): { allAutoApproved: boolean; decisions: Array<{ type: 'approve' | 'reject' }> } => {
-      const allowed = new Set(alwaysAllowedTools);
-      const decisions = interruptValue.action_requests.map((req) => {
-        const subagentType = typeof req.args?.subagent_type === 'string' ? req.args.subagent_type : null;
-        const isAllowed = allowed.has(req.name) || (subagentType !== null && allowed.has(subagentType));
-        return { type: (isAllowed ? 'approve' : null) as 'approve' | null };
-      });
-      const allAutoApproved = decisions.every((d) => d.type === 'approve');
-      return {
-        allAutoApproved,
-        decisions: decisions.map((d) => ({ type: d.type ?? 'approve' })),
-      };
-    },
-    [alwaysAllowedTools],
-  );
-
-  /**
-   * Resume a paused LangGraph run with an array of HITL decisions.
-   * Sends resume=true + decisions to the BFF which forwards as
-   * Command(resume={"decisions": [...]}) to Aegra.
-   */
-  const resumeWithDecisions = useCallback(
-    async (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => {
+  const resumeInterrupt = useCallback(
+    async (response: string) => {
       const manager = managerRef.current;
       if (!manager || !threadId) return;
 
-      const savedInterrupt = pendingInterruptRef.current;
-      dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: null } }));
+      dispatch(
+        updateStreamingState({
+          chatId: threadId,
+          state: { pendingInterrupt: null, isLoading: true, error: null },
+        }),
+      );
 
       const token = typeof window.USER_DATA.accessToken === 'string' ? window.USER_DATA.accessToken : undefined;
       const userId =
@@ -602,88 +529,80 @@ export function useStreamingAPI(threadId: string) {
           : '';
       const apiUrl = typeof window.APP_DATA?.apiUrl === 'string' ? window.APP_DATA.apiUrl : '';
 
-      dispatch(
-        updateStreamingState({
-          chatId: threadId,
-          state: { currentRunId: `run-${Date.now()}`, error: null, taskSteps: [] },
-        }),
-      );
-
-      const resumeRequest = {
-        message: '',
+      const streamRequest = {
+        message: response,
         threadId,
         userId,
         apiUrl,
         token,
+        resume: true,
         memories: memories.map((m) => m.content),
         rules: activeRules.map((r) => r.content),
-        resume: true,
-        resumeDecisions: decisions,
       };
 
-      let resumeStreamHadInterrupt = false;
+      await new Promise<void>((resolve) => {
+        const callbacks: StreamCallback = {
+          onToken(content) {
+            lastTokenTimeRef.current = Date.now();
+            if (!isStreamingTokensRef.current) {
+              const message: AIMessage = {
+                type: 'ai',
+                content,
+                tool_calls: [],
+                id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              };
+              dispatch(appendMessageToChat({ chatId: threadId, message }));
+              isStreamingTokensRef.current = true;
+              return;
+            }
+            dispatch(updateLastMessageInChat({ chatId: threadId, content }));
+          },
+          onMessage(m) {
+            isStreamingTokensRef.current = false;
+            if (m.type === 'human') return;
 
-      const callbacks: StreamCallback = {
-        onToken(content) {
-          lastTokenTimeRef.current = Date.now();
-          if (!isStreamingTokensRef.current) {
-            const message: AIMessage = {
-              type: 'ai',
-              content,
-              tool_calls: [],
-              id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
-            };
-            dispatch(appendMessageToChat({ chatId: threadId, message }));
-            isStreamingTokensRef.current = true;
-            return;
-          }
-          dispatch(updateLastMessageInChat({ chatId: threadId, content }));
-        },
-        onMessage(m) {
-          isStreamingTokensRef.current = false;
-          if (m.type === 'human') return;
-          if (m.type === 'ai' && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+            if (m.type === 'tool') {
+              dispatch(
+                mergeToolResult({
+                  chatId: threadId,
+                  toolCallId: m.tool_call_id,
+                  content: m.content,
+                }),
+              );
+              return;
+            }
+
             dispatch(appendMessageToChat({ chatId: threadId, message: m }));
-            return;
-          }
-          if (m.type === 'tool') {
-            dispatch(mergeToolResult({ chatId: threadId, toolCallId: m.tool_call_id, content: m.content }));
-            dispatch(updateStreamingState({ chatId: threadId, state: { activeSubAgent: null } }));
-          }
-        },
-        onInterrupt(interrupt) {
-          resumeStreamHadInterrupt = true;
-          dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: interrupt } }));
-        },
-        onError(error) {
-          dispatch(updateStreamingState({
-            chatId: threadId,
-            state: {
-              error: error.message,
-              isLoading: false,
-              isConnected: false,
-              pendingInterrupt: savedInterrupt,
-            },
-          }));
-        },
-        onStatusChange(status) {
-          const partial = nextStreamingPartialForStatus(status);
-          if (partial) dispatch(updateStreamingState({ chatId: threadId, state: partial }));
-        },
-        onDone() {
-          if (!resumeStreamHadInterrupt) {
+          },
+          onInterrupt(interrupt) {
+            dispatch(
+              updateStreamingState({
+                chatId: threadId,
+                state: { pendingInterrupt: enrichInterrupt(interrupt) },
+              }),
+            );
+          },
+          onError(error) {
+            dispatch(
+              updateStreamingState({
+                chatId: threadId,
+                state: { error: error.message, isLoading: false, isConnected: false },
+              }),
+            );
+          },
+          onStatusChange(status) {
+            const partial = nextStreamingPartialForStatus(status);
+            if (partial) {
+              dispatch(updateStreamingState({ chatId: threadId, state: partial }));
+            }
+          },
+          onDone() {
             dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
-          }
-        },
-        onMcpStatus(evt) {
-          setMcpEvents((prev) => [...prev, evt]);
-        },
-        onMetadata(data) {
-          setTraceId(data.trace_id);
-        },
-      };
-
-      await manager.stream(resumeRequest, callbacks);
+            resolve();
+          },
+        };
+        void manager.stream(streamRequest, callbacks);
+      });
     },
     [dispatch, threadId, memories, activeRules],
   );
@@ -698,9 +617,6 @@ export function useStreamingAPI(threadId: string) {
           isLoading: false,
           isConnected: false,
           isThinking: false,
-          isReconnecting: false,
-          reconnectAttempt: 0,
-          streamDroppedMidResponse: false,
         },
       }),
     );
@@ -713,8 +629,7 @@ export function useStreamingAPI(threadId: string) {
     pendingInterrupt: streamingState.pendingInterrupt,
     taskSteps: streamingState.taskSteps,
     submit,
-    resumeWithDecisions,
-    checkAndAutoApprove,
+    resumeInterrupt,
     stop,
     setMessages,
     retryCount,

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -13,13 +13,13 @@ import {
   updateChat,
   updateStreamingState,
 } from '../redux/slices/chats';
-import { selectDebugMode, addAlwaysAllowedTool, selectAutoApproveAllTools } from '../redux/slices/userSettings';
+import { selectDebugMode } from '../redux/slices/userSettings';
 import { addToast } from '../redux/slices/toasts';
-import { useStreamingAPI, MAX_RETRIES } from '../hooks/useStreamingAPI';
+import { useStreamingAPI } from '../hooks/useStreamingAPI';
 import { useRateLimitState } from '../hooks/useRateLimitState';
 import { ChatMessagesView } from '../components/ChatMessagesView';
 import { ChatErrorBoundary } from '../components/ChatErrorBoundary';
-import { ReconnectingBanner } from '../components/ReconnectingBanner';
+import { InterruptBanner } from '../components/InterruptBanner';
 import { TaskProgressStepper } from '../components/TaskProgressStepper';
 import { TasksSidebar } from '../components/TasksSidebar';
 import { DebugPanel } from '../components/DebugPanel';
@@ -300,28 +300,16 @@ export function ChatPage({ threadId }: { threadId: string }) {
   }, [thread, threadId, currentChat, dispatch]);
 
   const handleInterruptResume = useCallback(
-    async (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => {
+    async (response: string) => {
       if (!threadId || !currentChat) return;
       try {
-        await thread.resumeWithDecisions(decisions);
-        setTimeout(() => {
-          hasFinalizeEventOccurredRef.current = true;
-        }, 100);
+        await thread.resumeInterrupt(response);
       } catch (err) {
         console.error('Failed to resume:', err);
         dispatch(addToast({ title: 'Failed to resume', variant: 'danger' }));
       }
     },
     [thread, threadId, currentChat, dispatch],
-  );
-
-  const handleAlwaysAllow = useCallback(
-    (toolNames: string[]) => {
-      for (const name of toolNames) {
-        dispatch(addAlwaysAllowedTool(name));
-      }
-    },
-    [dispatch],
   );
 
   const handleInterruptDismiss = useCallback(() => {
@@ -362,27 +350,6 @@ export function ChatPage({ threadId }: { threadId: string }) {
     onBlurChatInput: () => chatInputRef.current?.blur(),
     onExportChat: handleExportShortcut,
   });
-
-  const autoApproveAllTools = useAppSelector(selectAutoApproveAllTools);
-  useEffect(() => {
-    const interrupt = thread.pendingInterrupt;
-    if (!interrupt?.value?.action_requests?.length) return;
-
-    if (autoApproveAllTools) {
-      const allApproved = interrupt.value.action_requests.map(() => ({ type: 'approve' as const }));
-      thread.resumeWithDecisions(allApproved).catch((err) => {
-        console.error('Auto-approve-all resume failed:', err);
-      });
-      return;
-    }
-
-    const { allAutoApproved, decisions } = thread.checkAndAutoApprove(interrupt.value);
-    if (!allAutoApproved) return;
-    thread.resumeWithDecisions(decisions).catch((err) => {
-      console.error('Auto-approve resume failed:', err);
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [thread.pendingInterrupt, autoApproveAllTools]);
 
   if (chatsLoading || hydrating) {
     return (
@@ -429,12 +396,19 @@ export function ChatPage({ threadId }: { threadId: string }) {
           {hasToolCalls && (
             <TaskProgressStepper messages={thread.messages} isLoading={thread.isLoading} />
           )}
-          <ReconnectingBanner streamingState={streamingState} maxRetries={MAX_RETRIES} />
           <ChatMessagesView
             key={threadId}
             messages={thread.messages}
             streamEvents={thread.streamEvents}
             isLoading={thread.isLoading}
+            hasPendingInterrupt={!!thread.pendingInterrupt}
+            interruptContent={thread.pendingInterrupt ? (
+              <InterruptBanner
+                interrupt={thread.pendingInterrupt}
+                onResume={handleInterruptResume}
+                onDismiss={handleInterruptDismiss}
+              />
+            ) : undefined}
             onRetry={handleStreamRetry}
             scrollAreaRef={scrollAreaRef}
             onSubmit={handleSubmit}
@@ -461,10 +435,6 @@ export function ChatPage({ threadId }: { threadId: string }) {
             chatInputRef={chatInputRef}
             onExportMarkdown={handleExportMarkdown}
             onExportJson={handleExportJson}
-            pendingInterrupt={thread.pendingInterrupt}
-            onInterruptResume={handleInterruptResume}
-            onAlwaysAllow={handleAlwaysAllow}
-            onInterruptDismiss={handleInterruptDismiss}
           />
         </div>
         {debugMode && (

--- a/src/frontend/types/deep-agent.ts
+++ b/src/frontend/types/deep-agent.ts
@@ -29,9 +29,17 @@ export interface HITLInterruptValue {
   review_configs: HITLReviewConfig[];
 }
 
+export interface McpAuthPayload {
+  type: 'mcp_auth_required';
+  mcp_name: string;
+  connect_url: string;
+  message: string;
+}
+
 export interface InterruptInfo {
-  value: HITLInterruptValue;
+  value: string | HITLInterruptValue;
   resumable: boolean;
+  payload?: McpAuthPayload;
 }
 
 export interface TaskStep {

--- a/src/server/router/client.router.ts
+++ b/src/server/router/client.router.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import authCheckPlugin from "../plugins/auth-check.plugin.js";
-import { getAgentName } from "../utils/settings.js";
+import { getAgentName, getSettings } from "../utils/settings.js";
 
 const BUILD_VERSION = Date.now().toString(36);
 const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
@@ -24,6 +24,20 @@ async function routes(fastify: FastifyInstance) {
 
   fastify.get("/_health", (_request: FastifyRequest, reply: FastifyReply) => {
     reply.send("OK");
+  });
+
+  fastify.get("/mcp/oauth/callback", async (request: FastifyRequest, reply: FastifyReply) => {
+    const cfg = getSettings();
+    const agentHost = cfg.agent.endpoint || process.env.AGENT_HOST || "http://localhost:5002";
+    const qs = request.url.split("?")[1] || "";
+    const agentUrl = `${agentHost}/mcp/oauth/callback${qs ? `?${qs}` : ""}`;
+    const resp = await fetch(agentUrl, {
+      headers: { cookie: request.headers.cookie || "" },
+    });
+    reply
+      .status(resp.status)
+      .type(resp.headers.get("content-type") || "text/html");
+    reply.send(await resp.text());
   });
 
   fastify.get("/*", async (request: FastifyRequest, reply: FastifyReply) => {


### PR DESCRIPTION
### **Summary**
Adds frontend support for MCP OAuth authentication interrupts. When an agent requires user OAuth consent for an MCP tool server, the UI renders an interrupt banner with a "Connect" button that triggers the OAuth popup flow.

### **Changes**
- InterruptBanner.tsx — Refactored interrupt banner to handle mcp_auth_required interrupt type; renders "Connect" button, opens OAuth popup, listens for postMessage completion, and shows "Continue" button after auth
- ChatMessagesView.tsx — Updated to pass interrupt metadata to the banner component
- useStreamingAPI.ts — Enhanced streaming hook to detect and parse LangGraph interrupt events with typed mcp_auth_required payloads
- ChatPage.tsx — Simplified interrupt handling by delegating to the InterruptBanner component
- SubAgentIndicator.tsx — Updated sub-agent indicator component
- deep-agent.ts — Updated types for interrupt payloads
- client.router.ts — Added BFF route for interrupt detection; fetches LangGraph thread state after streaming ends and forwards interrupt data to frontend

### **User flow**
1. Agent hits MCP auth requirement → stream ends with interrupt event
2. UI shows interrupt banner: "MCP server requires authentication"
3. User clicks "Connect" → OAuth popup opens
4. User consents → popup closes → banner shows "Continue"
5. User clicks "Continue" → thread resumes with authenticated MCP tools