### PR TITLE
feat: add config edge case tests

### DIFF
--- a/src/server/utils/config-edge-cases.test.ts
+++ b/src/server/utils/config-edge-cases.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getSettings, resetSettings } from "./settings.js";
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configDir = resolve(__dirname, "../../../config/ui");
+const testConfigPath = resolve(configDir, "edge-case-settings.yaml");
+
+// Minimal valid YAML that passes all validation
+const VALID_YAML_BASE = `
+branding:
+  title: "Test Agent"
+  colors:
+    light:
+      primary: "#ff0000"
+      accent: "#00ff00"
+      background: "#ffffff"
+      foreground: "#000000"
+    dark:
+      primary: "#ff00ff"
+      accent: "#00ffff"
+      background: "#000000"
+      foreground: "#ffffff"
+`;
+
+function saveEnv(...keys: string[]) {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of keys) saved[k] = process.env[k];
+  return () => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  };
+}
+
+beforeEach(() => {
+  resetSettings();
+  mkdirSync(configDir, { recursive: true });
+  delete process.env.UI_CONFIG_PATH;
+});
+
+afterEach(() => {
+  resetSettings();
+  try {
+    if (existsSync(testConfigPath)) unlinkSync(testConfigPath);
+  } catch { /* ignore */ }
+});
+
+// ── Invalid YAML → clear error ─────────────────────────────────────────────
+
+describe("Invalid YAML → clear parse error", () => {
+  it("throws a descriptive error for syntactically broken YAML", () => {
+    writeFileSync(testConfigPath, "key: value:\n  bad: [indent\n");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    expect(() => getSettings()).toThrow(/Config parse error: invalid YAML/);
+  });
+
+  it("error message includes the config file path", () => {
+    writeFileSync(testConfigPath, ": invalid_start\n  broken\n");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    expect(() => getSettings()).toThrow(testConfigPath);
+  });
+
+  it("throws for YAML with an unclosed flow sequence", () => {
+    writeFileSync(testConfigPath, "items: [one, two\n");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    expect(() => getSettings()).toThrow(/Config parse error/);
+  });
+});
+
+// ── Missing YAML → graceful fallback to defaults ────────────────────────────
+
+describe("Missing YAML → graceful fallback", () => {
+  it("returns defaults when config file does not exist in allowed dir", () => {
+    process.env.UI_CONFIG_PATH = resolve(configDir, "nonexistent-99999.yaml");
+    const settings = getSettings();
+
+    expect(settings.branding.title).toBe("Deep Agent");
+    expect(settings.features.auth_enabled).toBe(true);
+    expect(settings.features.debug_mode_default).toBe(false);
+  });
+
+  it("defaults include complete agent config", () => {
+    process.env.UI_CONFIG_PATH = resolve(configDir, "nonexistent-99999.yaml");
+    const settings = getSettings();
+
+    expect(settings.agent.timeout_ms).toBe(30000);
+    expect(settings.agent.streaming).toBe(true);
+    expect(settings.agent.endpoint).toBe("");
+  });
+
+  it("defaults include complete server config", () => {
+    process.env.UI_CONFIG_PATH = resolve(configDir, "nonexistent-99999.yaml");
+    const settings = getSettings();
+
+    expect(settings.server.port).toBe(8080);
+    expect(settings.server.host).toBe("0.0.0.0");
+  });
+});
+
+// ── Empty / comment-only YAML → graceful fallback ──────────────────────────
+
+describe("Empty or comment-only YAML → graceful fallback", () => {
+  it("falls back to defaults when config file is empty", () => {
+    writeFileSync(testConfigPath, "");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    const settings = getSettings();
+    expect(settings.branding.title).toBe("Deep Agent");
+    expect(settings.features.auth_enabled).toBe(true);
+  });
+
+  it("falls back to defaults when config file contains only comments", () => {
+    writeFileSync(testConfigPath, "# This is a placeholder\n# No actual config here\n");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    const settings = getSettings();
+    expect(settings.branding.title).toBe("Deep Agent");
+    expect(settings.agent.timeout_ms).toBe(30000);
+  });
+});
+
+// ── Feature flags ───────────────────────────────────────────────────────────
+
+describe("Feature flags toggle", () => {
+  it("FEATURE_AUTH_ENABLED=true enables auth", () => {
+    const restore = saveEnv("FEATURE_AUTH_ENABLED", "AUTH_ENABLED");
+    process.env.FEATURE_AUTH_ENABLED = "true";
+    delete process.env.AUTH_ENABLED;
+
+    const settings = getSettings();
+    expect(settings.features.auth_enabled).toBe(true);
+    restore();
+  });
+
+  it("FEATURE_AUTH_ENABLED=false disables auth", () => {
+    const restore = saveEnv("FEATURE_AUTH_ENABLED", "AUTH_ENABLED");
+    process.env.FEATURE_AUTH_ENABLED = "false";
+    delete process.env.AUTH_ENABLED;
+
+    const settings = getSettings();
+    expect(settings.features.auth_enabled).toBe(false);
+    restore();
+  });
+
+  it("legacy AUTH_ENABLED=false disables auth when FEATURE_AUTH_ENABLED not set", () => {
+    const restore = saveEnv("FEATURE_AUTH_ENABLED", "AUTH_ENABLED");
+    delete process.env.FEATURE_AUTH_ENABLED;
+    process.env.AUTH_ENABLED = "false";
+
+    const settings = getSettings();
+    expect(settings.features.auth_enabled).toBe(false);
+    restore();
+  });
+
+  it("FEATURE_AUTH_ENABLED takes precedence over legacy AUTH_ENABLED", () => {
+    const restore = saveEnv("FEATURE_AUTH_ENABLED", "AUTH_ENABLED");
+    process.env.FEATURE_AUTH_ENABLED = "true";
+    process.env.AUTH_ENABLED = "false"; // should be ignored
+
+    const settings = getSettings();
+    expect(settings.features.auth_enabled).toBe(true);
+    restore();
+  });
+
+  it("FEATURE_DEBUG_MODE_DEFAULT=true enables debug mode", () => {
+    const restore = saveEnv("FEATURE_DEBUG_MODE_DEFAULT");
+    process.env.FEATURE_DEBUG_MODE_DEFAULT = "true";
+
+    const settings = getSettings();
+    expect(settings.features.debug_mode_default).toBe(true);
+    restore();
+  });
+
+  it("FEATURE_DEBUG_MODE_DEFAULT=false keeps debug mode off", () => {
+    const restore = saveEnv("FEATURE_DEBUG_MODE_DEFAULT");
+    process.env.FEATURE_DEBUG_MODE_DEFAULT = "false";
+
+    const settings = getSettings();
+    expect(settings.features.debug_mode_default).toBe(false);
+    restore();
+  });
+});
+
+// ── Env override precedence ─────────────────────────────────────────────────
+
+describe("Env override precedence over YAML", () => {
+  it("BRANDING_TITLE env overrides YAML branding title", () => {
+    writeFileSync(testConfigPath, VALID_YAML_BASE + 'agent:\n  timeout_ms: 30000\n  streaming: true\n  endpoint: ""\n');
+    const restore = saveEnv("UI_CONFIG_PATH", "BRANDING_TITLE");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+    process.env.BRANDING_TITLE = "Overridden By Env";
+
+    const settings = getSettings();
+    expect(settings.branding.title).toBe("Overridden By Env");
+    restore();
+  });
+
+  it("BRANDING_PRIMARY_LIGHT env overrides YAML primary color", () => {
+    writeFileSync(testConfigPath, VALID_YAML_BASE + 'agent:\n  timeout_ms: 30000\n  streaming: true\n  endpoint: ""\n');
+    const restore = saveEnv("UI_CONFIG_PATH", "BRANDING_PRIMARY_LIGHT");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+    process.env.BRANDING_PRIMARY_LIGHT = "#123456";
+
+    const settings = getSettings();
+    expect(settings.branding.colors.light.primary).toBe("#123456");
+    restore();
+  });
+
+  it("AGENT_TIMEOUT_MS env overrides YAML timeout", () => {
+    writeFileSync(testConfigPath, VALID_YAML_BASE + "agent:\n  timeout_ms: 5000\n  streaming: true\n  endpoint: \"\"\n");
+    const restore = saveEnv("UI_CONFIG_PATH", "AGENT_TIMEOUT_MS");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+    process.env.AGENT_TIMEOUT_MS = "99000";
+
+    const settings = getSettings();
+    expect(settings.agent.timeout_ms).toBe(99000);
+    restore();
+  });
+
+  it("AGENT_ENDPOINT env sets endpoint value", () => {
+    writeFileSync(testConfigPath, VALID_YAML_BASE + 'agent:\n  timeout_ms: 30000\n  streaming: true\n  endpoint: ""\n');
+    const restore = saveEnv("UI_CONFIG_PATH", "AGENT_ENDPOINT");
+    process.env.UI_CONFIG_PATH = testConfigPath;
+    process.env.AGENT_ENDPOINT = "http://my-agent.example.com";
+
+    const settings = getSettings();
+    expect(settings.agent.endpoint).toBe("http://my-agent.example.com");
+    restore();
+  });
+});
+
+// ── Config reload (ConfigMap reload) ────────────────────────────────────────
+
+describe("Config reload via resetSettings()", () => {
+  it("resetSettings() clears cache so next call picks up new env var", () => {
+    const restore = saveEnv("BRANDING_TITLE");
+    process.env.BRANDING_TITLE = "First Title";
+    const first = getSettings();
+    expect(first.branding.title).toBe("First Title");
+
+    resetSettings();
+    process.env.BRANDING_TITLE = "Second Title";
+    const second = getSettings();
+    expect(second.branding.title).toBe("Second Title");
+    restore();
+  });
+
+  it("resetSettings() clears cache so next call reads updated config file", () => {
+    writeFileSync(testConfigPath, VALID_YAML_BASE + 'agent:\n  timeout_ms: 30000\n  streaming: true\n  endpoint: ""\n');
+    process.env.UI_CONFIG_PATH = testConfigPath;
+
+    const first = getSettings();
+    expect(first.branding.title).toBe("Test Agent");
+
+    // Simulate ConfigMap update: write new content and reload
+    resetSettings();
+    writeFileSync(
+      testConfigPath,
+      VALID_YAML_BASE.replace("Test Agent", "Reloaded Agent") +
+        'agent:\n  timeout_ms: 30000\n  streaming: true\n  endpoint: ""\n',
+    );
+
+    const second = getSettings();
+    expect(second.branding.title).toBe("Reloaded Agent");
+  });
+});

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -199,11 +199,23 @@ function deepMerge<T extends Record<string, unknown>>(
 }
 
 function loadYaml(filePath: string): Record<string, unknown> | null {
+  let raw: string;
   try {
-    const raw = readFileSync(filePath, "utf-8");
-    return (yaml.load(raw) as Record<string, unknown>) ?? null;
-  } catch {
-    return null;
+    raw = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return null;
+    }
+    throw err;
+  }
+
+  try {
+    const parsed = yaml.load(raw) as Record<string, unknown>;
+    return parsed ?? null;
+  } catch (parseError) {
+    const msg = parseError instanceof Error ? parseError.message : String(parseError);
+    throw new Error(`Config parse error: invalid YAML in "${filePath}": ${msg}`);
   }
 }
 
@@ -391,6 +403,7 @@ function applyEnvOverrides(config: UISettings): void {
 }
 
 let _settings: UISettings | undefined;
+let _agentName: string | null = null;
 
 export function getSettings(): UISettings {
   if (_settings) return _settings;
@@ -427,13 +440,11 @@ export function getSettings(): UISettings {
   return _settings;
 }
 
-// For testing only - clears the cached settings
+// For testing only - clears the cached settings and agent name
 export function resetSettings(): void {
   _settings = undefined;
+  _agentName = null;
 }
-
-// Agent name fallback (fetches from agent backend /info endpoint)
-let _agentName: string | null = null;
 
 export async function getAgentName(): Promise<string> {
   if (_agentName !== null) return _agentName;


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Adds 20 edge-case tests for the `template-ui` config/settings layer and fixes two related correctness gaps in `settings.ts`:

1. `loadYaml` now distinguishes a missing file (returns `null` → falls back to defaults) from a syntactically broken YAML file (throws `Config parse error: invalid YAML in "<path>": <details>`). Previously both cases were silently swallowed, making misconfigured ConfigMaps invisible at startup.
2. `resetSettings()` now also resets the `_agentName` cache, preventing stale values leaking across tests.

## Changes

- `src/server/utils/settings.ts` — `loadYaml` split into two try/catch blocks so ENOENT returns null while YAML parse errors throw a descriptive message; `_agentName` declaration moved alongside `_settings` so `resetSettings()` can safely clear both; `resetSettings()` updated to set `_agentName = null`
- `src/server/utils/config-edge-cases.test.ts` — new file: 20 Vitest tests across 6 groups:
  - **Invalid YAML → clear parse error** (3 tests): syntax error, unclosed sequence, error message includes filename
  - **Missing YAML → graceful fallback** (3 tests): default title/features, default agent config, default server config
  - **Empty / comment-only YAML → fallback** (2 tests): empty file, comment-only file
  - **Feature flags toggle** (6 tests): `FEATURE_AUTH_ENABLED` true/false, legacy `AUTH_ENABLED` fallback, precedence over legacy, `FEATURE_DEBUG_MODE_DEFAULT` true/false
  - **Env override precedence** (4 tests): `BRANDING_TITLE`, `BRANDING_PRIMARY_LIGHT`, `AGENT_TIMEOUT_MS`, `AGENT_ENDPOINT`
  - **Config reload via resetSettings()** (2 tests): env var reload, file content reload

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Full implementation — `loadYaml` fix and all 20 test cases generated and verified
- **Human verification**: All 20 new tests run locally and pass; confirmed the 2 pre-existing failures in `settings.test.ts` were present before this branch

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None — test-only changes plus a `loadYaml` error handling improvement (startup will now fail fast on corrupt config instead of silently booting on defaults).

## Reviewer Notes

<!-- What to focus on. -->

- Two tests in the pre-existing `settings.test.ts` were already failing before this branch (`should use defaults when YAML file not found` uses a path outside allowed dirs; `should throw error for empty logo_url` checks validation that doesn't exist). These are **not** regressions introduced here.
- The `loadYaml` change is intentionally opinionated: a file that exists but contains bad YAML is treated as a misconfiguration (throws), while a missing file is treated as "not configured yet" (falls back to defaults).