### PR TITLE
fix: retry banner regression for sse resilience

### DIFF
--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -25,6 +25,7 @@ import { buildAgentApiUrl } from '@/lib/app-paths';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
 import type { HITLInterruptValue, InterruptInfo } from '@/types/deep-agent';
+import { getThreadState } from '@/services/agent-rest';
 
 function enrichInterrupt(interrupt: InterruptPayload): InterruptInfo {
   const raw = interrupt.value as string | HITLInterruptValue;
@@ -63,11 +64,13 @@ function serializeLastMessage(messages: Message[]): string {
 const EMPTY_MESSAGES: Message[] = [];
 
 /** MR-56: max automatic retries after the first failed stream attempt */
-const MAX_RETRIES = 3;
+export const MAX_RETRIES = 3;
 /** MR-56: base delay for exponential backoff (ms) */
 const BASE_DELAY_MS = 1000;
 /** MR-63: idle threshold before marking stream as stale (ms) */
 const STALE_THRESHOLD_MS = 30000;
+/** Time threshold for refetching history on reconnect (ms) */
+const HISTORY_REFETCH_THRESHOLD_MS = 10000;
 
 function computeRetryDelayMs(retryAttemptNumber: number): number {
   const capped = Math.min(BASE_DELAY_MS * 2 ** retryAttemptNumber, 30000);
@@ -167,8 +170,11 @@ export function useStreamingAPI(threadId: string) {
   const lastStreamErrorRef = useRef<Error | null>(null);
   const lastTokenTimeRef = useRef<number>(0);
   const staleIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastSuccessfulConnectionRef = useRef<number>(Date.now());
   const threadIdRef = useRef(threadId);
   threadIdRef.current = threadId;
+  const chatRef = useRef(chat);
+  chatRef.current = chat;
 
   if (!managerRef.current) {
     managerRef.current = new StreamingManager();
@@ -318,6 +324,43 @@ export function useStreamingAPI(threadId: string) {
           break;
         }
 
+        // Update reconnection state on retry
+        if (attempt > 0) {
+          dispatch(
+            updateStreamingState({
+              chatId: threadId,
+              state: {
+                isReconnecting: true,
+                reconnectAttempt: attempt,
+                streamDroppedMidResponse: isStreamingTokensRef.current,
+              },
+            }),
+          );
+
+          // Remove incomplete AI message if stream dropped mid-response
+          if (isStreamingTokensRef.current) {
+            dispatch(updateChat({ id: threadId, updates: { messages: clones } }));
+            isStreamingTokensRef.current = false;
+          }
+        }
+
+        // Refetch conversation history on reconnect if connection was lost for > 10s
+        if (attempt > 0 && Date.now() - lastSuccessfulConnectionRef.current > HISTORY_REFETCH_THRESHOLD_MS) {
+          try {
+            const history = await getThreadState(threadId);
+            if (history.length > 0) {
+              const pendingMsg = clones[clones.length - 1];
+              const serverHasPending =
+                pendingMsg?.type === 'human' &&
+                history.some((m) => m.type === 'human' && m.content === pendingMsg.content);
+              const merged = serverHasPending ? history : [...history, pendingMsg];
+              dispatch(updateChat({ id: threadId, updates: { messages: merged } }));
+            }
+          } catch (err) {
+            console.warn('[useStreamingAPI] Failed to refetch conversation history on reconnect', err);
+          }
+        }
+
         type StreamOutcome = 'success' | 'cancelled' | 'failed';
         const outcome = await new Promise<StreamOutcome>((resolve) => {
           let settled = false;
@@ -332,6 +375,7 @@ export function useStreamingAPI(threadId: string) {
           const callbacks: StreamCallback = {
             onToken(content) {
               lastTokenTimeRef.current = Date.now();
+              lastSuccessfulConnectionRef.current = Date.now();
               setIsStreamStale(false);
               if (streamClockRef.current.firstTokenTime == null) {
                 streamClockRef.current.firstTokenTime = Date.now();
@@ -428,6 +472,9 @@ export function useStreamingAPI(threadId: string) {
                       error: error.message,
                       isLoading: false,
                       isConnected: false,
+                      isReconnecting: false,
+                      reconnectAttempt: 0,
+                      streamDroppedMidResponse: false,
                     },
                   }),
                 );
@@ -471,6 +518,19 @@ export function useStreamingAPI(threadId: string) {
             },
             onDone() {
               dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              lastSuccessfulConnectionRef.current = Date.now();
+              dispatch(
+                updateStreamingState({
+                  chatId: threadId,
+                  state: {
+                    isLoading: false,
+                    isConnected: false,
+                    isReconnecting: false,
+                    reconnectAttempt: 0,
+                    streamDroppedMidResponse: false,
+                  },
+                }),
+              );
               finish('success');
             },
             onMcpStatus(evt) {
@@ -617,6 +677,9 @@ export function useStreamingAPI(threadId: string) {
           isLoading: false,
           isConnected: false,
           isThinking: false,
+          isReconnecting: false,
+          reconnectAttempt: 0,
+          streamDroppedMidResponse: false,
         },
       }),
     );

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -15,10 +15,11 @@ import {
 } from '../redux/slices/chats';
 import { selectDebugMode } from '../redux/slices/userSettings';
 import { addToast } from '../redux/slices/toasts';
-import { useStreamingAPI } from '../hooks/useStreamingAPI';
+import { useStreamingAPI, MAX_RETRIES } from '../hooks/useStreamingAPI';
 import { useRateLimitState } from '../hooks/useRateLimitState';
 import { ChatMessagesView } from '../components/ChatMessagesView';
 import { ChatErrorBoundary } from '../components/ChatErrorBoundary';
+import { ReconnectingBanner } from '../components/ReconnectingBanner';
 import { InterruptBanner } from '../components/InterruptBanner';
 import { TaskProgressStepper } from '../components/TaskProgressStepper';
 import { TasksSidebar } from '../components/TasksSidebar';
@@ -396,6 +397,7 @@ export function ChatPage({ threadId }: { threadId: string }) {
           {hasToolCalls && (
             <TaskProgressStepper messages={thread.messages} isLoading={thread.isLoading} />
           )}
+          <ReconnectingBanner streamingState={streamingState} maxRetries={MAX_RETRIES} />
           <ChatMessagesView
             key={threadId}
             messages={thread.messages}


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Restores SSE resilience state management that was accidentally dropped by PR #64 (MCP OAuth interrupt banner). PR #64 rewrote `useStreamingAPI.ts` and in doing so silently removed all reconnect state mutations added by PR #61 — meaning the `ReconnectingBanner` component was a dead component (its `isReconnecting` input was always `false`) and the `getThreadState` history refetch on reconnect was never triggered. The retry backoff loop itself still ran silently, but users had no visibility into it and mid-response drop recovery was broken.

## Changes

- **`useStreamingAPI.ts`** — restored `getThreadState` import; re-exported `MAX_RETRIES`; re-added `HISTORY_REFETCH_THRESHOLD_MS` constant, `lastSuccessfulConnectionRef` and `chatRef` refs; restored reconnect state dispatch block inside retry loop (`attempt > 0`); restored `getThreadState` history refetch on reconnect (>10s gap); restored `lastSuccessfulConnectionRef` update in `onToken`; restored `isReconnecting/reconnectAttempt/streamDroppedMidResponse` resets in `onError` (terminal), `onDone`, and `stop()`
- **`ChatPage.tsx`** — added `MAX_RETRIES` to `useStreamingAPI` import; added `ReconnectingBanner` import and rendered it between `TaskProgressStepper` and `ChatMessagesView`

## AI Disclosure

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Identified the regression by diffing PR #61 vs PR #64 changes, restored all missing reconnect state mutations and wiring
- **Human verification**: Reviewed diff against original PR #61 merge commit to confirm line-for-line accuracy; TypeScript check passed with zero errors

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

This is a pure regression fix — no new logic, only restoring what PR #61 (`fix/sse-resilience`) originally merged. The root cause was a non-conflicting overwrite: PR #64 edited overlapping sections of `useStreamingAPI.ts` without conflict markers, silently dropping the PR #61 additions. Recommend reviewing any future PRs that touch `useStreamingAPI.ts` against the full file diff to catch silent overwrites.