### PR TITLE
Support for deleting chats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fastify/url-data": "^6.0.3",
         "@langchain/core": "^0.3.55",
         "@langchain/langgraph-sdk": "^0.0.74",
+        "@radix-ui/react-alert-dialog": "^1.1.14",
         "@radix-ui/react-scroll-area": "^1.2.8",
         "@radix-ui/react-select": "^2.2.4",
         "@radix-ui/react-slot": "^1.2.2",
@@ -1223,6 +1224,92 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.19.tgz",
+      "integrity": "sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dialog": "1.1.19",
+        "@radix-ui/react-primitive": "2.1.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1309,6 +1396,300 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -1665,13 +2046,28 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fastify/url-data": "^6.0.3",
     "@langchain/core": "^0.3.55",
     "@langchain/langgraph-sdk": "^0.0.74",
+    "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-scroll-area": "^1.2.8",
     "@radix-ui/react-select": "^2.2.4",
     "@radix-ui/react-slot": "^1.2.2",

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -30,6 +30,7 @@ interface SidebarProps {
   onNewChat: () => void;
   onSelectChat: (chatId: string) => void;
   onDeleteChat: (chatId: string) => void;
+  onDeleteAllChats: () => void;
   onRenameChat: (chatId: string, newTitle: string) => void;
 }
 
@@ -42,6 +43,7 @@ function SidebarComponent({
   onNewChat,
   onSelectChat,
   onDeleteChat,
+  onDeleteAllChats,
   onRenameChat
 }: SidebarProps) {
 
@@ -178,9 +180,20 @@ function SidebarComponent({
       {/* Chat History */}
       <div className="flex-1 flex flex-col overflow-hidden">
         <div className="px-4 py-2 border-b border-neutral-700 flex-shrink-0">
-          <h3 className="text-xs font-medium text-neutral-400 uppercase tracking-wider">
-            Recent Chats
-          </h3>
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-xs font-medium text-neutral-400 uppercase tracking-wider">
+              Recent Chats
+            </h3>
+            {chatHistory.length > 0 && (
+              <button
+                onClick={onDeleteAllChats}
+                className="text-xs text-neutral-500 hover:text-red-400 transition-colors duration-200"
+                title="Delete all chats"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
         </div>
         
         <div className="flex-1 overflow-y-auto px-2">

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -1,42 +1,53 @@
-import React, { useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useMemo, useCallback } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Sidebar } from '../Sidebar';
 import { ErrorBoundary } from '../ErrorBoundary';
 import { useChat } from '../../contexts/ChatContext';
 import { SidebarChatItem } from '../../types/chat';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
 
 interface AppLayoutProps {
   children: React.ReactNode;
 }
 
 export function AppLayout({ children }: AppLayoutProps) {
-  const { chats, deleteChat, renameChat, createNewChat } = useChat();
+  const { chats, deleteChat, deleteAllChats, renameChat, createNewChat } = useChat();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
+  const [showDeleteAllDialog, setShowDeleteAllDialog] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const currentChatId = location.pathname.startsWith('/chat/')
+    ? location.pathname.replace('/chat/', '')
+    : undefined;
   
-  // Get user data from window.USER_DATA
   const userData = useMemo(() => {
     return window.USER_DATA;
   }, []);
   
-  // Extract user name and token expiry from real user data
   const userName = userData?.displayName || userData?.name || "User";
   const tokenExpiry = useMemo(() => {
     if (userData?.expiresAt) {
       return new Date(userData.expiresAt);
     }
-    // Fallback to mock expiry if no real data
     const fallback = new Date();
     fallback.setHours(fallback.getHours() + 2);
     return fallback;
   }, [userData?.expiresAt]);
 
-  // Convert chats to sidebar format
   const sidebarChats: SidebarChatItem[] = useMemo(() => 
     chats.map(chat => ({
       id: chat.id,
       title: chat.title,
-      timestamp: chat.timestamp,
+      timestamp: chat.timestamp ?? new Date(),
       preview: chat.messages.length > 0 
         ? (chat.messages[0].content as string).substring(0, 60) + "..."
         : chat.preview,
@@ -52,17 +63,37 @@ export function AppLayout({ children }: AppLayoutProps) {
   };
 
   const handleDeleteChat = (chatId: string) => {
-    deleteChat(chatId);
-    // Navigate to home if we're currently on the deleted chat
-    if (window.location.pathname === `/chat/${chatId}`) {
-      const remainingChats = chats.filter(chat => chat.id !== chatId);
+    setDeletingChatId(chatId);
+  };
+
+  const handleDeleteAllChats = () => {
+    setShowDeleteAllDialog(true);
+  };
+
+  const confirmDeleteChat = useCallback(() => {
+    if (!deletingChatId) return;
+
+    deleteChat(deletingChatId);
+    if (currentChatId === deletingChatId) {
+      const remainingChats = chats.filter(chat => chat.id !== deletingChatId);
       if (remainingChats.length > 0) {
         navigate(`/chat/${remainingChats[0].id}`);
       } else {
         navigate('/');
       }
     }
-  };
+    setDeletingChatId(null);
+  }, [deletingChatId, currentChatId, chats, deleteChat, navigate]);
+
+  const confirmDeleteAllChats = useCallback(() => {
+    deleteAllChats();
+    setShowDeleteAllDialog(false);
+    navigate('/');
+  }, [deleteAllChats, navigate]);
+
+  const deletingChatTitle = deletingChatId
+    ? chats.find(chat => chat.id === deletingChatId)?.title ?? 'this chat'
+    : 'this chat';
 
   return (
     <div className="flex h-screen bg-neutral-800 text-neutral-100 font-sans antialiased">
@@ -73,7 +104,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       >
         <Sidebar
           userName={userName}
-          currentChatId={undefined} // No longer needed - sidebar will use URL
+          currentChatId={currentChatId}
           chatHistory={sidebarChats}
           isCollapsed={sidebarCollapsed}
           tokenExpiry={tokenExpiry}
@@ -81,6 +112,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           onNewChat={createNewChat}
           onSelectChat={handleSelectChat}
           onDeleteChat={handleDeleteChat}
+          onDeleteAllChats={handleDeleteAllChats}
           onRenameChat={renameChat}
         />
       </ErrorBoundary>
@@ -92,6 +124,32 @@ export function AppLayout({ children }: AppLayoutProps) {
       >
         {children}
       </ErrorBoundary>
+
+      <AlertDialog open={!!deletingChatId} onOpenChange={(open) => !open && setDeletingChatId(null)}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Delete chat?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete &quot;{deletingChatTitle}&quot;. This action cannot be undone.
+          </AlertDialogDescription>
+          <div className="mt-6 flex justify-end gap-3">
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDeleteChat}>Delete</AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showDeleteAllDialog} onOpenChange={setShowDeleteAllDialog}>
+        <AlertDialogContent>
+          <AlertDialogTitle>Delete all chats?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete all {chats.length} conversations from your history. This action cannot be undone.
+          </AlertDialogDescription>
+          <div className="mt-6 flex justify-end gap-3">
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDeleteAllChats}>Delete all</AlertDialogAction>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/frontend/components/ui/alert-dialog.tsx
+++ b/src/frontend/components/ui/alert-dialog.tsx
@@ -1,0 +1,106 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl border border-neutral-700 bg-neutral-800 p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogTitle = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-neutral-100", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("mt-2 text-sm text-neutral-400", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants({ variant: "destructive" }), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "ghost" }),
+      "text-neutral-300 hover:text-neutral-100",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/frontend/contexts/ChatContext.tsx
+++ b/src/frontend/contexts/ChatContext.tsx
@@ -15,7 +15,8 @@ type ChatAction =
   | { type: 'SET_ERROR'; payload: string | null }
   | { type: 'ADD_CHAT'; payload: ChatItem }
   | { type: 'UPDATE_CHAT'; payload: { id: string; updates: Partial<ChatItem> } }
-  | { type: 'DELETE_CHAT'; payload: string };
+  | { type: 'DELETE_CHAT'; payload: string }
+  | { type: 'CLEAR_CHATS' };
 
 // Initial state
 const initialState: ChatState = {
@@ -55,6 +56,12 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         chats: state.chats.filter(chat => chat.id !== action.payload),
       };
 
+    case 'CLEAR_CHATS':
+      return {
+        ...state,
+        chats: [],
+      };
+
     default:
       return state;
   }
@@ -83,25 +90,36 @@ export function ChatProvider({ children }: ChatProviderProps) {
 
   // Load chats from storage on mount
   useEffect(() => {
-    const loadedChats = chatStorage.loadChats();
+    const deletedThreadIds = chatStorage.getDeletedThreadIds();
+    const loadedChats = chatStorage
+      .loadChats()
+      .filter(chat => !deletedThreadIds.has(chat.id));
     dispatch({ type: 'SET_CHATS', payload: loadedChats });
-    dispatch({ type: 'SET_LOADING', payload: false }); // Mark loading as complete
+    dispatch({ type: 'SET_LOADING', payload: false });
   }, []);
 
   // Save chats to storage whenever they change
   useEffect(() => {
-    if (state.chats.length > 0) {
-      chatStorage.saveChats(state.chats);
+    if (state.isLoading) return;
+
+    if (state.chats.length === 0) {
+      chatStorage.clearChats();
+      return;
     }
-  }, [state.chats]);
+
+    chatStorage.saveChats(state.chats);
+  }, [state.chats, state.isLoading]);
 
   useEffect(() => {
     async function loadUserHistory() {
       try {
         dispatch({ type: 'SET_LOADING', payload: true });
+        const deletedThreadIds = chatStorage.getDeletedThreadIds();
         const history = await getAllThreadsByUserId(window.USER_DATA.preferred_username);
 
-        const chats: ChatItem[] = history.map((conversation) => {
+        const chats: ChatItem[] = history
+          .filter((conversation) => !deletedThreadIds.has(conversation.id))
+          .map((conversation) => {
 
           let title = 'New Chat';
 
@@ -118,7 +136,6 @@ export function ChatProvider({ children }: ChatProviderProps) {
         });
 
         dispatch({ type: 'SET_CHATS', payload: chats });
-        console.log(history)
       } catch (error) {
         console.error(error)
       } finally {
@@ -132,6 +149,15 @@ export function ChatProvider({ children }: ChatProviderProps) {
 
   // Actions
   const createNewChat = useCallback((): string => {
+    const existingEmptyChat = state.chats.find(
+      chat => chat.title === "New Chat" && chat.messages.length === 0
+    );
+
+    if (existingEmptyChat) {
+      navigate(`/chat/${existingEmptyChat.id}`);
+      return existingEmptyChat.id;
+    }
+
     const newChatId = uuidv4();
     const newChat: ChatItem = {
       id: newChatId,
@@ -149,17 +175,17 @@ export function ChatProvider({ children }: ChatProviderProps) {
     navigate(`/chat/${newChatId}`);
 
     return newChatId;
-  }, [navigate]);
+  }, [navigate, state.chats]);
 
   const deleteChat = useCallback((chatId: string) => {
+    chatStorage.deleteChat(chatId);
     dispatch({ type: 'DELETE_CHAT', payload: chatId });
+  }, []);
 
-    // Clear storage if no chats remain  
-    if (state.chats.filter(chat => chat.id !== chatId).length === 0) {
-      chatStorage.clearChats();
-    }
-
-    // Navigation will be handled by the component that calls this
+  const deleteAllChats = useCallback(() => {
+    const threadIds = state.chats.map(chat => chat.id);
+    chatStorage.deleteAllChats(threadIds);
+    dispatch({ type: 'CLEAR_CHATS' });
   }, [state.chats]);
 
   const renameChat = useCallback((chatId: string, newTitle: string) => {
@@ -230,6 +256,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
     // Actions
     createNewChat,
     deleteChat,
+    deleteAllChats,
     renameChat,
     updateChatMessages,
     updateChatActivities,

--- a/src/frontend/services/chatStorage.ts
+++ b/src/frontend/services/chatStorage.ts
@@ -2,6 +2,7 @@ import { ChatItem } from '../types/chat';
 
 class ChatStorageService {
   private readonly CHATS_STORAGE_KEY = 'dataverse-ai-chats';
+  private readonly DELETED_THREADS_KEY = 'dataverse-ai-deleted-threads';
   private readonly MAX_CHATS = 50; // Limit to prevent localStorage bloat
 
   /**
@@ -83,6 +84,85 @@ class ChatStorageService {
       localStorage.removeItem(this.CHATS_STORAGE_KEY);
     } catch (error) {
       console.error('Error clearing chat storage:', error);
+    }
+  }
+
+  /**
+   * Track a deleted thread so it is not restored from server history
+   */
+  markThreadDeleted(threadId: string): void {
+    try {
+      const deleted = this.getDeletedThreadIds();
+      deleted.add(threadId);
+      localStorage.setItem(this.DELETED_THREADS_KEY, JSON.stringify([...deleted]));
+    } catch (error) {
+      console.error('Error marking thread as deleted:', error);
+    }
+  }
+
+  /**
+   * Track multiple deleted threads at once
+   */
+  markThreadsDeleted(threadIds: string[]): void {
+    if (threadIds.length === 0) return;
+
+    try {
+      const deleted = this.getDeletedThreadIds();
+      threadIds.forEach(id => deleted.add(id));
+      localStorage.setItem(this.DELETED_THREADS_KEY, JSON.stringify([...deleted]));
+    } catch (error) {
+      console.error('Error marking threads as deleted:', error);
+    }
+  }
+
+  /**
+   * Get IDs of threads the user has deleted from the UI
+   */
+  getDeletedThreadIds(): Set<string> {
+    try {
+      const stored = localStorage.getItem(this.DELETED_THREADS_KEY);
+      if (!stored) return new Set();
+
+      const parsed: string[] = JSON.parse(stored);
+      return new Set(parsed.filter(Boolean));
+    } catch (error) {
+      console.error('Error loading deleted thread IDs:', error);
+      return new Set();
+    }
+  }
+
+  /**
+   * Remove a single chat from local storage
+   */
+  deleteChat(threadId: string): boolean {
+    try {
+      this.markThreadDeleted(threadId);
+      const chats = this.loadChats().filter(chat => chat.id !== threadId);
+
+      if (chats.length === 0) {
+        this.clearChats();
+      } else {
+        this.saveChats(chats);
+      }
+
+      return true;
+    } catch (error) {
+      console.error('Error deleting chat from localStorage:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Delete all chats from local storage
+   */
+  deleteAllChats(threadIds: string[]): boolean {
+    try {
+      this.markThreadsDeleted(threadIds);
+      this.clearChats();
+      return true;
+    } catch (error) {
+      console.error('Error deleting all chats from localStorage:', error);
+      return false;
     }
   }
 

--- a/src/frontend/types/chat.ts
+++ b/src/frontend/types/chat.ts
@@ -19,6 +19,7 @@ export interface ChatState {
 export interface ChatActions {
   createNewChat: () => string;
   deleteChat: (chatId: string) => void;
+  deleteAllChats: () => void;
   renameChat: (chatId: string, newTitle: string) => void;
   updateChatMessages: (chatId: string, messages: Message[]) => void;
   updateChatActivities: (chatId: string, messageId: string, activities: ProcessedEvent[]) => void;


### PR DESCRIPTION
Closes #12

**Summary**
- Add confirmation dialog before deleting a single chat
- Add "Clear all" button to delete all chats with confirmation
- Persist deleted thread IDs so chats don't reappear after reload
- Highlight the active chat in the sidebar

**Test plan**
- [x] Hover a chat and click delete — confirmation dialog appears
- [x] Cancel delete — chat remains
- [x] Confirm delete — chat is removed from sidebar
- [x] Delete the active chat — navigates to another chat or home
- [x] Click "Clear all" — confirmation shows chat count
- [x] Confirm clear all — all chats removed, navigates to home
- [x] Refresh page — deleted chats stay deleted