### PR TITLE
feat: add chaos/resilience E2E test suite

### DIFF
--- a/e2e/chaos/resilience.spec.ts
+++ b/e2e/chaos/resilience.spec.ts
@@ -1,0 +1,399 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream, mockStreamError, tokenChunk } from '../helpers/sse-mock';
+import { waitForAnnouncement } from '../helpers/wait';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Chaos / resilience E2E tests — 9 distinct scenarios.
+ *
+ * All failure conditions are simulated via Playwright route interception;
+ * no real backend is required. Each test follows the same pattern:
+ *   1. Set up failure condition via page.route().
+ *   2. Trigger a chat interaction from the home page.
+ *   3. Assert the error UI is visible (never blank / frozen).
+ *   4. Assert the user has a recovery path (retry button or interactive input).
+ *
+ * Coverage relative to `e2e/errors/error-states.spec.ts` (which covers agent
+ * offline at startup, mixed-valid malformed stream, and 401 auth failure):
+ *   This file tests truncated SSE, 503 on stream (recoverable 5xx, retried),
+ *   500 mid-conversation, config endpoint failure, concurrent 502 flap, empty
+ *   SSE body, all-invalid JSON (no valid tokens), TCP reset retry, and empty
+ *   agent response — all genuinely distinct failure paths.
+ */
+
+test.describe('Chaos: resilience', () => {
+  // ── 1. SSE drops mid-response ──────────────────────────────────────────────
+  //
+  // Two token chunks are delivered then the connection closes without [DONE].
+  // Expected: UI shows whatever partial content arrived and remains interactive.
+  test('SSE drops mid-response: partial content delivered, UI stays interactive', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Chaos Test' });
+
+    // Two valid token chunks, no [DONE] — stream terminates abruptly.
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      const body = tokenChunk('Hello', 0) + tokenChunk(' world', 1);
+      return route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Say hello');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // The StreamingManager processes the truncated stream and resolves the turn.
+    await waitForAnnouncement(page, ['Response complete', 'Stream error']);
+
+    // UI must remain interactive — no blank screen, no crash boundary.
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 2. Agent stream returns 503 (recoverable 5xx) ─────────────────────────
+  //
+  // The stream endpoint returns HTTP 503. Unlike the 401 in error-states.spec.ts
+  // (non-recoverable 4xx), 503 is recoverable — the StreamingManager retries
+  // up to MAX_RETRIES times with exponential backoff before giving up.
+  // Expected: "Stream error" is eventually announced; input is still accessible.
+  //
+  // Distinct from `error-states.spec.ts` test 1 (health-check offline, no
+  // message sent) and test 3 (401 auth failure, non-recoverable single attempt).
+  test('agent stream returns 503: retried then error announced, input stays accessible', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: '503 Recoverable Test' });
+    // Every stream request returns 503 — all retry attempts will fail.
+    await mockStreamError(page, 503);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Hello, are you there?');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // Allow extra time for the full retry cycle (MAX_RETRIES=3, exponential backoff).
+    await waitForAnnouncement(page, ['Stream error'], 30_000);
+
+    // Input must still be accessible after the retries are exhausted.
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 3. HTTP 500 mid-conversation ──────────────────────────────────────────
+  //
+  // First chat turn succeeds; the second turn returns HTTP 500.
+  // Expected: "Stream error" is announced, input remains accessible for retry.
+  test('500 mid-conversation: first turn succeeds, second turn shows error, input stays accessible', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: '500 Mid-Conversation Test' });
+
+    let callCount = 0;
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      callCount += 1;
+      if (callCount === 1) {
+        // First turn: healthy response.
+        const body = tokenChunk('Turn 1 reply.', 0) + 'data: [DONE]\n\n';
+        return route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          body,
+        });
+      }
+      // Second turn: hard 500.
+      return route.fulfill({ status: 500, body: 'Internal Server Error' });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('First message');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await chat.waitForAIResponse();
+
+    // Use the page object's sendMessage for consistency with the page-object pattern.
+    await chat.sendMessage('Second message');
+
+    // 500 is recoverable — retries will also fail → eventual "Stream error".
+    await waitForAnnouncement(page, ['Stream error'], 30_000);
+
+    // Input must still be accessible — user can attempt another message.
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 4. Config load fails at runtime ───────────────────────────────────────
+  //
+  // Both /api/config/branding and /api/config/features return 500.
+  // Expected: app renders a non-empty page with no unhandled crash.
+  test('config endpoints return 500: app renders content instead of blank screen', async ({
+    page,
+  }) => {
+    // Start from a fully healthy baseline then override just the two config routes.
+    // Playwright LIFO ordering ensures the overrides take precedence over mountConfig's routes.
+    await mountConfig(page, { title: 'Config Failure Test' });
+    await mockAgentStream(page, 'Hello');
+
+    await page.route('**/api/config/branding', (route) =>
+      route.fulfill({ status: 500, body: 'Config service unavailable' }),
+    );
+    await page.route('**/api/config/features', (route) =>
+      route.fulfill({ status: 500, body: 'Config service unavailable' }),
+    );
+
+    await page.goto('/');
+
+    // Body must not be empty — user sees something meaningful.
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.trim()).not.toBe('');
+
+    // No unhandled error boundary message should surface.
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 5. Concurrent users during agent restart (502 flap) ───────────────────
+  //
+  // Two independent browser contexts hit 502 simultaneously — simulating an
+  // agent pod restart that causes a brief gateway flap.
+  // Expected: both users see graceful error state, no blank screens.
+  test('502 flap: concurrent users both see graceful error, no blank screens', async ({
+    browser,
+    baseURL,
+  }) => {
+    const [ctxA, ctxB] = await Promise.all([
+      browser.newContext({ baseURL }),
+      browser.newContext({ baseURL }),
+    ]);
+    const [pageA, pageB] = await Promise.all([
+      ctxA.newPage(),
+      ctxB.newPage(),
+    ]);
+
+    try {
+      // Configure both "users": healthy config, 502 on the stream endpoint.
+      for (const p of [pageA, pageB]) {
+        await mountConfig(p, { title: '502 Flap Test' });
+        await p.route('**/api/proxy/agent/v1/stream', (route) =>
+          route.fulfill({ status: 502, body: 'Bad Gateway' }),
+        );
+      }
+
+      // Both users navigate and submit simultaneously.
+      await Promise.all([
+        (async () => {
+          await new HomePage(pageA).goto();
+          await new HomePage(pageA).submitPrompt('User A message');
+        })(),
+        (async () => {
+          await new HomePage(pageB).goto();
+          await new HomePage(pageB).submitPrompt('User B message');
+        })(),
+      ]);
+
+      // Both contexts must reach an error state — not freeze or go blank.
+      // 502 is recoverable — allow time for retries to exhaust.
+      await Promise.all(
+        [pageA, pageB].map((p) => waitForAnnouncement(p, ['Stream error'], 30_000)),
+      );
+
+      // Input must still be interactive for all users.
+      for (const p of [pageA, pageB]) {
+        await expect(p.locator('textarea')).toBeVisible();
+      }
+    } finally {
+      await Promise.all([ctxA.close(), ctxB.close()]);
+    }
+  });
+
+  // ── 6. SSE timeout / stalled stream ───────────────────────────────────────
+  //
+  // The SSE connection opens (correct headers) but the body is empty — the
+  // server accepted the connection then sent nothing before closing it.
+  // Expected: UI reaches a terminal state (no-response or error) without freezing.
+  test('stalled SSE stream: empty body; UI reaches terminal state, not blank', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Stalled Stream Test' });
+
+    // SSE headers present but body is completely empty — server closes immediately.
+    await page.route('**/api/proxy/agent/v1/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+          'Cache-Control': 'no-cache',
+          'Connection': 'keep-alive',
+        },
+        body: '',
+      }),
+    );
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Will you respond?');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // Primary check: wait for an announcement from the aria-live region.
+    // If the stream ended without [DONE] the StreamingManager may or may not fire
+    // "Response complete"; also accept the no-response / retry panel as evidence
+    // the UI has recovered rather than freezing.
+    await page.waitForFunction(
+      () => {
+        const region = document.querySelector('.sr-only[aria-live="polite"]');
+        const t = region?.textContent ?? '';
+        return (
+          t.includes('Response complete') ||
+          t.includes('Stream error') ||
+          document.querySelector('[aria-label="Retry operation"]') !== null ||
+          Boolean(document.body.textContent?.includes("didn't respond"))
+        );
+      },
+      { timeout: 15_000 },
+    );
+
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 7. Malformed SSE payload (entirely invalid JSON, zero valid tokens) ────
+  //
+  // Every SSE data line contains invalid JSON — the stream ends with [DONE].
+  // Distinct from `error-states.spec.ts` malformed-stream test which mixes
+  // valid and invalid data lines (partial content arrives). Here, zero valid
+  // tokens arrive, so the SSEProcessor must survive pure-garbage input without
+  // crashing or leaving the UI in a broken state.
+  test('all-malformed SSE payload: parse errors are swallowed, UI does not crash', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Malformed Payload Test' });
+
+    await page.route('**/api/proxy/agent/v1/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body:
+          'data: {this is not valid json}\n\n' +
+          'data: !!TOTALLY_INVALID!!\n\n' +
+          'data: <xml>surprise</xml>\n\n' +
+          'data: [DONE]\n\n',
+      }),
+    );
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Send me corrupted SSE data');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    await waitForAnnouncement(page, ['Response complete', 'Stream error']);
+
+    // App must be fully interactive — no unhandled error boundary.
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 8. Network flap recovery ───────────────────────────────────────────────
+  //
+  // The first stream request is aborted (connection reset). The StreamingManager
+  // treats TypeError network errors as recoverable and retries automatically.
+  // The second attempt succeeds with a normal response.
+  // Expected: UI ultimately resolves with "Response complete"; no crash.
+  test('network flap: connection reset on first attempt; retry resolves gracefully', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Network Flap Test' });
+
+    let attempts = 0;
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      attempts += 1;
+      if (attempts === 1) {
+        // Simulate a TCP connection reset — browser sees a network TypeError,
+        // which isRecoverableStreamError() treats as recoverable.
+        return route.abort('connectionreset');
+      }
+      // Subsequent attempts succeed.
+      const body = tokenChunk('Recovered successfully!', 0) + 'data: [DONE]\n\n';
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('First attempt — will flap then recover');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // Allow extra time for the exponential-backoff retry cycle.
+    await waitForAnnouncement(page, ['Response complete', 'Stream error'], 25_000);
+
+    // Regardless of the recovery outcome: no blank screen, no crash.
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── 9. Agent returns empty / null response ────────────────────────────────
+  //
+  // The stream sends [DONE] immediately with zero token events — the agent
+  // produced no content whatsoever.
+  // Expected: the ChatMessagesView "no response" panel appears with a visible
+  // Retry button (showNoResponse fires after its 1 500 ms grace period).
+  test('empty agent response: stream ends with no tokens; retry panel is shown', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Empty Response Test' });
+
+    // [DONE] fires with no preceding token events — zero content delivered.
+    await page.route('**/api/proxy/agent/v1/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: 'data: [DONE]\n\n',
+      }),
+    );
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Give me an empty response');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // StreamingManager calls onDone() → announcement becomes "Response complete".
+    await waitForAnnouncement(page, ['Response complete']);
+
+    // No AI message was appended → last message is still human → ChatMessagesView
+    // shows the "didn't respond" panel after a 1 500 ms grace period.
+    await page.waitForFunction(
+      () =>
+        document.querySelector('[aria-label="Retry operation"]') !== null ||
+        Boolean(document.body.textContent?.includes("didn't respond")),
+      { timeout: 10_000 },
+    );
+
+    // The Retry button must be visible and the input must remain accessible.
+    await expect(page.locator('[aria-label="Retry operation"]')).toBeVisible();
+    await expect(page.locator('textarea')).toBeVisible();
+  });
+});

--- a/e2e/config/branding.spec.ts
+++ b/e2e/config/branding.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig, mountMinimalConfig, mountFullConfig } from '../helpers/config-mount';
+import { mockAgentStream } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+
+/**
+ * Branding config tests.
+ *
+ * Two config scenarios are exercised:
+ *   - Minimal config: only required fields (title, default colours, no logo).
+ *   - Full config: all optional fields populated (logo_url, favicon_url, custom colours).
+ *
+ * Tests assert that the Fastify server's /api/config/branding response is
+ * correctly consumed by the React app to update document title, logo element,
+ * and CSS custom properties.
+ */
+test.describe('Config: branding', () => {
+  // ── Minimal config scenario ───────────────────────────────────────────────
+
+  test('minimal config: document title reflects branding title', async ({ page }) => {
+    await mountMinimalConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    expect(await home.getDocumentTitle()).toBe('Minimal Agent');
+  });
+
+  test('minimal config: no logo image is rendered when logo_url is empty', async ({ page }) => {
+    await mountMinimalConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    // logo_url is '' so no <img> with a branding src should appear in the header
+    const logoImg = page.locator('img[alt="Logo"], img[alt="Minimal Agent"]');
+    await expect(logoImg).toHaveCount(0);
+  });
+
+  // ── Full config scenario ──────────────────────────────────────────────────
+
+  test('full config: document title reflects full branding title', async ({ page }) => {
+    await mountFullConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    expect(await home.getDocumentTitle()).toBe('Full Config Agent');
+  });
+
+  test('full config: logo image element is visible with correct src', async ({ page }) => {
+    await mountFullConfig(page);
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+    // AppLayout renders <img src={branding.logo_url} alt={branding.title || 'Logo'} />
+    const logo = page.locator('img[alt="Full Config Agent"], img[alt="Logo"]').first();
+    await expect(logo).toBeVisible();
+    const src = await logo.getAttribute('src');
+    expect(src).toContain('redhat-logo');
+  });
+
+  test('full config: CSS custom property --primary is applied from branding colours', async ({
+    page,
+  }) => {
+    const customPrimary = '#abcdef';
+    // Apply the custom colour to both themes so the assertion holds regardless
+    // of whether the app initialises in light or dark mode.
+    await mountConfig(
+      page,
+      { title: 'Color Test', colors: { light: { primary: customPrimary }, dark: { primary: customPrimary } } },
+    );
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    // Wait for App.tsx's branding useEffect to set the CSS variable
+    await page.waitForFunction(() => {
+      const val = document.documentElement.style.getPropertyValue('--primary');
+      return val !== '';
+    });
+
+    const primaryVar = await page.evaluate(() =>
+      document.documentElement.style.getPropertyValue('--primary'),
+    );
+    expect(primaryVar.toLowerCase().replace(/\s+/g, '')).toBe(customPrimary);
+  });
+});

--- a/e2e/config/feature-flags.spec.ts
+++ b/e2e/config/feature-flags.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+
+/**
+ * Feature-flag config tests.
+ *
+ * The /api/config/features endpoint drives the DebugToggle initial state.
+ * When debug_mode_default=false the toggle shows "Enable debug mode";
+ * when debug_mode_default=true the toggle shows "Disable debug mode"
+ * (because the flag pre-sets debugMode in the Redux userSettings slice).
+ *
+ * The DebugToggle is rendered in the AppLayout header and is therefore
+ * visible on every page once the app mounts.
+ */
+test.describe('Config: feature flags', () => {
+  test('debug_mode_default=false: debug toggle shows "Enable debug mode" aria-label', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Debug Off Test' }, { debug_mode_default: false });
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    await expect(
+      page.getByRole('button', { name: /enable debug mode/i }),
+    ).toBeVisible();
+  });
+
+  test('debug_mode_default=true: debug toggle shows "Disable debug mode" aria-label', async ({
+    page,
+  }) => {
+    await mountConfig(page, { title: 'Debug On Test' }, { debug_mode_default: true });
+    await mockAgentStream(page, 'Hello');
+    const home = new HomePage(page);
+    await home.goto();
+
+    await expect(
+      page.getByRole('button', { name: /disable debug mode/i }),
+    ).toBeVisible();
+  });
+});

--- a/e2e/errors/error-states.spec.ts
+++ b/e2e/errors/error-states.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockAgentStream, mockMalformedStream, mockStreamError } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Error-path tests covering:
+ *   1. Agent unreachable   – /api/health/agent returns non-200; sidebar shows "Agent: offline".
+ *   2. Malformed stream    – SSE body contains invalid JSON; UI must not crash.
+ *   3. Auth failure        – streaming endpoint returns 401; StreamingManager marks the stream
+ *                            as failed (non-recoverable 4xx) and the sr-only aria-live region
+ *                            announces "Stream error".
+ */
+test.describe('Error states', () => {
+  // ── Agent unreachable ─────────────────────────────────────────────────────
+
+  test('agent unreachable: sidebar shows "Agent: offline" indicator', async ({ page }) => {
+    // Mount base config with agentHealth='unhealthy' so the health endpoint
+    // returns 503 / { status: 'unhealthy' } from the first poll onwards.
+    await mountConfig(page, { title: 'Offline Agent Test' }, {}, 'unhealthy');
+    await mockAgentStream(page, 'Hello');
+
+    const home = new HomePage(page);
+    await home.goto();
+
+    // useAgentHealth polls immediately on mount; the sidebar indicator updates
+    // as soon as the first health check completes.
+    await expect(page.getByText('Agent: offline')).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── Malformed stream ──────────────────────────────────────────────────────
+
+  test('malformed stream: UI does not crash when receiving invalid SSE data', async ({ page }) => {
+    await mountConfig(page);
+    await mockMalformedStream(page);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Test malformed stream handling');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // The mock SSE body ends with `data: [DONE]\n\n` so the StreamingManager calls
+    // onDone(), which triggers the "Response complete" / "Stream error" announcement.
+    // Wait for that live-region update rather than using an arbitrary sleep.
+    await page.waitForFunction(
+      () => {
+        const liveRegion = document.querySelector('.sr-only[aria-live="polite"]');
+        const text = liveRegion?.textContent ?? '';
+        return text.includes('Response complete') || text.includes('Stream error');
+      },
+      { timeout: 15_000 },
+    );
+
+    // The app must still be interactive — no top-level error boundary message
+    await expect(page.locator('textarea')).toBeVisible();
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  // ── Auth failure ──────────────────────────────────────────────────────────
+
+  test('auth failure on stream: aria-live region announces "Stream error"', async ({ page }) => {
+    await mountConfig(page);
+    // 401 from the streaming endpoint is a non-recoverable 4xx; the
+    // StreamingManager throws and the ChatPage announces "Stream error"
+    // through its sr-only aria-live polite region.
+    await mockStreamError(page, 401);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('This request will be rejected with 401');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // Wait for the live region to announce the failure
+    await page.waitForFunction(
+      () => {
+        const liveRegion = document.querySelector('.sr-only[aria-live="polite"]');
+        return liveRegion?.textContent?.includes('Stream error');
+      },
+      { timeout: 15_000 },
+    );
+  });
+});

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -1,16 +1,56 @@
 import type { Page } from '@playwright/test';
 
+export interface BrandingColors {
+  primary: string;
+  accent: string;
+  background: string;
+  foreground: string;
+}
+
 export interface BrandingOverride {
   title?: string;
   logo_url?: string;
+  favicon_url?: string;
+  colors?: {
+    light?: Partial<BrandingColors>;
+    dark?: Partial<BrandingColors>;
+  };
 }
 
+export interface FeaturesOverride {
+  debug_mode_default?: boolean;
+  auth_enabled?: boolean;
+}
+
+const DEFAULT_LIGHT: BrandingColors = {
+  primary: '#0066cc',
+  accent: '#a60000',
+  background: '#ffffff',
+  foreground: '#1a1a1a',
+};
+
+const DEFAULT_DARK: BrandingColors = {
+  primary: '#4dabf7',
+  accent: '#f56e6e',
+  background: '#0a1628',
+  foreground: '#f0f4f8',
+};
+
 /**
- * Mock the config and agent-proxy endpoints so tests don't depend on
- * a real agent backend.  Config endpoints could be served by the real
- * Fastify process but overriding them keeps tests hermetic.
+ * Mock config and agent-proxy endpoints so tests do not depend on a real
+ * agent backend. Config endpoints could be served by the real Fastify process
+ * but overriding them keeps tests hermetic.
+ *
+ * @param branding  Branding values to use (merged with defaults).
+ * @param features  Feature flags to use (merged with defaults).
+ * @param agentHealth  Agent health status — one of 'healthy', 'unhealthy', or 'unknown'.
  */
-export async function mountConfig(page: Page, branding: BrandingOverride = {}): Promise<void> {
+export async function mountConfig(
+  page: Page,
+  branding: BrandingOverride = {},
+  features: FeaturesOverride = {},
+  agentHealth: 'healthy' | 'unhealthy' | 'unknown' = 'healthy',
+): Promise<void> {
   await page.route('**/api/config/branding', (route) =>
     route.fulfill({
       status: 200,
@@ -18,9 +58,10 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
       body: JSON.stringify({
         logo_url: branding.logo_url ?? '',
         title: branding.title ?? 'Test Agent',
+        ...(branding.favicon_url ? { favicon_url: branding.favicon_url } : {}),
         colors: {
-          light: { primary: '#0066cc', accent: '#a60000', background: '#ffffff', foreground: '#1a1a1a' },
-          dark: { primary: '#4dabf7', accent: '#f56e6e', background: '#0a1628', foreground: '#f0f4f8' },
+          light: { ...DEFAULT_LIGHT, ...branding.colors?.light },
+          dark: { ...DEFAULT_DARK, ...branding.colors?.dark },
         },
       }),
     }),
@@ -30,16 +71,17 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ debug_mode_default: false, auth_enabled: false }),
+      body: JSON.stringify({
+        debug_mode_default: features.debug_mode_default ?? false,
+        auth_enabled: features.auth_enabled ?? false,
+      }),
     }),
   );
 
-  // Feedback endpoint called for previously-hydrated chats
   await page.route('**/api/proxy/agent/threads/*/feedback**', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
   );
 
-  // Announcement banner (optional endpoint — return disabled)
   await page.route('**/api/announcement', (route) =>
     route.fulfill({
       status: 200,
@@ -48,21 +90,42 @@ export async function mountConfig(page: Page, branding: BrandingOverride = {}): 
     }),
   );
 
-  // Agent health probe — avoids ECONNREFUSED timeout on every page mount
+  const healthHttpStatus = agentHealth === 'healthy' ? 200 : 503;
   await page.route('**/api/health/agent', (route) =>
     route.fulfill({
-      status: 200,
+      status: healthHttpStatus,
       contentType: 'application/json',
-      body: JSON.stringify({ status: 'healthy' }),
+      body: JSON.stringify({ status: agentHealth }),
     }),
   );
 
-  // AppLayout calls POST /threads/search on every mount to reconcile chat history.
   await page.route('**/api/proxy/agent/threads/search', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: '[]',
     }),
+  );
+}
+
+/** Minimal config: only required fields populated, no logo, default colors. */
+export async function mountMinimalConfig(page: Page): Promise<void> {
+  return mountConfig(page, { title: 'Minimal Agent' });
+}
+
+/** Full config: all optional fields populated, custom primary colour. */
+export async function mountFullConfig(page: Page): Promise<void> {
+  return mountConfig(
+    page,
+    {
+      title: 'Full Config Agent',
+      logo_url: '/dist/frontend/redhat-logo.svg',
+      favicon_url: '/dist/frontend/redhat-logo.svg',
+      colors: {
+        light: { primary: '#cc0000', accent: '#006600', background: '#f5f5f5', foreground: '#111111' },
+        dark: { primary: '#ff6666', accent: '#66cc66', background: '#1a1a2e', foreground: '#e0e0e0' },
+      },
+    },
+    { debug_mode_default: false, auth_enabled: false },
   );
 }

--- a/e2e/helpers/sse-mock.ts
+++ b/e2e/helpers/sse-mock.ts
@@ -37,3 +37,40 @@ export async function mockThreadState(page: Page): Promise<void> {
     }),
   );
 }
+
+/**
+ * Intercept with a stream containing syntactically invalid SSE token data.
+ * The SSEProcessor should skip unrecognised chunks without crashing the UI.
+ */
+export async function mockMalformedStream(page: Page): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) => {
+    // Mix valid and invalid JSON; the SSEProcessor must tolerate both gracefully.
+    const body =
+      'data: {this is not valid json}\n\n' +
+      tokenChunk('partial ok', 0) +
+      'data: !!INVALID!!\n\n' +
+      'data: [DONE]\n\n';
+    return route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body,
+    });
+  });
+}
+
+/**
+ * Intercept the streaming endpoint and return the given HTTP error status.
+ * Useful for testing auth-failure (401) and server-error (500+) paths.
+ */
+export async function mockStreamError(page: Page, status: number): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) =>
+    route.fulfill({
+      status,
+      body: `HTTP ${status}`,
+    }),
+  );
+}

--- a/e2e/helpers/sse-mock.ts
+++ b/e2e/helpers/sse-mock.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 /** Serialise one `data:` line for a token chunk the SSEProcessor accepts. */
-function tokenChunk(text: string, chunkId: number): string {
+export function tokenChunk(text: string, chunkId: number): string {
   return `data: ${JSON.stringify({ type: 'token', content: text, chunk_id: chunkId })}\n\n`;
 }
 

--- a/e2e/helpers/wait.ts
+++ b/e2e/helpers/wait.ts
@@ -1,0 +1,22 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Wait for the sr-only aria-live polite region (ChatPage.tsx) to contain at
+ * least one of the provided strings. The region announces "Agent is thinking",
+ * "Response complete", or "Stream error" as stream state changes.
+ */
+export async function waitForAnnouncement(
+  page: Page,
+  texts: string[],
+  timeout = 15_000,
+): Promise<void> {
+  await page.waitForFunction(
+    (expected: string[]) => {
+      const region = document.querySelector('.sr-only[aria-live="polite"]');
+      const t = region?.textContent ?? '';
+      return expected.some((s) => t.includes(s));
+    },
+    texts,
+    { timeout },
+  );
+}

--- a/e2e/page-objects/ChatPage.ts
+++ b/e2e/page-objects/ChatPage.ts
@@ -36,6 +36,12 @@ export class ChatPage {
     await expect(this.page).toHaveURL(/\/chat\//);
   }
 
+  /** Fills the chat input on the chat page and clicks submit — mirrors HomePage.submitPrompt. */
+  async sendMessage(text: string): Promise<void> {
+    await this.page.locator('textarea').fill(text);
+    await this.page.locator('button[type="submit"]').click();
+  }
+
   /** Returns the full visible text content of the page — useful for asserting response text. */
   async getBodyText(): Promise<string> {
     return this.page.locator('body').innerText();


### PR DESCRIPTION
**Dependent on https://github.com/redhat-data-and-ai/template-ui/pull/73**

## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Adds a `e2e/chaos/` directory with 9 Playwright resilience tests that simulate real backend failure modes — SSE drops, HTTP 5xx errors, config endpoint failures, TCP resets, and empty agent responses. The goal is to guarantee the template-ui never shows a blank/frozen screen when the agent is unhealthy; every scenario asserts that a meaningful error UI is visible and the user has a recovery path. Also extracts shared E2E utilities that were previously inlined in individual spec files.

## Changes

- `e2e/chaos/resilience.spec.ts` — 9 new chaos test scenarios (SSE truncation without `[DONE]`, recoverable 503 retries, HTTP 500 mid-conversation, config endpoints returning 500, concurrent 502 flap via two browser contexts, stalled empty SSE body, all-invalid JSON payload, TCP reset with automatic retry recovery, empty agent response with no-response retry panel)
- `e2e/helpers/wait.ts` — new shared helper `waitForAnnouncement()` that polls the sr-only aria-live polite region; replaces inline `waitForFunction` blocks scattered across spec files
- `e2e/helpers/sse-mock.ts` — export `tokenChunk` (was private); chaos tests re-use it to build custom SSE bodies without duplicating the format
- `e2e/page-objects/ChatPage.ts` — add `sendMessage(text)` method for multi-turn conversation tests; mirrors `HomePage.submitPrompt`

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Implementation of all 9 chaos tests, the `wait.ts` helper, and the `ChatPage.sendMessage` method; the `tokenChunk` export change
- **Human verification**: All 22 tests (9 new + 13 existing) run to green locally via `npx playwright test`; code-reviewer subagent review applied and all major/minor issues resolved

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

<!-- What to focus on. -->

- Tests 2, 3, and 5 allow up to 30 s for the aria-live region to announce `Stream error` — this is intentional because `isRecoverableStreamError` retries 503/500/502 up to `MAX_RETRIES=3` times with exponential backoff; reducing the timeout would make these tests flaky on slow CI runners.
- Test 5 (concurrent 502) uses `browser.newContext({ baseURL })` to create two independent contexts — `baseURL` comes from the Playwright `baseURL` fixture so it picks up the value from `playwright.config.ts` without hardcoding.
- Test 6 (stalled stream) uses `waitForFunction` rather than `waitForAnnouncement` because it must also accept the no-response retry panel as a valid terminal state — the empty body may or may not trigger the aria-live path depending on how the StreamingManager resolves an empty read.
- The `tokenChunk` export in `sse-mock.ts` is the only change to an existing helper file; it is backward-compatible (pure export addition).