### PR TITLE
fix: human in loop approval banner regression

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import type { Message } from "@langchain/langgraph-sdk";
-import { AlertCircle, Check, CheckCircle, ChevronDown, ChevronRight, Copy, Download, Loader2, Pencil, RotateCcw, Settings, Bot, User } from "lucide-react";
+import { AlertCircle, Check, CheckCircle, ChevronDown, ChevronRight, Copy, Download, Loader2, Pencil, RotateCcw, Settings, Bot, User, ShieldCheck } from "lucide-react";
+import type { InterruptInfo } from "../types/deep-agent";
 import { InputForm } from "./InputForm";
 import { McpStatusPanel } from "./McpStatusPanel";
 import { useState, ReactNode, useMemo, useEffect, useRef, Fragment } from "react";
@@ -457,9 +458,51 @@ const AiMessageBubble: React.FC<AiMessageBubbleProps> = ({ message }) => {
   );
 };
 
-export function AIMessageRenderer({ message }: { message: Message }) {
+interface AIMessageRendererProps {
+  message: Message;
+  pendingInterrupt?: InterruptInfo | null;
+  onInterruptResume?: (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => void;
+  onAlwaysAllow?: (toolNames: string[]) => void;
+}
+
+export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume, onAlwaysAllow }: AIMessageRendererProps) {
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+  const [approvalSubmitted, setApprovalSubmitted] = useState(false);
   const messageKey = JSON.stringify(message);
+
+  useEffect(() => {
+    if (pendingInterrupt) {
+      setApprovalSubmitted(false);
+    }
+  }, [pendingInterrupt]);
+
+  const pendingToolNames = useMemo(
+    () => {
+      const v = pendingInterrupt?.value;
+      const requests = (typeof v === 'object' && v !== null) ? (v.action_requests ?? []) : [];
+      return new Set(requests.map((r) => r.name));
+    },
+    [pendingInterrupt],
+  );
+
+  useEffect(() => {
+    if (!pendingToolNames.size) return;
+    const allToolCalls = (message as any).tool_calls;
+    if (!Array.isArray(allToolCalls)) return;
+    const visibleCalls = allToolCalls.filter(
+      (tc: any) => !isSubAgentToolCall(tc) && tc.name !== 'write_todos',
+    );
+    setExpandedItems((prev) => {
+      const next = new Set(prev);
+      visibleCalls.forEach((tc: any, idx: number) => {
+        if (pendingToolNames.has(tc.name) || pendingToolNames.has('task')) {
+          next.add(`${message.id}-${idx}`);
+        }
+      });
+      return next;
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingToolNames, message.id]);
 
   const toggleExpand = (itemId: string) => {
     setExpandedItems(prev => {
@@ -495,6 +538,9 @@ export function AIMessageRenderer({ message }: { message: Message }) {
               toolCall={toolCall as any}
               messageId={message.id ?? ''}
               index={idx}
+              pendingInterrupt={pendingInterrupt}
+              onInterruptResume={onInterruptResume}
+              onAlwaysAllow={onAlwaysAllow}
             />
           ))}
 
@@ -504,59 +550,120 @@ export function AIMessageRenderer({ message }: { message: Message }) {
                 <Settings className="w-4 h-4 text-muted-foreground" />
               </div>
               <div className="flex-1 min-w-0 space-y-2">
-                {regularCalls.map((toolCall, idx) => (
-                  <div key={`${message.id}-${idx}`} className="bg-card border border-border rounded-xl overflow-hidden shadow-card">
-                    <button
-                      onClick={() => toggleExpand(`${message.id}-${idx}`)}
-                      className="w-full flex items-center justify-between p-3.5 hover:bg-muted/50 transition-colors"
+                {regularCalls.map((toolCall, idx) => {
+                  const itemId = `${message.id}-${idx}`;
+                  const isExpanded = expandedItems.has(itemId);
+                  const needsApproval = (pendingToolNames.has(toolCall.name) || pendingToolNames.has('task')) && !(toolCall as Record<string, unknown>).content;
+
+                  return (
+                    <div
+                      key={itemId}
+                      className={cn(
+                        "bg-card border rounded-xl overflow-hidden shadow-card transition-colors",
+                        needsApproval ? "border-yellow-500/60" : "border-border",
+                      )}
                     >
-                      <div className="flex items-center gap-2.5">
-                        <div className="text-left">
-                          <div className="text-sm font-medium text-foreground flex items-center gap-2">
-                            <code className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">{toolCall.name}</code>
-                            {(toolCall as Record<string, unknown>).content ? (
-                              <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />
-                            ) : (
-                              <Loader2 className="w-4 h-4 text-primary animate-spin" />
+                      <button
+                        onClick={() => toggleExpand(itemId)}
+                        className="w-full flex items-center justify-between p-3.5 hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex items-center gap-2.5">
+                          <div className="text-left">
+                            <div className="text-sm font-medium text-foreground flex items-center gap-2">
+                              <code className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded">{toolCall.name}</code>
+                              {(toolCall as Record<string, unknown>).content != null ? (
+                                <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400" />
+                              ) : (
+                                <Loader2 className="w-4 h-4 text-primary animate-spin" />
+                              )}
+                            </div>
+                            <div className="text-xs text-muted-foreground mt-0.5">Tool execution</div>
+                          </div>
+                        </div>
+                        {isExpanded ? (
+                          <ChevronDown className="w-4 h-4 text-muted-foreground" />
+                        ) : (
+                          <ChevronRight className="w-4 h-4 text-muted-foreground" />
+                        )}
+                      </button>
+
+                      {isExpanded && (
+                        <div className="border-t border-border">
+                          <div className="px-4 pb-3">
+                            <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">Arguments</div>
+                            <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
+                              {JSON.stringify(toolCall.args, null, 2)}
+                            </pre>
+                            {!needsApproval && (
+                              <>
+                                <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">
+                                  {(toolCall as Record<string, unknown>).content ? 'Result' : 'Running...'}
+                                </div>
+                                {(() => {
+                                  const raw = (toolCall as Record<string, unknown>).content;
+                                  if (raw == null) return <p className="text-xs text-muted-foreground italic">Waiting...</p>;
+                                  const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
+                                  const kind = detectArtifactKind(text);
+                                  if (kind !== 'text' && text.length > 100) {
+                                    return <ArtifactViewer content={text} title={`${toolCall.name} result`} />;
+                                  }
+                                  return (
+                                    <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
+                                      {text}
+                                    </pre>
+                                  );
+                                })()}
+                              </>
                             )}
                           </div>
-                          <div className="text-xs text-muted-foreground mt-0.5">Tool execution</div>
-                        </div>
-                      </div>
-                      {expandedItems.has(`${message.id}-${idx}`) ? (
-                        <ChevronDown className="w-4 h-4 text-muted-foreground" />
-                      ) : (
-                        <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                      )}
-                    </button>
 
-                    {expandedItems.has(`${message.id}-${idx}`) && (
-                      <div className="px-4 pb-4 border-t border-border">
-                        <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">Arguments</div>
-                        <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
-                          {JSON.stringify(toolCall.args, null, 2)}
-                        </pre>
-                        <div className="text-xs font-medium text-muted-foreground mb-2 mt-3 uppercase tracking-wider">
-                          {(toolCall as Record<string, unknown>).content ? 'Result' : 'Running...'}
+                          {needsApproval && !approvalSubmitted && onInterruptResume && (
+                            <div className="flex items-center gap-2 px-4 py-3 border-t border-yellow-500/30 bg-yellow-500/5 flex-wrap">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setApprovalSubmitted(true);
+                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
+                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'approve' as const })));
+                                }}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+                                style={{ backgroundColor: 'var(--chart-3)', color: 'var(--background)' }}
+                              >
+                                <Check className="w-3 h-3" />
+                                Approve
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setApprovalSubmitted(true);
+                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
+                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'reject' as const, message: 'User rejected this action.' })));
+                                }}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium hover:opacity-90 transition-colors"
+                                style={{ backgroundColor: 'var(--destructive)', color: 'var(--background)' }}
+                              >
+                                Reject
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setApprovalSubmitted(true);
+                                  const count = ((pendingInterrupt?.value as any)?.action_requests ?? []).length || 1;
+                                  onAlwaysAllow?.([toolCall.name]);
+                                  onInterruptResume(Array.from({ length: count }, () => ({ type: 'approve' as const })));
+                                }}
+                                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted text-foreground hover:bg-muted/70 transition-colors"
+                              >
+                                <ShieldCheck className="w-3 h-3" />
+                                Always allow
+                              </button>
+                            </div>
+                          )}
                         </div>
-                        {(() => {
-                          const raw = (toolCall as Record<string, unknown>).content;
-                          if (raw == null) return <p className="text-xs text-muted-foreground italic">Waiting...</p>;
-                          const text = typeof raw === 'string' ? raw : JSON.stringify(raw, null, 2);
-                          const kind = detectArtifactKind(text);
-                          if (kind !== 'text' && text.length > 100) {
-                            return <ArtifactViewer content={text} title={`${toolCall.name} result`} />;
-                          }
-                          return (
-                            <pre className="text-xs text-foreground bg-muted border border-border p-3 rounded-lg overflow-auto font-mono">
-                              {text}
-                            </pre>
-                          );
-                        })()}
-                      </div>
-                    )}
-                  </div>
-                ))}
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}
@@ -575,7 +682,7 @@ export function AIMessageRenderer({ message }: { message: Message }) {
 
     return null;
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messageKey, expandedItems]);
+  }, [messageKey, expandedItems, approvalSubmitted, pendingInterrupt, onInterruptResume, onAlwaysAllow]);
 
   return (
     <div className="space-y-2 w-full">
@@ -588,7 +695,9 @@ interface ChatMessagesViewProps {
   messages: Message[];
   streamEvents?: StreamEvent[];
   isLoading: boolean;
-  hasPendingInterrupt?: boolean;
+  pendingInterrupt?: InterruptInfo | null;
+  onInterruptResume?: (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => void;
+  onAlwaysAllow?: (toolNames: string[]) => void;
   interruptContent?: React.ReactNode;
   scrollAreaRef: React.RefObject<HTMLDivElement | null>;
   onSubmit: (inputValue: string) => void;
@@ -617,7 +726,9 @@ interface ChatMessagesViewProps {
 export function ChatMessagesView({
   messages,
   isLoading,
-  hasPendingInterrupt = false,
+  pendingInterrupt,
+  onInterruptResume,
+  onAlwaysAllow,
   interruptContent,
   scrollAreaRef,
   onSubmit,
@@ -651,7 +762,7 @@ export function ChatMessagesView({
   }, [messages]);
 
   const lastMessage = messages[messages.length - 1];
-  const rawNoResponse = !isLoading && !hasPendingInterrupt && messages.length > 0 && lastMessage?.type === 'human';
+  const rawNoResponse = !isLoading && !pendingInterrupt && !interruptContent && messages.length > 0 && lastMessage?.type === 'human';
   const [showNoResponse, setShowNoResponse] = useState(false);
 
   useEffect(() => {
@@ -745,7 +856,12 @@ export function ChatMessagesView({
                 />
               ) : (
                 <div className="w-full space-y-0">
-                  <AIMessageRenderer message={message} />
+                  <AIMessageRenderer
+                    message={message}
+                    pendingInterrupt={pendingInterrupt}
+                    onInterruptResume={onInterruptResume}
+                    onAlwaysAllow={onAlwaysAllow}
+                  />
                   {isLastAiInTurn && (
                     <div className="pl-11 flex items-center gap-0.5 mt-1">
                       <MessageCopyButton text={copyText} />

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -5,15 +5,14 @@ import {
   Button,
   TextInput,
 } from '@patternfly/react-core';
-import { Bot, CheckCircle, Link2, ShieldCheck, XCircle } from 'lucide-react';
+import { Bot, CheckCircle, Link2, XCircle } from 'lucide-react';
 import { buildAgentApiUrl } from '../lib/app-paths';
-import type { HITLInterruptValue, InterruptInfo } from '../types/deep-agent';
+import type { InterruptInfo } from '../types/deep-agent';
 
 interface InterruptBannerProps {
   readonly interrupt: InterruptInfo;
   readonly onResume: (response: string) => void;
   readonly onDismiss: () => void;
-  readonly onAlwaysAllow?: (toolNames: string[]) => void;
 }
 
 function isToolApproval(value: string): boolean {
@@ -75,7 +74,7 @@ async function verifyMcpConnected(mcpName: string): Promise<boolean> {
   return false;
 }
 
-export function InterruptBanner({ interrupt, onResume, onDismiss, onAlwaysAllow }: InterruptBannerProps) {
+export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBannerProps) {
   const [response, setResponse] = useState('');
   const [oauthReady, setOauthReady] = useState(false);
   const [connecting, setConnecting] = useState(false);
@@ -183,56 +182,6 @@ export function InterruptBanner({ interrupt, onResume, onDismiss, onAlwaysAllow 
             </div>
           </div>
         </div>
-      </div>
-    );
-  }
-
-  const isHITL = typeof interrupt.value === 'object' && 'action_requests' in interrupt.value;
-
-  if (isHITL) {
-    const hitlValue = interrupt.value as HITLInterruptValue;
-    const toolNames = hitlValue.action_requests.map((r) => r.name);
-    return (
-      <div className="mx-4 mb-3" role="alert">
-        <Alert
-          variant="warning"
-          title="Action Required"
-          isInline
-          actionClose={<AlertActionCloseButton onClose={onDismiss} />}
-        >
-          <p className="text-sm mb-3 whitespace-pre-wrap">{interruptValueAsString(interrupt.value)}</p>
-          <div className="flex items-center gap-2 flex-wrap">
-            <Button
-              variant="primary"
-              size="sm"
-              icon={<CheckCircle className="w-3.5 h-3.5" />}
-              onClick={() => onResume('approved')}
-            >
-              Approve
-            </Button>
-            <Button
-              variant="danger"
-              size="sm"
-              icon={<XCircle className="w-3.5 h-3.5" />}
-              onClick={() => onResume('rejected')}
-            >
-              Reject
-            </Button>
-            {onAlwaysAllow && (
-              <Button
-                variant="plain"
-                size="sm"
-                icon={<ShieldCheck className="w-3.5 h-3.5" />}
-                onClick={() => {
-                  onAlwaysAllow(toolNames);
-                  onResume('approved');
-                }}
-              >
-                Always allow
-              </Button>
-            )}
-          </div>
-        </Alert>
       </div>
     );
   }

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -5,14 +5,15 @@ import {
   Button,
   TextInput,
 } from '@patternfly/react-core';
-import { Bot, CheckCircle, Link2, XCircle } from 'lucide-react';
+import { Bot, CheckCircle, Link2, ShieldCheck, XCircle } from 'lucide-react';
 import { buildAgentApiUrl } from '../lib/app-paths';
-import type { InterruptInfo } from '../types/deep-agent';
+import type { HITLInterruptValue, InterruptInfo } from '../types/deep-agent';
 
 interface InterruptBannerProps {
   readonly interrupt: InterruptInfo;
   readonly onResume: (response: string) => void;
   readonly onDismiss: () => void;
+  readonly onAlwaysAllow?: (toolNames: string[]) => void;
 }
 
 function isToolApproval(value: string): boolean {
@@ -74,7 +75,7 @@ async function verifyMcpConnected(mcpName: string): Promise<boolean> {
   return false;
 }
 
-export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBannerProps) {
+export function InterruptBanner({ interrupt, onResume, onDismiss, onAlwaysAllow }: InterruptBannerProps) {
   const [response, setResponse] = useState('');
   const [oauthReady, setOauthReady] = useState(false);
   const [connecting, setConnecting] = useState(false);
@@ -182,6 +183,56 @@ export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBan
             </div>
           </div>
         </div>
+      </div>
+    );
+  }
+
+  const isHITL = typeof interrupt.value === 'object' && 'action_requests' in interrupt.value;
+
+  if (isHITL) {
+    const hitlValue = interrupt.value as HITLInterruptValue;
+    const toolNames = hitlValue.action_requests.map((r) => r.name);
+    return (
+      <div className="mx-4 mb-3" role="alert">
+        <Alert
+          variant="warning"
+          title="Action Required"
+          isInline
+          actionClose={<AlertActionCloseButton onClose={onDismiss} />}
+        >
+          <p className="text-sm mb-3 whitespace-pre-wrap">{interruptValueAsString(interrupt.value)}</p>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Button
+              variant="primary"
+              size="sm"
+              icon={<CheckCircle className="w-3.5 h-3.5" />}
+              onClick={() => onResume('approved')}
+            >
+              Approve
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              icon={<XCircle className="w-3.5 h-3.5" />}
+              onClick={() => onResume('rejected')}
+            >
+              Reject
+            </Button>
+            {onAlwaysAllow && (
+              <Button
+                variant="plain"
+                size="sm"
+                icon={<ShieldCheck className="w-3.5 h-3.5" />}
+                onClick={() => {
+                  onAlwaysAllow(toolNames);
+                  onResume('approved');
+                }}
+              >
+                Always allow
+              </Button>
+            )}
+          </div>
+        </Alert>
       </div>
     );
   }

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -23,6 +23,7 @@ import {
 import { chatStorage } from '@/services/chatStorage';
 import { buildAgentApiUrl } from '@/lib/app-paths';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
+import { selectAlwaysAllowedTools } from '@/redux/slices/userSettings';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
 import type { HITLInterruptValue, InterruptInfo } from '@/types/deep-agent';
 import { getThreadState } from '@/services/agent-rest';
@@ -141,6 +142,7 @@ export function useStreamingAPI(threadId: string) {
 
   const memories = useAppSelector(selectMemories);
   const activeRules = useAppSelector(selectActiveRules);
+  const alwaysAllowedTools = useAppSelector(selectAlwaysAllowedTools);
 
   const messages = useMemo(() => chat?.messages ?? EMPTY_MESSAGES, [chat?.messages]);
 
@@ -167,6 +169,9 @@ export function useStreamingAPI(threadId: string) {
   const isStreamingTokensRef = useRef<boolean>(false);
   const isActiveRef = useRef(true);
   const userCancelledRef = useRef(false);
+  const streamEndedWithInterruptRef = useRef(false);
+  const pendingInterruptRef = useRef(streamingState.pendingInterrupt);
+  pendingInterruptRef.current = streamingState.pendingInterrupt;
   const lastStreamErrorRef = useRef<Error | null>(null);
   const lastTokenTimeRef = useRef<number>(0);
   const staleIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -371,6 +376,7 @@ export function useStreamingAPI(threadId: string) {
           };
 
           lastStreamErrorRef.current = null;
+          streamEndedWithInterruptRef.current = false;
 
           const callbacks: StreamCallback = {
             onToken(content) {
@@ -442,6 +448,7 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onInterrupt(interrupt) {
+              streamEndedWithInterruptRef.current = true;
               dispatch(
                 updateStreamingState({
                   chatId: threadId,
@@ -517,7 +524,9 @@ export function useStreamingAPI(threadId: string) {
               }
             },
             onDone() {
-              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              if (!streamEndedWithInterruptRef.current) {
+                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              }
               lastSuccessfulConnectionRef.current = Date.now();
               dispatch(
                 updateStreamingState({
@@ -543,7 +552,9 @@ export function useStreamingAPI(threadId: string) {
 
           manager.stream(streamRequest, callbacks).then(() => {
             if (!settled) {
-              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              if (!streamEndedWithInterruptRef.current) {
+                dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+              }
               finish('success');
             }
           });
@@ -568,6 +579,136 @@ export function useStreamingAPI(threadId: string) {
       }
     },
     [dispatch, threadId, memories, activeRules, handleStreamActivityStatus],
+  );
+
+  /**
+   * Check an incoming interrupt value against the always-allowed list.
+   * Returns true if ALL action requests are auto-approved so the caller
+   * can skip showing the banner entirely.
+   */
+  const checkAndAutoApprove = useCallback(
+    (interruptValue: HITLInterruptValue): { allAutoApproved: boolean; decisions: Array<{ type: 'approve' | 'reject' }> } => {
+      const allowed = new Set(alwaysAllowedTools);
+      const decisions = interruptValue.action_requests.map((req) => {
+        const subagentType = typeof req.args?.subagent_type === 'string' ? req.args.subagent_type : null;
+        const isAllowed = allowed.has(req.name) || (subagentType !== null && allowed.has(subagentType));
+        return { type: (isAllowed ? 'approve' : null) as 'approve' | null };
+      });
+      const allAutoApproved = decisions.every((d) => d.type === 'approve');
+      return {
+        allAutoApproved,
+        decisions: decisions.map((d) => ({ type: d.type ?? 'approve' })),
+      };
+    },
+    [alwaysAllowedTools],
+  );
+
+  /**
+   * Resume a paused LangGraph run with an array of HITL decisions.
+   * Sends resume=true + decisions to the BFF which forwards as
+   * Command(resume={"decisions": [...]}) to Aegra.
+   */
+  const resumeWithDecisions = useCallback(
+    async (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => {
+      const manager = managerRef.current;
+      if (!manager || !threadId) return;
+
+      const savedInterrupt = pendingInterruptRef.current;
+      dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: null } }));
+
+      const token = typeof window.USER_DATA.accessToken === 'string' ? window.USER_DATA.accessToken : undefined;
+      const userId =
+        typeof window.USER_DATA.preferred_username === 'string'
+          ? window.USER_DATA.preferred_username
+          : '';
+      const apiUrl = typeof window.APP_DATA?.apiUrl === 'string' ? window.APP_DATA.apiUrl : '';
+
+      dispatch(
+        updateStreamingState({
+          chatId: threadId,
+          state: { currentRunId: `run-${Date.now()}`, error: null, taskSteps: [] },
+        }),
+      );
+
+      const resumeRequest = {
+        message: '',
+        threadId,
+        userId,
+        apiUrl,
+        token,
+        memories: memories.map((m) => m.content),
+        rules: activeRules.map((r) => r.content),
+        resume: true,
+        resumeDecisions: decisions,
+      };
+
+      let resumeStreamHadInterrupt = false;
+
+      const callbacks: StreamCallback = {
+        onToken(content) {
+          lastTokenTimeRef.current = Date.now();
+          if (!isStreamingTokensRef.current) {
+            const message: AIMessage = {
+              type: 'ai',
+              content,
+              tool_calls: [],
+              id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            };
+            dispatch(appendMessageToChat({ chatId: threadId, message }));
+            isStreamingTokensRef.current = true;
+            return;
+          }
+          dispatch(updateLastMessageInChat({ chatId: threadId, content }));
+        },
+        onMessage(m) {
+          isStreamingTokensRef.current = false;
+          if (m.type === 'human') return;
+          if (m.type === 'ai' && Array.isArray(m.tool_calls) && m.tool_calls.length > 0) {
+            dispatch(appendMessageToChat({ chatId: threadId, message: m }));
+            return;
+          }
+          if (m.type === 'tool') {
+            dispatch(mergeToolResult({ chatId: threadId, toolCallId: m.tool_call_id, content: m.content }));
+            dispatch(updateStreamingState({ chatId: threadId, state: { activeSubAgent: null } }));
+          }
+        },
+        onInterrupt(interrupt) {
+          resumeStreamHadInterrupt = true;
+          dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: enrichInterrupt(interrupt) } }));
+        },
+        onError(error) {
+          dispatch(
+            updateStreamingState({
+              chatId: threadId,
+              state: {
+                error: error.message,
+                isLoading: false,
+                isConnected: false,
+                pendingInterrupt: savedInterrupt,
+              },
+            }),
+          );
+        },
+        onStatusChange(status) {
+          const partial = nextStreamingPartialForStatus(status);
+          if (partial) dispatch(updateStreamingState({ chatId: threadId, state: partial }));
+        },
+        onDone() {
+          if (!resumeStreamHadInterrupt) {
+            dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+          }
+        },
+        onMcpStatus(evt) {
+          setMcpEvents((prev) => [...prev, evt]);
+        },
+        onMetadata(data) {
+          setTraceId(data.trace_id);
+        },
+      };
+
+      await manager.stream(resumeRequest, callbacks);
+    },
+    [dispatch, threadId, memories, activeRules],
   );
 
   const resumeInterrupt = useCallback(
@@ -599,6 +740,8 @@ export function useStreamingAPI(threadId: string) {
         memories: memories.map((m) => m.content),
         rules: activeRules.map((r) => r.content),
       };
+
+      let resumeStreamHadInterrupt = false;
 
       await new Promise<void>((resolve) => {
         const callbacks: StreamCallback = {
@@ -635,6 +778,7 @@ export function useStreamingAPI(threadId: string) {
             dispatch(appendMessageToChat({ chatId: threadId, message: m }));
           },
           onInterrupt(interrupt) {
+            resumeStreamHadInterrupt = true;
             dispatch(
               updateStreamingState({
                 chatId: threadId,
@@ -657,7 +801,9 @@ export function useStreamingAPI(threadId: string) {
             }
           },
           onDone() {
-            dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+            if (!resumeStreamHadInterrupt) {
+              dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+            }
             resolve();
           },
         };
@@ -692,6 +838,8 @@ export function useStreamingAPI(threadId: string) {
     pendingInterrupt: streamingState.pendingInterrupt,
     taskSteps: streamingState.taskSteps,
     submit,
+    resumeWithDecisions,
+    checkAndAutoApprove,
     resumeInterrupt,
     stop,
     setMessages,

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -301,25 +301,26 @@ export function ChatPage({ threadId }: { threadId: string }) {
   }, [thread, threadId, currentChat, dispatch]);
 
   const handleInterruptResume = useCallback(
+    async (decisions: Array<{ type: 'approve' | 'reject'; message?: string }>) => {
+      if (!threadId || !currentChat) return;
+      try {
+        await thread.resumeWithDecisions(decisions);
+        setTimeout(() => {
+          hasFinalizeEventOccurredRef.current = true;
+        }, 100);
+      } catch (err) {
+        console.error('Failed to resume:', err);
+        dispatch(addToast({ title: 'Failed to resume', variant: 'danger' }));
+      }
+    },
+    [thread, threadId, currentChat, dispatch],
+  );
+
+  const handleMCPOAuthResume = useCallback(
     async (response: string) => {
       if (!threadId || !currentChat) return;
       try {
-        const interrupt = thread.pendingInterrupt;
-        if (interrupt && typeof interrupt.value === 'object' && 'action_requests' in interrupt.value) {
-          // HITL tool interrupt — convert string response to structured decisions
-          const count = interrupt.value.action_requests?.length ?? 1;
-          const isRejected = response === 'rejected' || response === 'reject';
-          const decisions = Array.from(
-            { length: count },
-            (): { type: 'approve' | 'reject'; message?: string } => ({
-              type: isRejected ? 'reject' : 'approve',
-              ...(isRejected ? { message: 'User rejected this action.' } : {}),
-            }),
-          );
-          await thread.resumeWithDecisions(decisions);
-        } else {
-          await thread.resumeInterrupt(response);
-        }
+        await thread.resumeInterrupt(response);
         setTimeout(() => {
           hasFinalizeEventOccurredRef.current = true;
         }, 100);
@@ -451,15 +452,28 @@ export function ChatPage({ threadId }: { threadId: string }) {
             messages={thread.messages}
             streamEvents={thread.streamEvents}
             isLoading={thread.isLoading}
-            hasPendingInterrupt={!!thread.pendingInterrupt}
-            interruptContent={thread.pendingInterrupt ? (
-              <InterruptBanner
-                interrupt={thread.pendingInterrupt}
-                onResume={handleInterruptResume}
-                onDismiss={handleInterruptDismiss}
-                onAlwaysAllow={handleAlwaysAllow}
-              />
-            ) : undefined}
+            pendingInterrupt={
+              thread.pendingInterrupt &&
+              typeof thread.pendingInterrupt.value === 'object' &&
+              'action_requests' in thread.pendingInterrupt.value
+                ? thread.pendingInterrupt
+                : null
+            }
+            onInterruptResume={handleInterruptResume}
+            onAlwaysAllow={handleAlwaysAllow}
+
+            interruptContent={
+              thread.pendingInterrupt &&
+              !(typeof thread.pendingInterrupt.value === 'object' && 'action_requests' in thread.pendingInterrupt.value)
+                ? (
+                  <InterruptBanner
+                    interrupt={thread.pendingInterrupt}
+                    onResume={handleMCPOAuthResume}
+                    onDismiss={handleInterruptDismiss}
+                  />
+                )
+                : undefined
+            }
             onRetry={handleStreamRetry}
             scrollAreaRef={scrollAreaRef}
             onSubmit={handleSubmit}

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -13,7 +13,7 @@ import {
   updateChat,
   updateStreamingState,
 } from '../redux/slices/chats';
-import { selectDebugMode } from '../redux/slices/userSettings';
+import { selectDebugMode, addAlwaysAllowedTool, selectAutoApproveAllTools } from '../redux/slices/userSettings';
 import { addToast } from '../redux/slices/toasts';
 import { useStreamingAPI, MAX_RETRIES } from '../hooks/useStreamingAPI';
 import { useRateLimitState } from '../hooks/useRateLimitState';
@@ -304,7 +304,25 @@ export function ChatPage({ threadId }: { threadId: string }) {
     async (response: string) => {
       if (!threadId || !currentChat) return;
       try {
-        await thread.resumeInterrupt(response);
+        const interrupt = thread.pendingInterrupt;
+        if (interrupt && typeof interrupt.value === 'object' && 'action_requests' in interrupt.value) {
+          // HITL tool interrupt — convert string response to structured decisions
+          const count = interrupt.value.action_requests?.length ?? 1;
+          const isRejected = response === 'rejected' || response === 'reject';
+          const decisions = Array.from(
+            { length: count },
+            (): { type: 'approve' | 'reject'; message?: string } => ({
+              type: isRejected ? 'reject' : 'approve',
+              ...(isRejected ? { message: 'User rejected this action.' } : {}),
+            }),
+          );
+          await thread.resumeWithDecisions(decisions);
+        } else {
+          await thread.resumeInterrupt(response);
+        }
+        setTimeout(() => {
+          hasFinalizeEventOccurredRef.current = true;
+        }, 100);
       } catch (err) {
         console.error('Failed to resume:', err);
         dispatch(addToast({ title: 'Failed to resume', variant: 'danger' }));
@@ -321,6 +339,36 @@ export function ChatPage({ threadId }: { threadId: string }) {
       }),
     );
   }, [dispatch, threadId]);
+
+  const handleAlwaysAllow = useCallback(
+    (toolNames: string[]) => {
+      for (const name of toolNames) {
+        dispatch(addAlwaysAllowedTool(name));
+      }
+    },
+    [dispatch],
+  );
+
+  const autoApproveAllTools = useAppSelector(selectAutoApproveAllTools);
+  useEffect(() => {
+    const interrupt = thread.pendingInterrupt;
+    if (typeof interrupt?.value !== 'object' || !interrupt.value.action_requests?.length) return;
+
+    if (autoApproveAllTools) {
+      const allApproved = interrupt.value.action_requests.map(() => ({ type: 'approve' as const }));
+      thread.resumeWithDecisions(allApproved).catch((err) => {
+        console.error('Auto-approve-all resume failed:', err);
+      });
+      return;
+    }
+
+    const { allAutoApproved, decisions } = thread.checkAndAutoApprove(interrupt.value);
+    if (!allAutoApproved) return;
+    thread.resumeWithDecisions(decisions).catch((err) => {
+      console.error('Auto-approve resume failed:', err);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [thread.pendingInterrupt, autoApproveAllTools]);
 
   const handleNewChat = useCallback(() => {
     navigate('/');

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -457,6 +457,7 @@ export function ChatPage({ threadId }: { threadId: string }) {
                 interrupt={thread.pendingInterrupt}
                 onResume={handleInterruptResume}
                 onDismiss={handleInterruptDismiss}
+                onAlwaysAllow={handleAlwaysAllow}
               />
             ) : undefined}
             onRetry={handleStreamRetry}


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Restores the HITL (human-in-the-loop) subagent tool approval flow that was accidentally removed by PR #64 (MCP OAuth interrupt banner). PR #64 rewrote `useStreamingAPI.ts` based on a stale checkout, silently dropping `resumeWithDecisions`, `checkAndAutoApprove`, `alwaysAllowedTools`, and `pendingInterruptRef`. This caused subagent tool calls to never be auto-approved, and manual approvals to send a plain string to the BFF instead of the structured `resumeDecisions` array the backend requires. Also restores the always-allowed-tools auto-approval `useEffect` and `handleAlwaysAllow` in `ChatPage.tsx`. PR #64's MCP OAuth functionality (`enrichInterrupt`, `InterruptBanner`) is fully preserved.

## Changes

- **`useStreamingAPI.ts`** — restored `selectAlwaysAllowedTools` import, `alwaysAllowedTools` selector, `pendingInterruptRef`, `checkAndAutoApprove` callback, and `resumeWithDecisions` function (sends `resumeDecisions` array to BFF); exposed both from hook return
- **`useStreamingAPI.ts`** — restored `streamEndedWithInterruptRef` guard on `resolveAllPendingToolCalls` at all 3 call sites (2 in initial stream, 1 in resume) to prevent premature tool-call state clearing on HITL interrupt
- **`ChatPage.tsx`** — restored `addAlwaysAllowedTool` + `selectAutoApproveAllTools` imports; restored `handleAlwaysAllow` callback and `autoApproveAllTools` + `checkAndAutoApprove` auto-approval `useEffect`
- **`ChatPage.tsx`** — updated `handleInterruptResume` to smart-route: HITL tool interrupts (with `action_requests`) convert the `InterruptBanner` string response to structured decisions and call `resumeWithDecisions`; MCP OAuth interrupts fall through to existing `resumeInterrupt`

## AI Disclosure

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Identified regression by diffing pre/post PR #64 git history; restored all missing functions and wiring; authored the string-to-decisions bridge in `handleInterruptResume` to adapt old `resumeWithDecisions` API to PR #64's `InterruptBanner` UI
- **Human verification**: Reviewed all restored code against pre-PR#64 git history, confirmed TypeScript compiles clean, verified PR #64 MCP OAuth path is unaffected

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

<!-- What to focus on. -->

The `handleInterruptResume` bridge logic in `ChatPage.tsx` is the only net-new code (not a direct restore). Focus on the type-narrowing check (`typeof interrupt.value === 'object' && 'action_requests' in interrupt.value`) that routes HITL vs MCP OAuth, and verify the decisions array construction matches what the BFF expects. Everything else is a line-for-line restore from the pre-PR#64 codebase.