### PR TITLE
feat: add e2e test suite

### DIFF
--- a/e2e/config/branding.spec.ts
+++ b/e2e/config/branding.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig, mountMinimalConfig, mountFullConfig } from '../helpers/config-mount';
+import { mockAgentStream } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+
+/**
+ * Branding config tests.
+ *
+ * Two config scenarios are exercised:
+ *   - Minimal config: only required fields (title, default colours, no logo).
+ *   - Full config: all optional fields populated (logo_url, favicon_url, custom colours).
+ *
+ * Tests assert that the Fastify server's /api/config/branding response is
+ * correctly consumed by the React app to update document title, logo element,
+ * and CSS custom properties.
+ */
+test.describe('Config: branding', () => {
+  // ── Minimal config scenario ───────────────────────────────────────────────
+
+  test('minimal config: document title reflects branding title', async ({ page }) => {
+    await mountMinimalConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    expect(await home.getDocumentTitle()).toBe('Minimal Agent');
+  });
+
+  test('minimal config: no logo image is rendered when logo_url is empty', async ({ page }) => {
+    await mountMinimalConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    // logo_url is '' so no <img> with a branding src should appear in the header
+    const logoImg = page.locator('img[alt="Logo"], img[alt="Minimal Agent"]');
+    await expect(logoImg).toHaveCount(0);
+  });
+
+  // ── Full config scenario ──────────────────────────────────────────────────
+
+  test('full config: document title reflects full branding title', async ({ page }) => {
+    await mountFullConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    expect(await home.getDocumentTitle()).toBe('Full Config Agent');
+  });
+
+  test('full config: logo image element is visible with correct src', async ({ page }) => {
+    await mountFullConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    // AppLayout renders <img src={branding.logo_url} alt={branding.title || 'Logo'} />
+    const logo = page.locator('img[alt="Full Config Agent"], img[alt="Logo"]').first();
+    await expect(logo).toBeVisible();
+    const src = await logo.getAttribute('src');
+    expect(src).toContain('redhat-logo');
+  });
+
+  test('full config: CSS custom property --primary is applied from branding colours', async ({
+    page,
+  }) => {
+    const customPrimary = '#abcdef';
+    // Apply the custom colour to both themes so the assertion holds regardless
+    // of whether the app initialises in light or dark mode.
+    await mountConfig(
+      page,
+      { title: 'Color Test', colors: { light: { primary: customPrimary }, dark: { primary: customPrimary } } },
+    );
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    // Wait for App.tsx's branding useEffect to set the CSS variable
+    await page.waitForFunction(() => {
+      const val = document.documentElement.style.getPropertyValue('--primary');
+      return val !== '';
+    });
+
+    const primaryVar = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue('--primary'),
+    );
+    expect(primaryVar.toLowerCase().replace(/\s+/g, '')).toBe(customPrimary);
+  });
+});

--- a/e2e/config/feature-flags.spec.ts
+++ b/e2e/config/feature-flags.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+
+/**
+ * Feature-flag config tests.
+ *
+ * The /api/config/features endpoint drives the DebugToggle initial state.
+ * When debug_mode_default=false the toggle shows "Enable debug mode";
+ * when debug_mode_default=true the toggle shows "Disable debug mode"
+ * (because the flag pre-sets debugMode in the Redux userSettings slice).
+ *
+ * The DebugToggle is rendered in the AppLayout header and is therefore
+ * visible on every page once the app mounts.
+ */
+test.describe('Config: feature flags', () => {
+  test('debug_mode_default=false: debug toggle shows "Enable debug mode" aria-label', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Debug Off Test' }, { debug_mode_default: false });
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    await expect(
+      page.getByRole('button', { name: /enable debug mode/i }),
+    ).toBeVisible();
+  });
+
+  test('debug_mode_default=true: debug toggle shows "Disable debug mode" aria-label', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Debug On Test' }, { debug_mode_default: true });
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    await expect(
+      page.getByRole('button', { name: /disable debug mode/i }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/errors/error-states.spec.ts
+++ b/e2e/errors/error-states.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream, mockMalformedStream, mockStreamError } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Error-path tests covering:
+ *   1. Agent unreachable   – /api/health/agent returns non-200; sidebar shows "Agent: offline".
+ *   2. Malformed stream    – SSE body contains invalid JSON; UI must not crash.
+ *   3. Auth failure        – streaming endpoint returns 401; StreamingManager marks the stream
+ *                            as failed (non-recoverable 4xx) and the sr-only aria-live region
+ *                            announces "Stream error".
+ */
+test.describe('Error states', () => {
+  // ── Agent unreachable ─────────────────────────────────────────────────────
+
+  test('agent unreachable: sidebar shows "Agent: offline" indicator', async ({ page }) => {
+    // Mount base config with agentHealth='unhealthy' so the health endpoint
+    // returns 503 / { status: 'unhealthy' } from the first poll onwards.
+    await mountConfig(page, { title: 'Offline Agent Test' }, {}, 'unhealthy');
+    await mockAgentStream(page, 'Hello');
+
+    const home = new HomePage(page);
+    await home.goto();
+
+    // useAgentHealth polls immediately on mount; the sidebar indicator updates
+    // as soon as the first health check completes.
+    await expect(page.getByText('Agent: offline')).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── Malformed stream ──────────────────────────────────────────────────────
+
+  test('malformed stream: UI does not crash when receiving invalid SSE data', async ({ page }) => {
+    await mountConfig(page);
+    await mockMalformedStream(page);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Test malformed stream handling');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // The mock SSE body ends with `data: [DONE]\n\n` so the StreamingManager calls
+    // onDone(), which triggers the "Response complete" / "Stream error" announcement.
+    // Wait for that live-region update rather than using an arbitrary sleep.
+    await page.waitForFunction(
+      () => {
+        const liveRegion = document.querySelector('.sr-only[aria-live="polite"]');
+        const text = liveRegion?.textContent ?? '';
+        return text.includes('Response complete') || text.includes('Stream error');
+      },
+      { timeout: 15_000 },
+    );
+
+    // The app must still be interactive — no top-level error boundary message
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── Auth failure ──────────────────────────────────────────────────────────
+
+  test('auth failure on stream: aria-live region announces "Stream error"', async ({ page }) => {
+    await mountConfig(page);
+    // 401 from the streaming endpoint is a non-recoverable 4xx; the
+    // StreamingManager throws and the ChatPage announces "Stream error"
+    // through its sr-only aria-live polite region.
+    await mockStreamError(page, 401);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('This request will be rejected with 401');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // Wait for the live region to announce the failure
+    await page.waitForFunction(
+      () => {
+        const liveRegion = document.querySelector('.sr-only[aria-live="polite"]');
+        return liveRegion?.textContent?.includes('Stream error');
+      },
+      { timeout: 15_000 },
+    );
+  });
+});

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -1,16 +1,56 @@
 import type { Page } from '@playwright/test';
 
+export interface BrandingColors {
+  primary: string;
+  accent: string;
+  background: string;
+  foreground: string;
+}
+
 export interface BrandingOverride {
   title?: string;
   logo_url?: string;
+  favicon_url?: string;
+  colors?: {
+    light?: Partial<BrandingColors>;
+    dark?: Partial<BrandingColors>;
+  };
 }
 
+export interface FeaturesOverride {
+  debug_mode_default?: boolean;
+  auth_enabled?: boolean;
+}
+
+const DEFAULT_LIGHT: BrandingColors = {
+  primary: '#0066cc',
+  accent: '#a60000',
+  background: '#ffffff',
+  foreground: '#1a1a1a',
+};
+
+const DEFAULT_DARK: BrandingColors = {
+  primary: '#4dabf7',
+  accent: '#f56e6e',
+  background: '#0a1628',
+  foreground: '#f0f4f8',
+};
+
 /**
- * Mock the config and agent-proxy endpoints so tests don't depend on
- * a real agent backend.  Config endpoints could be served by the real
- * Fastify process but overriding them keeps tests hermetic.
+ * Mock config and agent-proxy endpoints so tests do not depend on a real
+ * agent backend. Config endpoints could be served by the real Fastify process
+ * but overriding them keeps tests hermetic.
+ *
+ * @param branding  Branding values to use (merged with defaults).
+ * @param features  Feature flags to use (merged with defaults).
+ * @param agentHealth  Agent health status — one of 'healthy', 'unhealthy', or 'unknown'.
  */
-export async function mountConfig(page: Page, branding: BrandingOverride = {}): Promise<void> {
+export async function mountConfig(
+  page: Page,
+  branding: BrandingOverride = {},
+  features: FeaturesOverride = {},
+  agentHealth: 'healthy' | 'unhealthy' | 'unknown' = 'healthy',
+): Promise<void> {
   await page.route('**/api/config/branding', (route) =>
     route.fulfill({
       status: 200,
@@ -18,9 +58,10 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
       body: JSON.stringify({
         logo_url: branding.logo_url ?? '',
         title: branding.title ?? 'Test Agent',
+        ...(branding.favicon_url ? { favicon_url: branding.favicon_url } : {}),
         colors: {
-          light: { primary: '#0066cc', accent: '#a60000', background: '#ffffff', foreground: '#1a1a1a' },
-          dark: { primary: '#4dabf7', accent: '#f56e6e', background: '#0a1628', foreground: '#f0f4f8' },
+          light: { ...DEFAULT_LIGHT, ...branding.colors?.light },
+          dark: { ...DEFAULT_DARK, ...branding.colors?.dark },
         },
       }),
     }),
@@ -30,16 +71,17 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ debug_mode_default: false, auth_enabled: false }),
+      body: JSON.stringify({
+        debug_mode_default: features.debug_mode_default ?? false,
+        auth_enabled: features.auth_enabled ?? false,
+      }),
     }),
   );
 
-  // Feedback endpoint called for previously-hydrated chats
   await page.route('**/api/proxy/agent/threads/*/feedback**', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
   );
 
-  // Announcement banner (optional endpoint — return disabled)
   await page.route('**/api/announcement', (route) =>
     route.fulfill({
       status: 200,
@@ -48,21 +90,42 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
     }),
   );
 
-  // Agent health probe — avoids ECONNREFUSED timeout on every page mount
+  const healthHttpStatus = agentHealth === 'healthy' ? 200 : 503;
   await page.route('**/api/health/agent', (route) =>
     route.fulfill({
-      status: 200,
+      status: healthHttpStatus,
       contentType: 'application/json',
-      body: JSON.stringify({ status: 'healthy' }),
+      body: JSON.stringify({ status: agentHealth }),
     }),
   );
 
-  // AppLayout calls POST /threads/search on every mount to reconcile chat history.
   await page.route('**/api/proxy/agent/threads/search', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: '[]',
     }),
+  );
+}
+
+/** Minimal config: only required fields populated, no logo, default colors. */
+export async function mountMinimalConfig(page: Page): Promise<void> {
+  return mountConfig(page, { title: 'Minimal Agent' });
+}
+
+/** Full config: all optional fields populated, custom primary colour. */
+export async function mountFullConfig(page: Page): Promise<void> {
+  return mountConfig(
+    page,
+    {
+      title: 'Full Config Agent',
+      logo_url: '/dist/frontend/redhat-logo.svg',
+      favicon_url: '/dist/frontend/redhat-logo.svg',
+      colors: {
+        light: { primary: '#cc0000', accent: '#006600', background: '#f5f5f5', foreground: '#111111' },
+        dark: { primary: '#ff6666', accent: '#66cc66', background: '#1a1a2e', foreground: '#e0e0e0' },
+      },
+    },
+    { debug_mode_default: false, auth_enabled: false },
   );
 }

--- a/e2e/helpers/sse-mock.ts
+++ b/e2e/helpers/sse-mock.ts
@@ -37,3 +37,40 @@ export async function mockThreadState(page: Page): Promise<void> {
     }),
   );
 }
+
+/**
+ * Intercept with a stream containing syntactically invalid SSE token data.
+ * The SSEProcessor should skip unrecognised chunks without crashing the UI.
+ */
+export async function mockMalformedStream(page: Page): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) => {
+    // Mix valid and invalid JSON; the SSEProcessor must tolerate both gracefully.
+    const body =
+      'data: {this is not valid json}\n\n' +
+      tokenChunk('partial ok', 0) +
+      'data: !!INVALID!!\n\n' +
+      'data: [DONE]\n\n';
+    return route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body,
+    });
+  });
+}
+
+/**
+ * Intercept the streaming endpoint and return the given HTTP error status.
+ * Useful for testing auth-failure (401) and server-error (500+) paths.
+ */
+export async function mockStreamError(page: Page, status: number): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) =>
+    route.fulfill({
+      status,
+      body: `HTTP ${status}`,
+    }),
+  );
+}


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Builds a minimal-but-comprehensive end-to-end Playwright test suite for `template-ui` that exercises the full config-driven lifecycle. Prior to this MR the suite contained only 3 smoke tests; this brings the total to 13 (10 new) covering branding, feature flags, SSE streaming, and error paths — runnable with a single `npm run test:e2e` command.

## Changes

- `e2e/helpers/config-mount.ts` — extended `mountConfig()` to accept optional `FeaturesOverride` and `agentHealth` parameters; added `mountMinimalConfig()` and `mountFullConfig()` convenience helpers; narrowed `agentHealth` param type to `'healthy' | 'unhealthy' | 'unknown'`
- `e2e/helpers/sse-mock.ts` — added `mockMalformedStream()` (invalid SSE JSON) and `mockStreamError(status)` (arbitrary HTTP error code) helpers
- `e2e/config/branding.spec.ts` — 5 new tests: minimal-config document title, no-logo check, full-config title, logo visibility, CSS `--primary` custom property applied from branding colours
- `e2e/config/feature-flags.spec.ts` — 2 new tests: `debug_mode_default` flag drives DebugToggle aria-label (off/on)
- `e2e/errors/error-states.spec.ts` — 3 new tests: agent offline sidebar indicator (health 503), malformed stream no-crash, 401 from stream announces "Stream error" via aria-live region

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Implementation of all new test files and helper extensions
- **Human verification**: All 13 tests run locally against the built app (`npm run build && npm run test:e2e`); code-reviewer subagent review applied (replaced hardcoded sleep with condition-based wait, narrowed agentHealth type)

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

None — test-only changes; no production code, no new dependencies, no env vars.

## Reviewer Notes

<!-- What to focus on. -->

- The `agentHealth` route registration order in `mountConfig` matters: Playwright evaluates routes in registration order, so calling `mountConfig(..., 'unhealthy')` will intercept `/api/health/agent` before any additional `page.route()` call on the same URL — confirm this matches your expected precedence if you add more health-route tests.
- `mockMalformedStream` intentionally includes a mix of invalid and valid SSE frames to verify the `SSEProcessor` error-tolerance path; the `[DONE]` frame at the end means the `waitForFunction` on the live region completes quickly rather than timing out.
- The CSS `--primary` assertion sets the same custom colour on both light and dark themes so the test result is theme-mode agnostic.