### PR TITLE
feat: fix subagent responses

### DIFF
--- a/src/frontend/components/SubAgentIndicator.tsx
+++ b/src/frontend/components/SubAgentIndicator.tsx
@@ -21,8 +21,14 @@ interface SubAgentIndicatorProps {
 
 type VisualStatus = 'delegating' | 'complete' | 'error';
 
+function hasContent(toolCall: ToolCallWithContent): boolean {
+  if (toolCall.content == null) return false;
+  if (typeof toolCall.content === 'string') return toolCall.content.trim().length > 0;
+  return true;
+}
+
 function deriveStatus(toolCall: ToolCallWithContent): VisualStatus {
-  if (toolCall.content == null) return 'delegating';
+  if (!hasContent(toolCall)) return 'delegating';
   if (typeof toolCall.content === 'string' && toolCall.content.startsWith('Error')) return 'error';
   return 'complete';
 }
@@ -115,7 +121,7 @@ export function SubAgentIndicator({ toolCall, messageId: _messageId, index: _ind
                   </p>
                 </div>
               )}
-              {toolCall.content != null && (
+              {hasContent(toolCall) && (
                 <div>
                   <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1.5">
                     Result

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -398,7 +398,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
           runBody.config = { metadata: { trace_id: traceId } };
         }
 
-        const streamTimeoutMs = Math.max(cfg.agent.timeout_ms * 10, 300_000);
+        const streamTimeoutMs = Math.max(cfg.agent.timeout_ms, 300_000);
         const runResp = await fetch(runUrl, {
           method: 'POST',
           headers: { ...headers, Accept: 'text/event-stream' },

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -398,11 +398,12 @@ async function proxyRoutes(fastify: FastifyInstance) {
           runBody.config = { metadata: { trace_id: traceId } };
         }
 
+        const streamTimeoutMs = Math.max(cfg.agent.timeout_ms * 10, 300_000);
         const runResp = await fetch(runUrl, {
           method: 'POST',
           headers: { ...headers, Accept: 'text/event-stream' },
           body: JSON.stringify(runBody),
-          signal: AbortSignal.timeout(cfg.agent.timeout_ms),
+          signal: AbortSignal.timeout(streamTimeoutMs),
         });
 
         if (!runResp.ok) {
@@ -618,11 +619,16 @@ async function proxyRoutes(fastify: FastifyInstance) {
           reply.raw.end('data: [DONE]\n\n');
         }
       } catch (error: unknown) {
-        if ((error as Error).name === 'AbortError') {
+        const errName = (error as Error).name;
+        if (errName === 'AbortError') {
           fastify.log.info({ traceId }, 'Client disconnected, stream aborted');
           return;
         }
-        fastify.log.error({ traceId, error }, 'Proxy stream error');
+        if (errName === 'TimeoutError') {
+          fastify.log.warn({ traceId }, 'Agent stream timed out');
+        } else {
+          fastify.log.error({ traceId, err: error }, 'Proxy stream error');
+        }
         if (reply.raw.headersSent) {
           reply.raw.end();
         } else {
@@ -708,7 +714,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
 
         return reply.send(responseBody);
       } catch (error) {
-        fastify.log.error({ traceId, error }, 'Proxy error');
+        fastify.log.error({ traceId, err: error }, 'Proxy error');
         return reply.status(502).send({ error: 'Failed to connect to agent service' });
       }
     }
@@ -746,7 +752,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
       const responseBody = await agentResponse.text();
       return reply.send(responseBody);
     } catch (error) {
-      fastify.log.error({ traceId, error }, 'Feedback proxy error');
+      fastify.log.error({ traceId, err: error }, 'Feedback proxy error');
       return reply.status(502).send({ error: 'Failed to send feedback' });
     }
   });


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Fixes two related regressions introduced in a previous runtime-config commit (21e9c7b):

1. **SSE stream timing out after 30 seconds** — the runtime-config feature added `AbortSignal.timeout(cfg.agent.timeout_ms)` uniformly to all five proxy fetch calls, including the long-lived SSE streaming run. `agent.timeout_ms` defaults to 30 000 ms, which is appropriate for short REST calls but kills an SSE connection mid-flight when sub-agents are involved (they routinely take 30–120 s). The bug manifested as `Proxy stream error` with `error: {}` in logs and `responseTime: 30016ms` — an exact timeout.

2. **Sub-agent card stuck on "Complete" with empty result** — because the stream was killed before the tool result arrived, `toolCall.content` was set to an empty string `""`. `deriveStatus()` treated any non-null value as "complete", so the card flipped to green immediately while the Result section rendered a blank box. Users saw a "Complete" badge but no output.

## Changes

- `proxy.router.ts`: Override stream fetch timeout to `max(timeout_ms × 10, 300 000 ms)` — short REST calls keep the configurable timeout, the SSE run gets at least 5 minutes
- `proxy.router.ts`: Catch `TimeoutError` (thrown by `AbortSignal.timeout()`) separately from `AbortError` (client disconnect) and log as `warn` instead of `error`
- `proxy.router.ts`: Fix pino serialization — use `err:` key (not `error:`) so error objects are not logged as `{}`
- `SubAgentIndicator.tsx`: Add `hasContent()` guard that treats `null` and empty string equally as "no content yet" — status stays "Working" and Result section is hidden until real content arrives

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: Root cause analysis, all four fixes in both files
- **Human verification**: Verified against terminal logs (`responseTime: 30016ms` confirms timeout), traced the offending commit via `git log -S`, reviewed diff manually before committing

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

No new env vars or config changes. `AGENT_TIMEOUT_MS` env var and `agent.timeout_ms` in `settings.yaml` continue to control REST call timeouts — only the SSE streaming fetch is now exempt from that limit. No security surface changes.

## Reviewer Notes

<!-- What to focus on. -->

The stream timeout formula `max(timeout_ms × 10, 300_000)` is intentionally a floor, not a ceiling — very long-running agents are handled by the client disconnect signal (`AbortError`) rather than a server-side timeout. If a hard upper bound on stream duration is ever needed, it should be a separate dedicated config key (e.g. `agent.stream_timeout_ms`) rather than a multiplier.