### PR TITLE
fix: add fallback tag pattern for non-semver tags in workflow

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix={{branch}}-,enable=${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -40,6 +40,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix={{branch}}-,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
 


### PR DESCRIPTION
The workflow was failing when triggered by non-semver tags (e.g., dev-1.0.0) because docker/metadata-action only had semver patterns configured.

Added type=ref,event=tag to ensure any tag generates a valid Docker image tag, preventing "tag is needed when pushing to registry" build failures.