### PR TITLE
feat: set up e2e test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist-ssr
 *.sw?
 .env
 ROADMAP.md
+
+# Playwright
+playwright-report/
+test-results/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,71 @@
+stages:
+  - lint
+  - test
+  - build
+  - e2e
+
+variables:
+  NODE_VERSION: "22"
+
+default:
+  image: node:22-slim
+  cache:
+    key:
+      files:
+        - package-lock.json
+    paths:
+      - node_modules/
+
+.install: &install
+  before_script:
+    - npm ci
+
+lint:
+  stage: lint
+  <<: *install
+  script:
+    - npm run lint
+
+unit-test:
+  stage: test
+  <<: *install
+  script:
+    - npm run test:run
+  coverage: '/All files[^|]*\|[^|]*\s+([\d.]+)/'
+  artifacts:
+    when: always
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage/cobertura-coverage.xml
+
+build:
+  stage: build
+  <<: *install
+  script:
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+    expire_in: 1 hour
+
+e2e:
+  stage: e2e
+  # Use the Playwright image whose bundled browser channel matches @playwright/test ^1.61.x.
+  # If the package version is bumped, update this tag accordingly.
+  image: mcr.microsoft.com/playwright:v1.61.0-noble
+  needs:
+    - build
+  variables:
+    CI: "true"
+  before_script:
+    - npm ci
+    # Reinstall browsers so the CLI version always matches the image channel.
+    - npx playwright install chromium --with-deps
+  script:
+    - npx playwright test
+  artifacts:
+    when: always
+    paths:
+      - playwright-report/
+    expire_in: 7 days

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ unit-test:
   stage: test
   <<: *install
   script:
-    - npm run test:run
+    - npm run test:coverage
   coverage: '/All files[^|]*\|[^|]*\s+([\d.]+)/'
   artifacts:
     when: always
@@ -51,17 +51,13 @@ build:
 
 e2e:
   stage: e2e
-  # Use the Playwright image whose bundled browser channel matches @playwright/test ^1.61.x.
-  # If the package version is bumped, update this tag accordingly.
-  image: mcr.microsoft.com/playwright:v1.61.0-noble
+  image: mcr.microsoft.com/playwright:v1.61.1-noble
   needs:
     - build
   variables:
     CI: "true"
   before_script:
     - npm ci
-    # Reinstall browsers so the CLI version always matches the image channel.
-    - npx playwright install chromium --with-deps
   script:
     - npx playwright test
   artifacts:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev clean local deploy undeploy
+.PHONY: dev clean local deploy undeploy e2e
 
 # OpenShift namespace (can be overridden: make deploy openshift NAMESPACE=my-project)
 NAMESPACE ?= $(shell oc project -q 2>/dev/null)
@@ -23,6 +23,12 @@ install:
 
 clean:
 	rm -rf node_modules dist
+
+## Run Playwright e2e tests
+e2e:
+	npm run build
+	npx playwright install chromium --with-deps 2>/dev/null || npx playwright install chromium
+	npx playwright test
 
 dev:
 	npm run dev

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -48,12 +48,21 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
     }),
   );
 
-  // Agent health probe — avoids 10 s ECONNREFUSED timeout on every page mount
+  // Agent health probe — avoids ECONNREFUSED timeout on every page mount
   await page.route('**/api/health/agent', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ status: 'healthy' }),
+    }),
+  );
+
+  // AppLayout calls POST /threads/search on every mount to reconcile chat history.
+  await page.route('**/api/proxy/agent/threads/search', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
     }),
   );
 }

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -1,0 +1,59 @@
+import type { Page } from '@playwright/test';
+
+export interface BrandingOverride {
+  title?: string;
+  logo_url?: string;
+}
+
+/**
+ * Mock the config and agent-proxy endpoints so tests don't depend on
+ * a real agent backend.  Config endpoints could be served by the real
+ * Fastify process but overriding them keeps tests hermetic.
+ */
+export async function mountConfig(page: Page, branding: BrandingOverride = {}): Promise<void> {
+  await page.route('**/api/config/branding', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        logo_url: branding.logo_url ?? '',
+        title: branding.title ?? 'Test Agent',
+        colors: {
+          light: { primary: '#0066cc', accent: '#a60000', background: '#ffffff', foreground: '#1a1a1a' },
+          dark: { primary: '#4dabf7', accent: '#f56e6e', background: '#0a1628', foreground: '#f0f4f8' },
+        },
+      }),
+    }),
+  );
+
+  await page.route('**/api/config/features', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ debug_mode_default: false, auth_enabled: false }),
+    }),
+  );
+
+  // Feedback endpoint called for previously-hydrated chats
+  await page.route('**/api/proxy/agent/threads/*/feedback**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  );
+
+  // Announcement banner (optional endpoint — return disabled)
+  await page.route('**/api/announcement', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabled: false }),
+    }),
+  );
+
+  // Agent health probe — avoids 10 s ECONNREFUSED timeout on every page mount
+  await page.route('**/api/health/agent', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'healthy' }),
+    }),
+  );
+}

--- a/e2e/helpers/sse-mock.ts
+++ b/e2e/helpers/sse-mock.ts
@@ -1,0 +1,39 @@
+import type { Page } from '@playwright/test';
+
+/** Serialise one `data:` line for a token chunk the SSEProcessor accepts. */
+function tokenChunk(text: string, chunkId: number): string {
+  return `data: ${JSON.stringify({ type: 'token', content: text, chunk_id: chunkId })}\n\n`;
+}
+
+/**
+ * Install a browser-level route that intercepts the streaming endpoint and
+ * returns a minimal SSE response containing the provided text.
+ *
+ * Because Playwright intercepts at the CDP network layer the request never
+ * reaches the Fastify server, so no upstream AGENT_HOST calls are made.
+ */
+export async function mockAgentStream(page: Page, responseText: string): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) => {
+    const body = tokenChunk(responseText, 0) + 'data: [DONE]\n\n';
+    return route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body,
+    });
+  });
+}
+
+/** Intercept thread state requests (used when navigating to an existing chat). */
+export async function mockThreadState(page: Page): Promise<void> {
+  await page.route('**/api/proxy/agent/threads/*/state', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ messages: [], tasks: [] }),
+    }),
+  );
+}

--- a/e2e/page-objects/ChatPage.ts
+++ b/e2e/page-objects/ChatPage.ts
@@ -1,0 +1,43 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/** Page object for the chat view (`/chat/:threadId`). */
+export class ChatPage {
+  constructor(private readonly page: Page) {}
+
+  async waitForLoad(): Promise<void> {
+    // The chat input becomes visible once the page has mounted
+    await this.page.waitForSelector('textarea', { state: 'visible', timeout: 10_000 });
+  }
+
+  /**
+   * Wait for the streaming loading indicator to disappear and for at least
+   * one AI message bubble to appear in the DOM.
+   */
+  async waitForAIResponse(timeout = 15_000): Promise<void> {
+    // The sr-only aria-live region in ChatPage.tsx announces "Response complete".
+    // Use the .sr-only qualifier to avoid matching the chat messages live-log element.
+    await this.page.waitForFunction(
+      () => {
+        const liveRegion = document.querySelector('.sr-only[aria-live="polite"]');
+        return liveRegion?.textContent?.includes('Response complete');
+      },
+      { timeout },
+    );
+  }
+
+  /** Returns true when the current URL matches a chat route. */
+  async isOnChatRoute(): Promise<boolean> {
+    return /\/chat\//.test(this.page.url());
+  }
+
+  /** Asserts the current URL contains a chat thread segment. */
+  async expectChatRoute(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/chat\//);
+  }
+
+  /** Returns the full visible text content of the page — useful for asserting response text. */
+  async getBodyText(): Promise<string> {
+    return this.page.locator('body').innerText();
+  }
+}

--- a/e2e/page-objects/HomePage.ts
+++ b/e2e/page-objects/HomePage.ts
@@ -1,0 +1,27 @@
+import type { Page } from '@playwright/test';
+
+/** Page object for the homepage (`/`). */
+export class HomePage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/');
+    await this.page.waitForSelector('textarea', { state: 'visible' });
+  }
+
+  /** Returns the browser document title set from the branding config. */
+  async getDocumentTitle(): Promise<string> {
+    return this.page.title();
+  }
+
+  /** Fills the chat input and clicks the submit button. */
+  async submitPrompt(text: string): Promise<void> {
+    await this.page.locator('textarea').fill(text);
+    await this.page.locator('button[type="submit"]').click();
+  }
+
+  /** Clicks a quick-prompt chip button that contains the given text. */
+  async clickQuickPrompt(text: string): Promise<void> {
+    await this.page.getByText(text, { exact: false }).first().click();
+  }
+}

--- a/e2e/page-objects/SettingsPage.ts
+++ b/e2e/page-objects/SettingsPage.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+type SettingsTab = 'Profile' | 'Memories' | 'Custom Rules' | 'Appearance' | 'Tool Approvals';
+
+/** Page object for the settings view (`/settings`). */
+export class SettingsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/settings');
+    await this.page.waitForSelector('h1', { state: 'visible' });
+  }
+
+  async getHeading(): Promise<string> {
+    return this.page.locator('h1').innerText();
+  }
+
+  async clickTab(tab: SettingsTab): Promise<void> {
+    await this.page.getByRole('button', { name: tab, exact: false }).click();
+  }
+
+  async expectTabContentVisible(heading: SettingsTab): Promise<void> {
+    await expect(this.page.getByRole('heading', { name: heading, exact: false })).toBeVisible();
+  }
+
+  /** Navigate back to the home page via the back arrow button. */
+  async navigateBack(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Back' }).click();
+    await expect(this.page).toHaveURL('/');
+  }
+}

--- a/e2e/smoke/chat-flow.spec.ts
+++ b/e2e/smoke/chat-flow.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream } from '../helpers/sse-mock';
+
+const MOCK_RESPONSE = 'Hello from the test agent!';
+
+test.describe('Chat flow smoke test', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountConfig(page, { title: 'Test Agent' });
+    await mockAgentStream(page, MOCK_RESPONSE);
+  });
+
+  test('home page loads with textarea and submit button', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.goto();
+
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
+  });
+
+  test('submitting a prompt navigates to the chat route', async ({ page }) => {
+    const home = new HomePage(page);
+    const chat = new ChatPage(page);
+
+    await home.goto();
+    await home.submitPrompt('What can you do?');
+
+    await chat.expectChatRoute();
+  });
+
+  test('chat page shows AI response after streaming completes', async ({ page }) => {
+    const home = new HomePage(page);
+    const chat = new ChatPage(page);
+
+    await home.goto();
+    await home.submitPrompt('Tell me something interesting.');
+
+    await chat.expectChatRoute();
+    await chat.waitForAIResponse();
+
+    const bodyText = await chat.getBodyText();
+    expect(bodyText).toContain(MOCK_RESPONSE);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -4686,6 +4687,22 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@posthog/core": {
       "version": "1.29.1",
@@ -10849,6 +10866,53 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@fastify/cookie": "^11.0.2",
@@ -62,6 +63,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:18080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    // Bypasses --env-file=.env (not needed in CI) by invoking the compiled server directly.
+    command: 'node dist/server/index.js',
+    url: 'http://localhost:18080',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+    env: {
+      PORT: '18080',
+      AUTH_ENABLED: 'false',
+      ENVIRONMENT: 'test',
+      AGENT_HOST: 'http://localhost:19999',
+    },
+  },
+});

--- a/src/frontend/pages/SettingsPage.tsx
+++ b/src/frontend/pages/SettingsPage.tsx
@@ -40,6 +40,7 @@ export function SettingsPage() {
             variant="plain"
             size="sm"
             onClick={() => navigate('/')}
+            aria-label="Back"
             className="!p-1.5"
           >
             <ArrowLeft className="w-4 h-4" />


### PR DESCRIPTION
## Description

Adds a complete Playwright end-to-end test framework to `template-ui`. Previously the project had only Vitest unit tests; this gives us a browser-level smoke test that validates the full chat flow (home → submit prompt → streaming AI response) without requiring a real agent backend.

## Changes

- `playwright.config.ts` — Playwright config: single Chromium project, `webServer` boots the compiled Fastify server with `AUTH_ENABLED=false`
- `e2e/helpers/sse-mock.ts` — CDP-level route intercept for the streaming endpoint; returns a fake SSE token chunk so no upstream calls are made
- `e2e/helpers/config-mount.ts` — Mocks branding, features, agent health, announcement, and feedback endpoints to make tests hermetic
- `e2e/page-objects/HomePage.ts` — Page object for `/` (goto, submitPrompt, clickQuickPrompt)
- `e2e/page-objects/ChatPage.ts` — Page object for `/chat/:threadId` (expectChatRoute, waitForAIResponse, getBodyText)
- `e2e/page-objects/SettingsPage.ts` — Page object for `/settings` (goto, clickTab, navigateBack)
- `e2e/smoke/chat-flow.spec.ts` — 3 smoke tests: home loads, submit navigates, AI response appears
- `Makefile` — New `make e2e` target: build → install chromium → `playwright test`
- `.gitlab-ci.yml` — New 4-stage pipeline (lint / unit-test / build / e2e); e2e stage uses `mcr.microsoft.com/playwright:v1.61.0-noble` image with `dist/` artifact dependency
- `src/frontend/pages/SettingsPage.tsx` — Added `aria-label="Back"` to back button for stable selector

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Playwright config, test helpers, smoke tests, Makefile target, and CI stage
- **Human verification**: Tests confirmed passing locally via `make e2e`; reviewed page object selectors against actual component markup, outline design/scope

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

- The `waitForAIResponse` helper in `ChatPage.ts` relies on a `.sr-only[aria-live="polite"]` region in `ChatPage.tsx` announcing `"Response complete"` — if that aria-live region is ever removed or renamed this selector will break.
- The CI `e2e` stage pins `mcr.microsoft.com/playwright:v1.61.0-noble` — if `@playwright/test` is bumped in `package.json`, this image tag must be updated to match.