### PR TITLE
feat: expand test suite and add coverage

### DIFF
--- a/e2e/auth/rate-limit.spec.ts
+++ b/e2e/auth/rate-limit.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { mockRateLimitResponse } from '../helpers/sse-mock';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Rate-limit (429) tests:
+ *
+ *  1. When the stream endpoint returns 429, the input form shows a
+ *     "Rate limited. Try again in Xs" alert and the submit button is disabled.
+ *  2. The countdown text updates while the rate limit is active.
+ */
+
+test.describe('Rate limit — 429 handling', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountConfig(page, { title: 'Rate Limit Test' });
+  });
+
+  // ── Banner appears ─────────────────────────────────────────────────────────
+
+  test('shows a rate-limit alert when the stream returns 429', async ({ page }) => {
+    await mockRateLimitResponse(page, 30);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Send a message');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // The InputForm renders <Alert title="Rate limited. Try again in Xs" />
+    // Use the alert heading role to avoid matching user-message text bubbles
+    await expect(page.getByRole('heading', { name: /rate limited/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── Submit button is disabled ──────────────────────────────────────────────
+
+  test('the cancel button is shown (submit blocked) while rate-limited', async ({ page }) => {
+    await mockRateLimitResponse(page, 30);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Rate limited test');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await expect(page.getByRole('heading', { name: /rate limited/i })).toBeVisible({ timeout: 15_000 });
+
+    // During the retry backoff the stream is still active (cancel button visible),
+    // which means the submit button is NOT rendered and new messages cannot be sent.
+    await expect(page.getByRole('button', { name: /cancel streaming/i })).toBeVisible();
+  });
+
+  // ── Retry-After respected ──────────────────────────────────────────────────
+
+  test('shows the Retry-After seconds in the alert text', async ({ page }) => {
+    await mockRateLimitResponse(page, 10);
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Rate limited request');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    // The alert heading "Rate limited. Try again in Xs" should mention the countdown
+    await expect(page.getByRole('heading', { name: /try again in \d+s/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ── Normal flow unaffected ─────────────────────────────────────────────────
+
+  test('does NOT show a rate-limit alert on a normal 200 response', async ({ page }) => {
+    // Override the rate-limit mock with a normal response
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      const body = `data: ${JSON.stringify({ type: 'token', content: 'OK', chunk_id: 0 })}\n\ndata: [DONE]\n\n`;
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Normal request');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await chat.waitForAIResponse(15_000);
+
+    await expect(page.getByRole('heading', { name: /rate limited/i })).not.toBeVisible();
+  });
+});

--- a/e2e/helpers/local-storage.ts
+++ b/e2e/helpers/local-storage.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+
+const SETTINGS_KEY = 'template-ui-settings';
+
+/**
+ * Inject localStorage settings before the page loads.
+ * Must be called before `page.goto()`.
+ *
+ * Merges the provided settings into the template-ui-settings key so
+ * individual fields (e.g. alwaysAllowedTools) can be set independently.
+ */
+export async function setLocalStorageSettings(
+  page: Page,
+  settings: Partial<{
+    theme: 'light' | 'dark';
+    debugMode: boolean;
+    alwaysAllowedTools: string[];
+    autoApproveAllTools: boolean;
+  }>,
+): Promise<void> {
+  await page.addInitScript(
+    ({ key, value }) => {
+      let existing: Record<string, unknown> = {};
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) existing = JSON.parse(raw);
+      } catch {
+        // start fresh
+      }
+      localStorage.setItem(key, JSON.stringify({ ...existing, ...value }));
+    },
+    { key: SETTINGS_KEY, value: settings },
+  );
+}
+
+/**
+ * Read the stored template-ui-settings from localStorage after the page has
+ * loaded. Returns null when the key is not set.
+ */
+export async function getLocalStorageSettings(
+  page: Page,
+): Promise<Record<string, unknown> | null> {
+  return page.evaluate((key) => {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, SETTINGS_KEY);
+}

--- a/e2e/helpers/sse-mock.ts
+++ b/e2e/helpers/sse-mock.ts
@@ -1,8 +1,17 @@
-import type { Page } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
 
 /** Serialise one `data:` line for a token chunk the SSEProcessor accepts. */
 export function tokenChunk(text: string, chunkId: number): string {
   return `data: ${JSON.stringify({ type: 'token', content: text, chunk_id: chunkId })}\n\n`;
+}
+
+/** Serialise one `data:` line for an interrupt chunk the SSEProcessor accepts. */
+export function interruptChunk(value: object | string, chunkId: number): string {
+  return `data: ${JSON.stringify({
+    type: 'interrupt',
+    content: { value, resumable: true },
+    chunk_id: chunkId,
+  })}\n\n`;
 }
 
 /**
@@ -71,6 +80,69 @@ export async function mockStreamError(page: Page, status: number): Promise<void>
     route.fulfill({
       status,
       body: `HTTP ${status}`,
+    }),
+  );
+}
+
+/**
+ * Intercept the streaming endpoint and return a single interrupt chunk.
+ * The interrupt value can be a plain string (generic) or an HITLInterruptValue object.
+ */
+export async function mockInterruptStream(
+  page: Page,
+  value: object | string,
+): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) => {
+    const body = interruptChunk(value, 0) + 'data: [DONE]\n\n';
+    return route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body,
+    });
+  });
+}
+
+/**
+ * Override the streaming endpoint for a resume request to return a simple
+ * token response. Intercepts only the NEXT call — the route is unregistered
+ * after it fires once, so subsequent stream requests fall through to any
+ * previously registered handlers.
+ */
+export async function mockResumeStream(page: Page, responseText: string): Promise<void> {
+  const handler = async (route: Route) => {
+    // Unregister before fulfilling so only the first matching request is intercepted
+    await page.unroute('**/api/proxy/agent/v1/stream', handler);
+    const body = tokenChunk(responseText, 0) + 'data: [DONE]\n\n';
+    await route.fulfill({
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+      },
+      body,
+    });
+  };
+  await page.route('**/api/proxy/agent/v1/stream', handler);
+}
+
+/**
+ * Intercept the streaming endpoint and return HTTP 429 with a Retry-After header.
+ * Used for testing the rate-limit UI.
+ */
+export async function mockRateLimitResponse(page: Page, retryAfterSeconds = 5): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) =>
+    route.fulfill({
+      status: 429,
+      headers: {
+        'Retry-After': String(retryAfterSeconds),
+        'Content-Type': 'text/plain',
+      },
+      body: 'Rate limited',
     }),
   );
 }

--- a/e2e/hitl/auto-approve.spec.ts
+++ b/e2e/hitl/auto-approve.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { setLocalStorageSettings } from '../helpers/local-storage';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Auto-approve tests:
+ *
+ *  1. When `alwaysAllowedTools` contains the tool from an action_requests interrupt,
+ *     the resume is sent automatically without showing any approval UI.
+ *  2. When the tool is NOT in `alwaysAllowedTools` AND the interrupt is a non-actionable
+ *     string value, the InterruptBanner appears for the user.
+ *  3. When `autoApproveAllTools` is true, every action_requests interrupt is auto-approved.
+ */
+
+const TOOL_APPROVAL_INTERRUPT = {
+  action_requests: [{ name: 'github_search', args: { query: 'bugs' } }],
+  review_configs: [{ action_name: 'github_search', allowed_decisions: ['approve', 'reject'] }],
+};
+
+// A string interrupt (not action_requests) that triggers the InterruptBanner's
+// "Action Required" branch (contains "approve").  Since it's a string, the
+// ChatPage auto-approve useEffect skips it — the banner always appears.
+const APPROVAL_STRING_INTERRUPT =
+  'Do you approve running the dangerous_tool with the provided arguments?';
+
+const UNKNOWN_TOOL_INTERRUPT = {
+  action_requests: [{ name: 'dangerous_tool', args: {} }],
+  review_configs: [{ action_name: 'dangerous_tool', allowed_decisions: ['approve', 'reject'] }],
+};
+
+async function makeInterruptStream(
+  value: object | string,
+  callCount: { n: number },
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.route('**/api/proxy/agent/v1/stream', (route) => {
+    callCount.n++;
+    if (callCount.n === 1) {
+      const body =
+        `data: ${JSON.stringify({
+          type: 'interrupt',
+          content: { value, resumable: true },
+          chunk_id: 0,
+        })}\n\n` + 'data: [DONE]\n\n';
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    }
+    const body = `data: ${JSON.stringify({ type: 'token', content: 'Done automatically.', chunk_id: 0 })}\n\ndata: [DONE]\n\n`;
+    return route.fulfill({
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+      body,
+    });
+  });
+}
+
+test.describe('HITL — auto-approve', () => {
+  // ── auto-approve via alwaysAllowedTools ──────────────────────────────────
+
+  test(
+    'banner is skipped when the interrupted tool is in alwaysAllowedTools',
+    async ({ page }) => {
+      await setLocalStorageSettings(page, { alwaysAllowedTools: ['github_search'] });
+      await mountConfig(page, { title: 'Auto Approve Test' });
+
+      const callCount = { n: 0 };
+      await makeInterruptStream(TOOL_APPROVAL_INTERRUPT, callCount, page);
+
+      const home = new HomePage(page);
+      await home.goto();
+      await home.submitPrompt('Search GitHub issues');
+
+      const chat = new ChatPage(page);
+      await chat.expectChatRoute();
+
+      // The response should complete without the interrupt banner ever appearing
+      await chat.waitForAIResponse(15_000);
+      await expect(page.getByText('Action Required')).not.toBeVisible();
+      await expect(page.getByText('Input Required')).not.toBeVisible();
+      expect(callCount.n).toBeGreaterThanOrEqual(2);
+    },
+  );
+
+  // ── banner still shown when interrupt is not auto-approvable ─────────────
+  // String interrupts bypass the auto-approve useEffect (which only handles
+  // action_requests objects), so the InterruptBanner always renders.
+
+  test(
+    'banner is shown when the interrupt is a string value (not auto-approved)',
+    async ({ page }) => {
+      await setLocalStorageSettings(page, { alwaysAllowedTools: ['github_search'] });
+      await mountConfig(page, { title: 'Auto Approve Test' });
+
+      const callCount = { n: 0 };
+      await makeInterruptStream(APPROVAL_STRING_INTERRUPT, callCount, page);
+
+      const home = new HomePage(page);
+      await home.goto();
+      await home.submitPrompt('Run the dangerous tool');
+
+      const chat = new ChatPage(page);
+      await chat.expectChatRoute();
+
+      // Banner MUST appear because string interrupts are never auto-approved
+      await expect(page.getByText('Action Required')).toBeVisible({ timeout: 15_000 });
+    },
+  );
+
+  // ── auto-approve all via autoApproveAllTools flag ─────────────────────────
+
+  test(
+    'banner is skipped when autoApproveAllTools is true, regardless of tool name',
+    async ({ page }) => {
+      await setLocalStorageSettings(page, { autoApproveAllTools: true });
+      await mountConfig(page, { title: 'Auto Approve All Test' });
+
+      const callCount = { n: 0 };
+      await makeInterruptStream(UNKNOWN_TOOL_INTERRUPT, callCount, page);
+
+      const home = new HomePage(page);
+      await home.goto();
+      await home.submitPrompt('Run all tools');
+
+      const chat = new ChatPage(page);
+      await chat.expectChatRoute();
+
+      await chat.waitForAIResponse(15_000);
+      await expect(page.getByText('Action Required')).not.toBeVisible();
+      expect(callCount.n).toBeGreaterThanOrEqual(2);
+    },
+  );
+});

--- a/e2e/hitl/interrupt-flow.spec.ts
+++ b/e2e/hitl/interrupt-flow.spec.ts
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { HomePage } from '../page-objects/HomePage';
+import { ChatPage } from '../page-objects/ChatPage';
+
+/**
+ * Human-In-The-Loop (HITL) interrupt flow tests.
+ *
+ * The InterruptBanner component is rendered via `interruptContent` in ChatPage
+ * for NON-action_requests interrupts (strings and MCP auth).
+ * For string interrupt values, isToolApproval() decides which branch:
+ *  - Contains "approve" / "confirm" / "allow" etc → "Action Required" (Approve/Reject buttons)
+ *  - Otherwise → "Input Required" (text input + Send button)
+ */
+
+// String interrupt that triggers the "Action Required" branch (contains "approve")
+const TOOL_APPROVAL_STR = 'Do you approve running github_create_pr with title "Test PR"?';
+
+// String interrupt that triggers the "Input Required" branch (no approval keywords)
+const GENERIC_INTERRUPT_VALUE = 'What format should the output be in?';
+
+function makeInterruptBody(value: string | object, chunkId = 0): string {
+  return (
+    `data: ${JSON.stringify({
+      type: 'interrupt',
+      content: { value, resumable: true },
+      chunk_id: chunkId,
+    })}\n\n` + 'data: [DONE]\n\n'
+  );
+}
+
+test.describe('HITL — interrupt banner rendering', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountConfig(page, { title: 'HITL Test Agent' });
+  });
+
+  // ── Tool approval ─────────────────────────────────────────────────────────
+
+  test('renders the interrupt banner for a tool-approval interrupt', async ({ page }) => {
+    await page.route('**/api/proxy/agent/v1/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: makeInterruptBody(TOOL_APPROVAL_STR),
+      }),
+    );
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Create a pull request');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    await expect(page.getByText('Action Required')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: /approve/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /reject/i })).toBeVisible();
+  });
+
+  test('clicking Approve sends a resume stream request and removes the banner', async ({
+    page,
+  }) => {
+    let callCount = 0;
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      callCount++;
+      if (callCount === 1) {
+        return route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          body: makeInterruptBody(TOOL_APPROVAL_STR),
+        });
+      }
+      const body = `data: ${JSON.stringify({ type: 'token', content: 'PR created!', chunk_id: 0 })}\n\ndata: [DONE]\n\n`;
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Create a pull request');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await expect(page.getByText('Action Required')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: /approve/i }).click();
+
+    // Banner should disappear once resume is sent
+    await expect(page.getByText('Action Required')).not.toBeVisible({ timeout: 10_000 });
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('clicking Reject sends a reject resume and removes the banner', async ({ page }) => {
+    let callCount = 0;
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      callCount++;
+      if (callCount === 1) {
+        return route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          body: makeInterruptBody(TOOL_APPROVAL_STR),
+        });
+      }
+      const body = `data: ${JSON.stringify({ type: 'token', content: 'Skipped.', chunk_id: 0 })}\n\ndata: [DONE]\n\n`;
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Create a pull request');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await expect(page.getByText('Action Required')).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole('button', { name: /reject/i }).click();
+    await expect(page.getByText('Action Required')).not.toBeVisible({ timeout: 10_000 });
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── Generic text interrupt ──────────────────────────────────────────────
+
+  test('renders "Input Required" for a generic text interrupt', async ({ page }) => {
+    await page.route('**/api/proxy/agent/v1/stream', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: makeInterruptBody(GENERIC_INTERRUPT_VALUE),
+      }),
+    );
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Run the analysis');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+
+    await expect(page.getByText('Input Required')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('textbox', { name: /interrupt response/i })).toBeVisible();
+    // Use exact name to avoid matching the chat's "Send message" submit button
+    await expect(page.getByRole('button', { name: 'Send', exact: true })).toBeVisible();
+  });
+
+  test('Send button submits the typed text as the resume response', async ({ page }) => {
+    let callCount = 0;
+    await page.route('**/api/proxy/agent/v1/stream', (route) => {
+      callCount++;
+      if (callCount === 1) {
+        return route.fulfill({
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+          body: makeInterruptBody(GENERIC_INTERRUPT_VALUE),
+        });
+      }
+      const body = `data: ${JSON.stringify({ type: 'token', content: 'Got it.', chunk_id: 0 })}\n\ndata: [DONE]\n\n`;
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body,
+      });
+    });
+
+    const home = new HomePage(page);
+    await home.goto();
+    await home.submitPrompt('Run the analysis');
+
+    const chat = new ChatPage(page);
+    await chat.expectChatRoute();
+    await expect(page.getByText('Input Required')).toBeVisible({ timeout: 15_000 });
+
+    const input = page.getByRole('textbox', { name: /interrupt response/i });
+    await input.fill('JSON format please');
+    await page.getByRole('button', { name: 'Send', exact: true }).click();
+
+    // Banner gone, second stream call made
+    await expect(page.getByText('Input Required')).not.toBeVisible({ timeout: 10_000 });
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/e2e/page-objects/SettingsPage.ts
+++ b/e2e/page-objects/SettingsPage.ts
@@ -17,11 +17,11 @@ export class SettingsPage {
   }
 
   async clickTab(tab: SettingsTab): Promise<void> {
-    await this.page.getByRole('button', { name: tab, exact: false }).click();
+    await this.page.getByRole('tab', { name: tab, exact: false }).click();
   }
 
   async expectTabContentVisible(heading: SettingsTab): Promise<void> {
-    await expect(this.page.getByRole('heading', { name: heading, exact: false })).toBeVisible();
+    await expect(this.page.getByRole('heading', { name: heading, exact: false }).first()).toBeVisible();
   }
 
   /** Navigate back to the home page via the back arrow button. */

--- a/e2e/settings/settings-page.spec.ts
+++ b/e2e/settings/settings-page.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { mountConfig } from '../helpers/config-mount';
+import { SettingsPage } from '../page-objects/SettingsPage';
+import { setLocalStorageSettings, getLocalStorageSettings } from '../helpers/local-storage';
+
+/**
+ * Settings page tests:
+ *
+ *  1. Settings page loads with the expected heading.
+ *  2. All tabs are navigable.
+ *  3. Theme toggle persists to localStorage.
+ *  4. "Tool Approvals" tab shows always-allowed tools list.
+ *  5. Adding a tool to always-allowed saves to localStorage.
+ */
+
+test.describe('Settings page', () => {
+  test.beforeEach(async ({ page }) => {
+    await mountConfig(page, { title: 'Settings Test' });
+  });
+
+  // ── Basic load ─────────────────────────────────────────────────────────────
+
+  test('settings page loads with the Settings heading', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    const heading = await settings.getHeading();
+    expect(heading.toLowerCase()).toContain('settings');
+  });
+
+  test('settings page can be reached via the /settings route', async ({ page }) => {
+    await mountConfig(page);
+    await page.goto('/settings');
+    await expect(page).toHaveURL(/\/settings/);
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  // ── Tab navigation ─────────────────────────────────────────────────────────
+
+  test('Profile tab is visible and active by default', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.expectTabContentVisible('Profile');
+  });
+
+  test('clicking Appearance tab shows the Appearance section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('Appearance');
+    await settings.expectTabContentVisible('Appearance');
+  });
+
+  test('clicking Tool Approvals tab shows the tool list', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('Tool Approvals');
+    await settings.expectTabContentVisible('Tool Approvals');
+  });
+
+  test('clicking Memories tab shows the Memories section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('Memories');
+    await settings.expectTabContentVisible('Memories');
+  });
+
+  // ── Theme toggle + localStorage persistence ────────────────────────────────
+
+  test('toggling the theme persists the selection to localStorage', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('Appearance');
+
+    // Toggle to "Dark" theme
+    const darkOption = page.getByRole('radio', { name: /dark/i });
+    await darkOption.click();
+
+    const stored = await getLocalStorageSettings(page);
+    expect(stored?.theme).toBe('dark');
+
+    // Toggle back to "Light"
+    const lightOption = page.getByRole('radio', { name: /light/i });
+    await lightOption.click();
+
+    const stored2 = await getLocalStorageSettings(page);
+    expect(stored2?.theme).toBe('light');
+  });
+
+  // ── Pre-populated settings from localStorage ───────────────────────────────
+
+  test('pre-populated alwaysAllowedTools from localStorage are shown in Tool Approvals', async ({
+    page,
+  }) => {
+    await setLocalStorageSettings(page, { alwaysAllowedTools: ['web_search', 'github_search'] });
+    await mountConfig(page, { title: 'Tool Approvals Test' });
+
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('Tool Approvals');
+
+    await expect(page.getByText('web_search')).toBeVisible();
+    await expect(page.getByText('github_search')).toBeVisible();
+  });
+
+  // ── Back navigation ────────────────────────────────────────────────────────
+
+  test('back button navigates to the home page', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.navigateBack();
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30_000,
+  timeout: 60_000,
   expect: { timeout: 10_000 },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/src/frontend/components/AIMessageRenderer.test.tsx
+++ b/src/frontend/components/AIMessageRenderer.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Message } from '@langchain/langgraph-sdk';
+import { AIMessageRenderer } from './ChatMessagesView';
+import type { InterruptInfo } from '../types/deep-agent';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+/** Cast a plain object to the LangGraph Message type — only the fields used by
+ *  AIMessageRenderer are needed at runtime. */
+function makeMsg(overrides: Record<string, unknown>): Message {
+  return { type: 'ai', content: '', id: 'msg-1', tool_calls: [], ...overrides } as unknown as Message;
+}
+
+const CREATE_PR_TOOL_CALL = {
+  id: 'tc-1',
+  name: 'github_create_pr',
+  args: { title: 'My PR', base: 'main' },
+};
+
+const hitlInterrupt: InterruptInfo = {
+  value: {
+    action_requests: [{ name: 'github_create_pr', args: { title: 'My PR' } }],
+    review_configs: [{ action_name: 'github_create_pr', allowed_decisions: ['approve', 'reject'] }],
+  },
+  resumable: true,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AIMessageRenderer — HITL approval (production path for HITLInterruptValue)', () => {
+  it('renders Approve and Reject buttons for a pending tool-call interrupt', () => {
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer
+        message={msg}
+        pendingInterrupt={hitlInterrupt}
+        onInterruptResume={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /approve tool call: github_create_pr/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject tool call: github_create_pr/i })).toBeInTheDocument();
+  });
+
+  it('calls onInterruptResume with approve decisions when Approve is clicked', async () => {
+    const onInterruptResume = vi.fn();
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer
+        message={msg}
+        pendingInterrupt={hitlInterrupt}
+        onInterruptResume={onInterruptResume}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /approve tool call: github_create_pr/i }));
+    expect(onInterruptResume).toHaveBeenCalledOnce();
+    const [decisions] = onInterruptResume.mock.calls[0];
+    expect(decisions).toEqual(expect.arrayContaining([{ type: 'approve' }]));
+    expect(decisions.every((d: { type: string }) => d.type === 'approve')).toBe(true);
+  });
+
+  it('calls onInterruptResume with reject decisions when Reject is clicked', async () => {
+    const onInterruptResume = vi.fn();
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer
+        message={msg}
+        pendingInterrupt={hitlInterrupt}
+        onInterruptResume={onInterruptResume}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /reject tool call: github_create_pr/i }));
+    expect(onInterruptResume).toHaveBeenCalledOnce();
+    const [decisions] = onInterruptResume.mock.calls[0];
+    expect(decisions.every((d: { type: string }) => d.type === 'reject')).toBe(true);
+  });
+
+  it('calls onAlwaysAllow and approves when Always allow is clicked', async () => {
+    const onInterruptResume = vi.fn();
+    const onAlwaysAllow = vi.fn();
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer
+        message={msg}
+        pendingInterrupt={hitlInterrupt}
+        onInterruptResume={onInterruptResume}
+        onAlwaysAllow={onAlwaysAllow}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /always allow tool: github_create_pr/i }));
+    expect(onAlwaysAllow).toHaveBeenCalledWith(['github_create_pr']);
+    expect(onInterruptResume).toHaveBeenCalledOnce();
+    const [decisions] = onInterruptResume.mock.calls[0];
+    expect(decisions.every((d: { type: string }) => d.type === 'approve')).toBe(true);
+  });
+
+  it('hides approval buttons after one of them is clicked (approvalSubmitted)', async () => {
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer
+        message={msg}
+        pendingInterrupt={hitlInterrupt}
+        onInterruptResume={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /approve tool call: github_create_pr/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /approve tool call: github_create_pr/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /reject tool call: github_create_pr/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('does NOT render approval buttons when pendingInterrupt is null', () => {
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer message={msg} pendingInterrupt={null} onInterruptResume={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole('button', { name: /approve tool call/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reject tool call/i })).not.toBeInTheDocument();
+  });
+
+  it('does NOT render approval buttons when onInterruptResume is not provided', () => {
+    const msg = makeMsg({ tool_calls: [CREATE_PR_TOOL_CALL] });
+
+    render(
+      <AIMessageRenderer message={msg} pendingInterrupt={hitlInterrupt} />,
+    );
+
+    expect(screen.queryByRole('button', { name: /approve tool call/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/InterruptBanner.test.tsx
+++ b/src/frontend/components/InterruptBanner.test.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InterruptBanner } from './InterruptBanner';
+import type { InterruptInfo } from '../types/deep-agent';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const toolApprovalInterrupt: InterruptInfo = {
+  value: 'Do you approve this action? Please confirm or reject.',
+  resumable: true,
+};
+
+const genericInterrupt: InterruptInfo = {
+  value: 'What format would you prefer for the output?',
+  resumable: true,
+};
+
+const mcpAuthInterrupt: InterruptInfo = {
+  value: '',
+  resumable: true,
+  payload: {
+    type: 'mcp_auth_required',
+    mcp_name: 'github',
+    connect_url: '/api/proxy/agent/mcp/github/connect',
+    message: 'Connect your GitHub account.',
+  },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('InterruptBanner — tool approval branch', () => {
+  it('renders "Action Required" for an approval interrupt', () => {
+    render(
+      <InterruptBanner interrupt={toolApprovalInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByText('Action Required')).toBeInTheDocument();
+  });
+
+  it('renders Approve and Reject buttons', () => {
+    render(
+      <InterruptBanner interrupt={toolApprovalInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /approve/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it('calls onResume("approved") when Approve is clicked', async () => {
+    const onResume = vi.fn();
+    render(<InterruptBanner interrupt={toolApprovalInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /approve/i }));
+    expect(onResume).toHaveBeenCalledWith('approved');
+  });
+
+  it('calls onResume("rejected") when Reject is clicked', async () => {
+    const onResume = vi.fn();
+    render(<InterruptBanner interrupt={toolApprovalInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /reject/i }));
+    expect(onResume).toHaveBeenCalledWith('rejected');
+  });
+
+  it('calls onDismiss when the close button is clicked', async () => {
+    const onDismiss = vi.fn();
+    render(<InterruptBanner interrupt={toolApprovalInterrupt} onResume={vi.fn()} onDismiss={onDismiss} />);
+    const closeBtn = screen.getByRole('button', { name: /close/i });
+    await userEvent.click(closeBtn);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('renders the interrupt value text in the body', () => {
+    render(
+      <InterruptBanner interrupt={toolApprovalInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByText(/do you approve/i)).toBeInTheDocument();
+  });
+
+  // NOTE: in production, structured HITLInterruptValue interrupts (with action_requests)
+  // are routed through ChatPage → ChatMessagesView → AIMessageRenderer, NOT through
+  // InterruptBanner.  Those flows are covered by AIMessageRenderer.test.tsx.
+});
+
+describe('InterruptBanner — generic input branch', () => {
+  it('renders "Input Required" for a non-approval interrupt', () => {
+    render(
+      <InterruptBanner interrupt={genericInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByText('Input Required')).toBeInTheDocument();
+  });
+
+  it('renders a text input and Send button', () => {
+    render(
+      <InterruptBanner interrupt={genericInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByRole('textbox', { name: /interrupt response/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+  });
+
+  it('Send button is disabled when input is empty', () => {
+    render(
+      <InterruptBanner interrupt={genericInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+  });
+
+  it('calls onResume with the typed text when Send is clicked', async () => {
+    const onResume = vi.fn();
+    render(<InterruptBanner interrupt={genericInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+    const input = screen.getByRole('textbox', { name: /interrupt response/i });
+    await userEvent.type(input, 'JSON format please');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(onResume).toHaveBeenCalledWith('JSON format please');
+  });
+
+  it('calls onResume when Enter is pressed in the input', async () => {
+    const onResume = vi.fn();
+    render(<InterruptBanner interrupt={genericInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+    const input = screen.getByRole('textbox', { name: /interrupt response/i });
+    await userEvent.type(input, 'My response');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onResume).toHaveBeenCalledWith('My response');
+  });
+
+  it('does NOT call onResume on Enter when input is empty', () => {
+    const onResume = vi.fn();
+    render(<InterruptBanner interrupt={genericInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+    const input = screen.getByRole('textbox', { name: /interrupt response/i });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onResume).not.toHaveBeenCalled();
+  });
+});
+
+describe('InterruptBanner — MCP auth branch', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('open', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the Authenticate button for mcp_auth_required', () => {
+    render(
+      <InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /authenticate/i })).toBeInTheDocument();
+  });
+
+  it('does NOT render Approve / Reject buttons for MCP auth', () => {
+    render(
+      <InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /approve/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reject/i })).not.toBeInTheDocument();
+  });
+
+  it('opens the OAuth popup when Authenticate is clicked', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ authorize_url: 'https://oauth.example.com/auth' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    render(<InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /authenticate/i }));
+    await waitFor(() => {
+      expect(vi.mocked(open)).toHaveBeenCalledWith(
+        'https://oauth.example.com/auth',
+        'mcp-oauth',
+        expect.stringContaining('width='),
+      );
+    });
+  });
+
+  it('shows an error when the connect request fails', async () => {
+    // Empty body → InterruptBanner renders "Connect failed (401)" as the error
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('', { status: 401 }),
+    );
+    render(<InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /authenticate/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/connect failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows Continue button after mcp_oauth_done postMessage + connected status', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />);
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: 'mcp_oauth_done', mcp_name: 'github' },
+        origin: window.location.origin,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+    });
+  });
+
+  it('ignores mcp_oauth_done postMessage from a different origin', async () => {
+    render(<InterruptBanner interrupt={mcpAuthInterrupt} onResume={vi.fn()} onDismiss={vi.fn()} />);
+
+    // Fire the same message type but from an untrusted origin
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: 'mcp_oauth_done', mcp_name: 'github' },
+        origin: 'https://evil.example.com',
+      }),
+    );
+
+    // Continue button must NOT appear — cross-origin message must be ignored
+    await new Promise((r) => setTimeout(r, 100));
+    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onResume("continue") when Continue is clicked', async () => {
+    const onResume = vi.fn();
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(<InterruptBanner interrupt={mcpAuthInterrupt} onResume={onResume} onDismiss={vi.fn()} />);
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: 'mcp_oauth_done', mcp_name: 'github' },
+        origin: window.location.origin,
+      }),
+    );
+
+    await waitFor(() => screen.getByRole('button', { name: /continue/i }));
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onResume).toHaveBeenCalledWith('continue');
+  });
+});

--- a/src/frontend/hooks/useStreamingAPI.test.ts
+++ b/src/frontend/hooks/useStreamingAPI.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import type { Message } from '@langchain/langgraph-sdk';
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import chatsReducer, { addChat } from '../redux/slices/chats';
+import configReducer from '../redux/slices/config';
+import personalizationReducer from '../redux/slices/personalization';
+import toastsReducer from '../redux/slices/toasts';
+import userSettingsReducer, { addAlwaysAllowedTool } from '../redux/slices/userSettings';
+import { useStreamingAPI } from './useStreamingAPI';
+
+// ── Store factory ─────────────────────────────────────────────────────────────
+
+function makeStore(preloadedState?: Record<string, unknown>) {
+  return configureStore({
+    reducer: {
+      chats: chatsReducer,
+      config: configReducer,
+      personalization: personalizationReducer,
+      toasts: toastsReducer,
+      userSettings: userSettingsReducer,
+    },
+    preloadedState,
+  });
+}
+
+function makeWrapper(store: ReturnType<typeof makeStore>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store }, children);
+  };
+}
+
+const THREAD_ID = 'test-thread';
+
+function seedChat(store: ReturnType<typeof makeStore>) {
+  store.dispatch(
+    addChat({
+      id: THREAD_ID,
+      title: 'Test',
+      timestamp: new Date().toISOString(),
+      preview: '',
+      messages: [],
+      historicalActivities: {},
+      feedback: {},
+    }),
+  );
+}
+
+// ── checkAndAutoApprove ───────────────────────────────────────────────────────
+
+describe('useStreamingAPI — checkAndAutoApprove', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    store = makeStore();
+    seedChat(store);
+  });
+
+  it('returns allAutoApproved=true when all action_requests are in alwaysAllowedTools', () => {
+    store.dispatch(addAlwaysAllowedTool('create_pr'));
+    store.dispatch(addAlwaysAllowedTool('web_search'));
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const interruptValue = {
+      action_requests: [
+        { name: 'create_pr', args: {} },
+        { name: 'web_search', args: {} },
+      ],
+      review_configs: [],
+    };
+
+    const { allAutoApproved, decisions } = result.current.checkAndAutoApprove(interruptValue);
+    expect(allAutoApproved).toBe(true);
+    expect(decisions.every((d) => d.type === 'approve')).toBe(true);
+  });
+
+  it('returns allAutoApproved=false when any action_request is not in alwaysAllowedTools', () => {
+    store.dispatch(addAlwaysAllowedTool('web_search'));
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const interruptValue = {
+      action_requests: [
+        { name: 'create_pr', args: {} }, // NOT allowed
+        { name: 'web_search', args: {} }, // allowed
+      ],
+      review_configs: [],
+    };
+
+    const { allAutoApproved } = result.current.checkAndAutoApprove(interruptValue);
+    expect(allAutoApproved).toBe(false);
+  });
+
+  it('auto-approves when the subagent_type arg matches an allowed tool', () => {
+    store.dispatch(addAlwaysAllowedTool('analyst'));
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const interruptValue = {
+      action_requests: [{ name: 'task', args: { subagent_type: 'analyst' } }],
+      review_configs: [],
+    };
+
+    const { allAutoApproved } = result.current.checkAndAutoApprove(interruptValue);
+    expect(allAutoApproved).toBe(true);
+  });
+
+  it('returns allAutoApproved=true for an empty action_requests list', () => {
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const { allAutoApproved } = result.current.checkAndAutoApprove({
+      action_requests: [],
+      review_configs: [],
+    });
+    expect(allAutoApproved).toBe(true);
+  });
+
+  it('returns allAutoApproved=false when alwaysAllowedTools is empty', () => {
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const interruptValue = {
+      action_requests: [{ name: 'create_pr', args: {} }],
+      review_configs: [],
+    };
+
+    const { allAutoApproved } = result.current.checkAndAutoApprove(interruptValue);
+    expect(allAutoApproved).toBe(false);
+  });
+
+  // NOTE: the autoApproveAllTools flag bypass is handled at the ChatPage level
+  // (ChatPage.tsx's useEffect calls resumeWithDecisions directly when the flag is true)
+  // rather than inside checkAndAutoApprove itself.  The E2E suite (auto-approve.spec.ts)
+  // covers that path end-to-end.
+});
+
+// ── Initial state & stop() ────────────────────────────────────────────────────
+
+describe('useStreamingAPI — initial state and stop()', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    store = makeStore();
+    seedChat(store);
+    vi.stubGlobal('fetch', vi.fn()); // prevent real network calls
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts idle with null pendingInterrupt and retryCount 0', () => {
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.pendingInterrupt).toBeNull();
+    expect(result.current.retryCount).toBe(0);
+    expect(result.current.wasInterrupted).toBe(false);
+  });
+
+  it('stop() is safe to call when idle (no error thrown)', () => {
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    // stop() on an idle hook should not throw and should leave state unchanged
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('setMessages() updates the messages visible in the hook', () => {
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    const fakeMsg = { type: 'ai', content: 'injected', id: 'injected-1', tool_calls: [] };
+    act(() => {
+      result.current.setMessages([fakeMsg as Parameters<typeof result.current.setMessages>[0][number]]);
+    });
+
+    // The hook exposes the messages it was given
+    expect(result.current.messages).toHaveLength(1);
+    expect((result.current.messages[0] as { id: string }).id).toBe('injected-1');
+  });
+
+  it('submit() transitions isLoading to true while a stream is in flight', async () => {
+    // Return a stream that never resolves so we can observe the loading state
+    vi.mocked(fetch).mockImplementationOnce(
+      () => new Promise(() => { /* never resolves — allows us to observe isLoading: true */ }),
+    );
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+
+    // submit() takes { messages: Message[] }; seed with a human message so the hook
+    // proceeds past the "empty message text" guard and actually calls fetch
+    const userMessage = {
+      type: 'human',
+      content: 'hello world',
+      id: 'user-msg-1',
+    } as unknown as Message;
+
+    act(() => void result.current.submit({ messages: [userMessage] }));
+
+    // isLoading should become true once the hook's setStreamingState fires
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Clean up the in-flight request
+    act(() => result.current.stop());
+  });
+});

--- a/src/frontend/lib/streaming/SSEProcessor.test.ts
+++ b/src/frontend/lib/streaming/SSEProcessor.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SSEProcessor } from './SSEProcessor';
+
+function makeData(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+describe('SSEProcessor', () => {
+  let proc: SSEProcessor;
+
+  beforeEach(() => {
+    proc = new SSEProcessor();
+  });
+
+  // ── Token chunk ──────────────────────────────────────────────────────────
+  it('parses a token chunk', () => {
+    const events = proc.feed(makeData({ type: 'token', content: 'Hello', chunk_id: 0 }));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'chunk', data: { type: 'token', content: 'Hello', chunk_id: 0 } });
+  });
+
+  // ── Interrupt chunk (HITLInterruptValue object) ──────────────────────────
+  it('parses an interrupt chunk with object value', () => {
+    const value = {
+      action_requests: [{ name: 'create_pr', args: {} }],
+      review_configs: [{ action_name: 'create_pr', allowed_decisions: ['approve', 'reject'] }],
+    };
+    const events = proc.feed(
+      makeData({ type: 'interrupt', content: { value, resumable: true }, chunk_id: 1 }),
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    // Explicit kind assertion first — guards below won't silently pass on wrong shape
+    expect(ev.kind).toBe('chunk');
+    if (ev.kind === 'chunk') {
+      expect(ev.data.type).toBe('interrupt');
+      if (ev.data.type === 'interrupt') {
+        expect(ev.data.content.resumable).toBe(true);
+        expect(ev.data.content.value).toMatchObject(value);
+      }
+    }
+  });
+
+  // ── Interrupt chunk (resumable: false) ───────────────────────────────────
+  it('preserves resumable: false on an interrupt chunk', () => {
+    const events = proc.feed(
+      makeData({ type: 'interrupt', content: { value: 'Confirm?', resumable: false }, chunk_id: 3 }),
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.kind).toBe('chunk');
+    if (ev.kind === 'chunk') {
+      expect(ev.data.type).toBe('interrupt');
+      if (ev.data.type === 'interrupt') {
+        expect(ev.data.content.resumable).toBe(false);
+      }
+    }
+  });
+
+  // ── Interrupt chunk (plain string value preserved) ───────────────────────
+  it('preserves a plain-text (non-JSON) interrupt value as a string', () => {
+    const events = proc.feed(
+      makeData({
+        type: 'interrupt',
+        content: { value: 'Do you approve this action?', resumable: true },
+        chunk_id: 99,
+      }),
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    // Explicit kind assertion first — guard below won't silently pass on wrong shape
+    expect(ev.kind).toBe('chunk');
+    if (ev.kind === 'chunk') {
+      expect(ev.data.type).toBe('interrupt');
+      if (ev.data.type === 'interrupt') {
+        expect(ev.data.content.value).toBe('Do you approve this action?');
+      }
+    }
+  });
+
+  // ── Interrupt chunk (JSON string value unwrapped) ─────────────────────────
+  it('unwraps a JSON string interrupt value into an object', () => {
+    const rawValue = { action_requests: [], review_configs: [] };
+    const events = proc.feed(
+      makeData({
+        type: 'interrupt',
+        content: { value: JSON.stringify(rawValue), resumable: true },
+        chunk_id: 2,
+      }),
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    // Explicit kind assertion first — guard below won't silently pass on wrong shape
+    expect(ev.kind).toBe('chunk');
+    if (ev.kind === 'chunk') {
+      expect(ev.data.type).toBe('interrupt');
+      if (ev.data.type === 'interrupt') {
+        expect(ev.data.content.value).toMatchObject(rawValue);
+      }
+    }
+  });
+
+  // ── Interrupt chunk (numeric value → fallback empty object) ───────────────
+  it('falls back to {} when the interrupt value is neither an object nor a string', () => {
+    const events = proc.feed(
+      makeData({ type: 'interrupt', content: { value: 42, resumable: true }, chunk_id: 5 }),
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.kind).toBe('chunk');
+    if (ev.kind === 'chunk') {
+      expect(ev.data.type).toBe('interrupt');
+      if (ev.data.type === 'interrupt') {
+        expect(ev.data.content.value).toEqual({});
+      }
+    }
+  });
+
+  // ── Message chunk ─────────────────────────────────────────────────────────
+  it('parses a message chunk', () => {
+    const msg = { type: 'ai', content: 'Done', tool_calls: [], id: 'msg-1' };
+    const events = proc.feed(makeData({ type: 'message', content: msg, chunk_id: 3 }));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'chunk', data: { type: 'message' } });
+  });
+
+  // ── mcp_status via event: line ────────────────────────────────────────────
+  it('parses an mcp_status event from the event: field', () => {
+    const raw = `event: mcp_status\ndata: ${JSON.stringify({ tool: 'github', status: 'running' })}\n\n`;
+    const events = proc.feed(raw);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'mcp_status', data: { tool: 'github', status: 'running' } });
+  });
+
+  // ── mcp_status via type field in data ─────────────────────────────────────
+  it('parses an mcp_status event from the type field in data', () => {
+    const events = proc.feed(makeData({ type: 'mcp_status', tool: 'github', status: 'done' }));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'mcp_status', data: { tool: 'github', status: 'done' } });
+  });
+
+  // ── Metadata chunk ───────────────────────────────────────────────────────
+  it('parses a metadata chunk', () => {
+    const events = proc.feed(
+      makeData({ type: 'metadata', content: { run_id: 'r1', trace_id: 't1', thread_id: 'th1' } }),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'metadata',
+      data: { run_id: 'r1', trace_id: 't1', thread_id: 'th1' },
+    });
+  });
+
+  // ── Metadata missing fields → not parsed as metadata ─────────────────────
+  it('does not parse metadata when required fields are missing', () => {
+    const events = proc.feed(
+      makeData({ type: 'metadata', content: { run_id: 'r1' } }),
+    );
+    // No run_id+trace_id+thread_id → falls through to error (invalid message shape)
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('error');
+  });
+
+  // ── [DONE] sentinel ───────────────────────────────────────────────────────
+  it('emits a done event for [DONE]', () => {
+    const events = proc.feed('data: [DONE]\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: 'done' });
+  });
+
+  // ── Invalid JSON → error event ────────────────────────────────────────────
+  it('emits an error event for invalid JSON', () => {
+    const events = proc.feed('data: {this is not json}\n\n');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ kind: 'error', message: expect.stringContaining('Malformed SSE chunk') });
+  });
+
+  // ── Unknown shape → error event ───────────────────────────────────────────
+  it('emits an error event for a valid JSON object with unknown shape', () => {
+    const events = proc.feed(makeData({ type: 'unknown_type', foo: 'bar' }));
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('error');
+  });
+
+  // ── Multi-chunk buffer (split across two feed() calls) ──────────────────
+  it('buffers incomplete SSE data across feed() calls', () => {
+    const fullEvent = `data: ${JSON.stringify({ type: 'token', content: 'hi', chunk_id: 0 })}`;
+    // Feed first half without the trailing \n\n
+    const events1 = proc.feed(fullEvent);
+    expect(events1).toHaveLength(0);
+    // Feed the closing delimiter
+    const events2 = proc.feed('\n\n');
+    expect(events2).toHaveLength(1);
+    expect(events2[0]).toMatchObject({ kind: 'chunk', data: { type: 'token', content: 'hi' } });
+  });
+
+  // ── Multiple events in one feed() call ───────────────────────────────────
+  it('returns multiple events when multiple complete SSE blocks arrive', () => {
+    const block1 = makeData({ type: 'token', content: 'a', chunk_id: 0 });
+    const block2 = makeData({ type: 'token', content: 'b', chunk_id: 1 });
+    const events = proc.feed(block1 + block2);
+    expect(events).toHaveLength(2);
+  });
+
+  // ── reset() clears mid-buffer state ──────────────────────────────────────
+  it('reset() discards buffered incomplete data', () => {
+    const partial = `data: ${JSON.stringify({ type: 'token', content: 'hi', chunk_id: 0 })}`;
+    proc.feed(partial); // no \n\n — stays in buffer
+    proc.reset();
+    const events = proc.feed('\n\n'); // delimiter without prior data
+    expect(events).toHaveLength(0);
+  });
+
+  // ── Comment lines ignored ─────────────────────────────────────────────────
+  it('ignores SSE comment lines (: prefix)', () => {
+    const raw = `: keep-alive\ndata: ${JSON.stringify({ type: 'token', content: 'x', chunk_id: 0 })}\n\n`;
+    const events = proc.feed(raw);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('chunk');
+  });
+});

--- a/src/frontend/lib/streaming/SSEProcessor.ts
+++ b/src/frontend/lib/streaming/SSEProcessor.ts
@@ -4,7 +4,7 @@ import type { HITLInterruptValue } from '@/types/deep-agent';
 export type SSEChunk =
   | { type: 'token'; content: string; chunk_id: number }
   | { type: 'message'; content: Message; chunk_id: number }
-  | { type: 'interrupt'; content: { value: HITLInterruptValue; resumable: boolean }; chunk_id: number };
+  | { type: 'interrupt'; content: { value: HITLInterruptValue | string; resumable: boolean }; chunk_id: number };
 
 export type McpStatusData = {
   tool: string;
@@ -51,13 +51,13 @@ function parseSSEChunkPayload(parsed: unknown): SSEChunk | null {
       try {
         rawValue = JSON.parse(rawValue);
       } catch {
-        rawValue = {};
+        // non-JSON plain-text interrupt value — preserve as string
       }
     }
     return {
       type: 'interrupt',
       content: {
-        value: (isRecord(rawValue) ? rawValue : {}) as unknown as HITLInterruptValue,
+        value: (isRecord(rawValue) || typeof rawValue === 'string' ? rawValue : {}) as HITLInterruptValue | string,
         resumable: contentUnknown.resumable === true,
       },
       chunk_id: chunkIdRaw,

--- a/src/frontend/lib/streaming/StreamingManager.test.ts
+++ b/src/frontend/lib/streaming/StreamingManager.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamingManager } from './StreamingManager';
+import type { StreamCallback } from './StreamingManager';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTokenSSE(content: string, chunkId: number): string {
+  return `data: ${JSON.stringify({ type: 'token', content, chunk_id: chunkId })}\n\n`;
+}
+
+function makeInterruptSSE(value: object | string, chunkId: number): string {
+  return `data: ${JSON.stringify({
+    type: 'interrupt',
+    content: { value, resumable: true },
+    chunk_id: chunkId,
+  })}\n\n`;
+}
+
+function makeStreamResponse(sseBody: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(sseBody));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function makeCallbacks(overrides: Partial<StreamCallback> = {}): StreamCallback {
+  return {
+    onToken: vi.fn(),
+    onMessage: vi.fn(),
+    onInterrupt: vi.fn(),
+    onError: vi.fn(),
+    onDone: vi.fn(),
+    onStatusChange: vi.fn(),
+    onMcpStatus: vi.fn(),
+    onMetadata: vi.fn(),
+    ...overrides,
+  };
+}
+
+const BASE_REQUEST = {
+  message: 'hello',
+  threadId: 'thread-1',
+  userId: 'user-1',
+  apiUrl: 'http://localhost:8080/api/proxy/agent',
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('StreamingManager', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Happy path: token + done ───────────────────────────────────────────────
+  it('calls onToken then onDone for a normal stream', async () => {
+    const sseBody = makeTokenSSE('Hello', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onToken).toHaveBeenCalledWith('Hello');
+    expect(callbacks.onDone).toHaveBeenCalledOnce();
+    expect(callbacks.onError).not.toHaveBeenCalled();
+  });
+
+  // ── Status transitions: connecting → streaming → idle ────────────────────
+  it('emits connecting → streaming → idle status changes', async () => {
+    const sseBody = makeTokenSSE('Hi', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const statuses: string[] = [];
+    const callbacks = makeCallbacks({ onStatusChange: (s) => statuses.push(s) });
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(statuses).toContain('connecting');
+    expect(statuses).toContain('streaming');
+    expect(statuses).toContain('idle');
+  });
+
+  // ── Interrupt chunk → onInterrupt called ─────────────────────────────────
+  it('calls onInterrupt when an interrupt chunk arrives', async () => {
+    const interruptValue = {
+      action_requests: [{ name: 'create_pr', args: {} }],
+      review_configs: [{ action_name: 'create_pr', allowed_decisions: ['approve', 'reject'] }],
+    };
+    const sseBody = makeInterruptSSE(interruptValue, 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onInterrupt).toHaveBeenCalledOnce();
+    const [payload] = vi.mocked(callbacks.onInterrupt).mock.calls[0];
+    expect(payload.resumable).toBe(true);
+    expect(payload.value).toMatchObject(interruptValue);
+  });
+
+  // ── Duplicate chunk_id deduplication ─────────────────────────────────────
+  it('ignores a chunk with a duplicate chunk_id', async () => {
+    const sseBody =
+      makeTokenSSE('First', 5) +
+      makeTokenSSE('Duplicate', 5) + // same chunk_id
+      'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onToken).toHaveBeenCalledTimes(1);
+    expect(callbacks.onToken).toHaveBeenCalledWith('First');
+  });
+
+  // ── HTTP error → onError + status 'error' ────────────────────────────────
+  it('calls onError and emits error status for a non-2xx response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response('Internal Server Error', { status: 500 }),
+    );
+
+    const statuses: string[] = [];
+    const callbacks = makeCallbacks({ onStatusChange: (s) => statuses.push(s) });
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onError).toHaveBeenCalledOnce();
+    expect(statuses).toContain('error');
+  });
+
+  // ── cancel() → AbortError → status 'cancelled' ───────────────────────────
+  it('emits cancelled status when cancel() is called during stream', async () => {
+    let rejectFn!: (e: Error) => void;
+    vi.mocked(fetch).mockImplementationOnce(
+      (_url, opts) =>
+        new Promise<Response>((_resolve, reject) => {
+          rejectFn = reject;
+          opts?.signal?.addEventListener('abort', () => {
+            const err = new Error('Aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+
+    const statuses: string[] = [];
+    const callbacks = makeCallbacks({ onStatusChange: (s) => statuses.push(s) });
+    const manager = new StreamingManager();
+
+    const streamPromise = manager.stream(BASE_REQUEST, callbacks);
+    manager.cancel();
+    await streamPromise;
+
+    expect(statuses).toContain('cancelled');
+    expect(callbacks.onError).not.toHaveBeenCalled();
+  });
+
+  // ── getStatus() reflects current state ───────────────────────────────────
+  it('getStatus() returns idle before and after a completed stream', async () => {
+    const sseBody = makeTokenSSE('Hi', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const manager = new StreamingManager();
+    expect(manager.getStatus()).toBe('idle');
+    await manager.stream(BASE_REQUEST, makeCallbacks());
+    expect(manager.getStatus()).toBe('idle');
+  });
+
+  // ── Multiple tokens in one stream ────────────────────────────────────────
+  it('calls onToken for each token chunk in the stream', async () => {
+    const sseBody =
+      makeTokenSSE('Hello', 0) +
+      makeTokenSSE(' world', 1) +
+      'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onToken).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(callbacks.onToken).mock.calls[0][0]).toBe('Hello');
+    expect(vi.mocked(callbacks.onToken).mock.calls[1][0]).toBe(' world');
+  });
+
+  // ── No reader from response body ─────────────────────────────────────────
+  it('calls onError when response body is null', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 200 }),
+    );
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onError).toHaveBeenCalledOnce();
+  });
+
+  // ── Plain-string interrupt propagated to onInterrupt ─────────────────────
+  it('propagates a plain-string interrupt value to onInterrupt', async () => {
+    const sseBody = makeInterruptSSE('Approve this action?', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const callbacks = makeCallbacks();
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, callbacks);
+
+    expect(callbacks.onInterrupt).toHaveBeenCalledOnce();
+    const [payload] = vi.mocked(callbacks.onInterrupt).mock.calls[0];
+    expect(payload.resumable).toBe(true);
+    expect(payload.value).toBe('Approve this action?');
+  });
+
+  // ── cancel() between streams resets state ────────────────────────────────
+  // Note: tests that cancel() on an idle manager resets the chunk ID set,
+  // allowing the same IDs to be reused in a subsequent stream.
+  it('cancel() resets processedChunkIds so next stream can use the same ids', async () => {
+    const sseBody = makeTokenSSE('Re-used', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(makeStreamResponse(sseBody))
+      .mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const manager = new StreamingManager();
+    const cb1 = makeCallbacks();
+    await manager.stream(BASE_REQUEST, cb1);
+    manager.cancel();
+
+    const cb2 = makeCallbacks();
+    await manager.stream(BASE_REQUEST, cb2);
+
+    // chunk_id 0 was used in first stream; after cancel+reset it should work again
+    expect(cb2.onToken).toHaveBeenCalledWith('Re-used');
+  });
+});

--- a/src/frontend/lib/streaming/StreamingManager.test.ts
+++ b/src/frontend/lib/streaming/StreamingManager.test.ts
@@ -143,11 +143,9 @@ describe('StreamingManager', () => {
 
   // ── cancel() → AbortError → status 'cancelled' ───────────────────────────
   it('emits cancelled status when cancel() is called during stream', async () => {
-    let rejectFn!: (e: Error) => void;
     vi.mocked(fetch).mockImplementationOnce(
       (_url, opts) =>
         new Promise<Response>((_resolve, reject) => {
-          rejectFn = reject;
           opts?.signal?.addEventListener('abort', () => {
             const err = new Error('Aborted');
             err.name = 'AbortError';

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -22,7 +22,7 @@ export interface StreamRequest {
 export type StreamStatus = 'idle' | 'connecting' | 'streaming' | 'error' | 'cancelled';
 
 export interface InterruptPayload {
-  value: HITLInterruptValue;
+  value: HITLInterruptValue | string;
   resumable: boolean;
 }
 

--- a/src/frontend/redux/slices/chats.test.ts
+++ b/src/frontend/redux/slices/chats.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import type { Message } from '@langchain/langgraph-sdk';
+import chatsReducer, {
+  addChat,
+  appendMessageToChat,
+  clearAllChats,
+  deleteChat,
+  mergeToolResult,
+  resolveAllPendingToolCalls,
+  setMessageFeedback,
+  updateChat,
+  updateLastMessageInChat,
+  updateStreamingState,
+  type ChatsState,
+  type ChatItem,
+} from './chats';
+
+/** Minimal fixture shape that matches the runtime duck-type expected by chats slice reducers. */
+type TestToolCall = { id: string; name: string; args: Record<string, unknown>; content?: string };
+type TestMessage = {
+  type: 'ai' | 'human';
+  content: string;
+  id: string;
+  tool_calls?: TestToolCall[];
+};
+/** Cast a TestMessage fixture to the LangGraph Message type used by the chats slice. */
+function asMsg(m: TestMessage): Message {
+  return m as unknown as Message;
+}
+
+// ── Factory helpers ───────────────────────────────────────────────────────────
+
+function makeChat(id: string, overrides: Partial<ChatItem> = {}): ChatItem {
+  return {
+    id,
+    title: `Chat ${id}`,
+    timestamp: new Date().toISOString(),
+    preview: '',
+    messages: [],
+    historicalActivities: {},
+    feedback: {},
+    ...overrides,
+  };
+}
+
+function initialState(): ChatsState {
+  return chatsReducer(undefined, { type: '@@INIT' });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('chats slice — addChat', () => {
+  it('adds a chat to the front of the list', () => {
+    const chat = makeChat('c1');
+    const s = chatsReducer(initialState(), addChat(chat));
+    expect(s.chats[0].id).toBe('c1');
+  });
+});
+
+describe('chats slice — updateChat', () => {
+  it('updates fields on a matching chat', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, updateChat({ id: 'c1', updates: { title: 'New Title' } }));
+    expect(s.chats[0].title).toBe('New Title');
+  });
+
+  it('is a no-op when the chat id is not found', () => {
+    const base = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const s = chatsReducer(base, updateChat({ id: 'nonexistent', updates: { title: 'X' } }));
+    expect(s.chats[0].title).toBe('Chat c1');
+  });
+});
+
+describe('chats slice — deleteChat', () => {
+  it('removes the chat from the list', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, deleteChat('c1'));
+    expect(s.chats).toHaveLength(0);
+  });
+});
+
+describe('chats slice — clearAllChats', () => {
+  it('empties the chats list and clears streamingStates', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, clearAllChats());
+    expect(s.chats).toHaveLength(0);
+    expect(s.streamingStates).toEqual({});
+  });
+});
+
+describe('chats slice — appendMessageToChat', () => {
+  it('appends a message to the correct chat', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = { type: 'ai', content: 'Hello', tool_calls: [], id: 'msg-1' };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    expect(s.chats[0].messages).toHaveLength(1);
+    expect((s.chats[0].messages[0] as TestMessage).id).toBe('msg-1');
+  });
+
+  it('is idempotent when the same message id is appended twice', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = { type: 'ai', content: 'Hello', tool_calls: [], id: 'msg-1' };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    expect(s.chats[0].messages).toHaveLength(1);
+  });
+
+  it('is a no-op when the chat does not exist', () => {
+    const stub: TestMessage = { type: 'ai', content: '', id: 'x' };
+    const s = chatsReducer(
+      initialState(),
+      appendMessageToChat({ chatId: 'missing', message: asMsg(stub) }),
+    );
+    expect(s.chats).toHaveLength(0);
+  });
+});
+
+describe('chats slice — updateLastMessageInChat', () => {
+  it('concatenates new content onto the last message', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = { type: 'ai', content: 'Hello', tool_calls: [], id: 'm1' };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, updateLastMessageInChat({ chatId: 'c1', content: ' world' }));
+    expect((s.chats[0].messages[0] as TestMessage).content).toBe('Hello world');
+  });
+
+  it('is a no-op when the chat has no messages', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, updateLastMessageInChat({ chatId: 'c1', content: 'x' }));
+    expect(s.chats[0].messages).toHaveLength(0);
+  });
+});
+
+describe('chats slice — mergeToolResult', () => {
+  it('finds the matching tool_call_id and sets content', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = {
+      type: 'ai',
+      content: '',
+      tool_calls: [{ id: 'tc-1', name: 'search', args: {} }],
+      id: 'm1',
+    };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, mergeToolResult({ chatId: 'c1', toolCallId: 'tc-1', content: 'result data' }));
+
+    const toolCall = (s.chats[0].messages[0] as TestMessage).tool_calls![0];
+    expect(toolCall.content).toBe('result data');
+  });
+
+  it('is a no-op when the tool_call_id is not found', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = {
+      type: 'ai',
+      content: '',
+      tool_calls: [{ id: 'tc-1', name: 'search', args: {} }],
+      id: 'm1',
+    };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, mergeToolResult({ chatId: 'c1', toolCallId: 'missing', content: 'x' }));
+    // tc-1 still has no content
+    expect((s.chats[0].messages[0] as TestMessage).tool_calls![0].content).toBeUndefined();
+  });
+});
+
+describe('chats slice — resolveAllPendingToolCalls', () => {
+  it('sets content to empty string on all tool_calls with null content', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = {
+      type: 'ai',
+      content: '',
+      tool_calls: [
+        { id: 'tc-1', name: 'a', args: {} },
+        { id: 'tc-2', name: 'b', args: {} },
+      ],
+      id: 'm1',
+    };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, resolveAllPendingToolCalls({ chatId: 'c1' }));
+
+    const tcs = (s.chats[0].messages[0] as TestMessage).tool_calls!;
+    expect(tcs[0].content).toBe('');
+    expect(tcs[1].content).toBe('');
+  });
+
+  it('does not overwrite a tool_call that already has content', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const msg: TestMessage = {
+      type: 'ai',
+      content: '',
+      tool_calls: [{ id: 'tc-1', name: 'a', args: {}, content: 'already set' }],
+      id: 'm1',
+    };
+    s = chatsReducer(s, appendMessageToChat({ chatId: 'c1', message: asMsg(msg) }));
+    s = chatsReducer(s, resolveAllPendingToolCalls({ chatId: 'c1' }));
+
+    const tc = (s.chats[0].messages[0] as TestMessage).tool_calls![0];
+    expect(tc.content).toBe('already set');
+  });
+});
+
+describe('chats slice — setMessageFeedback', () => {
+  it('stores up/down feedback for a message', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, setMessageFeedback({ chatId: 'c1', messageId: 'msg-1', feedback: 'up' }));
+    expect(s.chats[0].feedback['msg-1']).toBe('up');
+  });
+
+  it('removes feedback when null is passed', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, setMessageFeedback({ chatId: 'c1', messageId: 'msg-1', feedback: 'down' }));
+    s = chatsReducer(s, setMessageFeedback({ chatId: 'c1', messageId: 'msg-1', feedback: null }));
+    expect(s.chats[0].feedback['msg-1']).toBeUndefined();
+  });
+});
+
+describe('chats slice — updateStreamingState', () => {
+  it('merges partial streaming state for a chat', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(
+      s,
+      updateStreamingState({ chatId: 'c1', state: { isLoading: true, error: null } }),
+    );
+    expect(s.streamingStates['c1'].isLoading).toBe(true);
+  });
+
+  it('stores a pendingInterrupt in streaming state', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    const interrupt = { value: 'Approve this action?', resumable: true };
+    s = chatsReducer(
+      s,
+      updateStreamingState({ chatId: 'c1', state: { pendingInterrupt: interrupt } }),
+    );
+    expect(s.streamingStates['c1'].pendingInterrupt).toEqual(interrupt);
+  });
+
+  it('creates a new streaming state entry when none exists', () => {
+    const s = chatsReducer(
+      initialState(),
+      updateStreamingState({ chatId: 'new-chat', state: { isLoading: true } }),
+    );
+    expect(s.streamingStates['new-chat'].isLoading).toBe(true);
+    // defaults are preserved
+    expect(s.streamingStates['new-chat'].pendingInterrupt).toBeNull();
+  });
+});

--- a/src/frontend/redux/slices/userSettings.test.ts
+++ b/src/frontend/redux/slices/userSettings.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userSettingsReducer, {
+  addAlwaysAllowedTool,
+  clearAlwaysAllowedTools,
+  removeAlwaysAllowedTool,
+  setAutoApproveAllTools,
+  setConfigDefaults,
+  setDebugMode,
+  setTheme,
+  toggleAutoApproveAllTools,
+  toggleTheme,
+} from './userSettings';
+
+function freshState() {
+  // localStorage may have data from other tests; clear it first
+  localStorage.removeItem('template-ui-settings');
+  return userSettingsReducer(undefined, { type: '@@INIT' });
+}
+
+describe('userSettings slice', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ── Theme ──────────────────────────────────────────────────────────────────
+  it('setTheme sets the theme and persists to localStorage', () => {
+    const s = userSettingsReducer(freshState(), setTheme('light'));
+    expect(s.theme).toBe('light');
+    const stored = JSON.parse(localStorage.getItem('template-ui-settings')!);
+    expect(stored.theme).toBe('light');
+  });
+
+  it('toggleTheme flips from dark to light', () => {
+    const base = userSettingsReducer(freshState(), setTheme('dark'));
+    const s = userSettingsReducer(base, toggleTheme());
+    expect(s.theme).toBe('light');
+  });
+
+  it('toggleTheme flips from light to dark', () => {
+    const base = userSettingsReducer(freshState(), setTheme('light'));
+    const s = userSettingsReducer(base, toggleTheme());
+    expect(s.theme).toBe('dark');
+  });
+
+  // ── Always-allowed tools ───────────────────────────────────────────────────
+  it('addAlwaysAllowedTool adds a tool name', () => {
+    const s = userSettingsReducer(freshState(), addAlwaysAllowedTool('github_search'));
+    expect(s.alwaysAllowedTools).toContain('github_search');
+  });
+
+  it('addAlwaysAllowedTool is idempotent — no duplicates', () => {
+    let s = userSettingsReducer(freshState(), addAlwaysAllowedTool('github_search'));
+    s = userSettingsReducer(s, addAlwaysAllowedTool('github_search'));
+    expect(s.alwaysAllowedTools.filter((t) => t === 'github_search')).toHaveLength(1);
+  });
+
+  it('removeAlwaysAllowedTool removes the tool', () => {
+    let s = userSettingsReducer(freshState(), addAlwaysAllowedTool('github_search'));
+    s = userSettingsReducer(s, addAlwaysAllowedTool('web_search'));
+    s = userSettingsReducer(s, removeAlwaysAllowedTool('github_search'));
+    expect(s.alwaysAllowedTools).not.toContain('github_search');
+    expect(s.alwaysAllowedTools).toContain('web_search');
+  });
+
+  it('clearAlwaysAllowedTools empties the list', () => {
+    let s = userSettingsReducer(freshState(), addAlwaysAllowedTool('a'));
+    s = userSettingsReducer(s, addAlwaysAllowedTool('b'));
+    s = userSettingsReducer(s, clearAlwaysAllowedTools());
+    expect(s.alwaysAllowedTools).toHaveLength(0);
+  });
+
+  // ── Auto-approve all tools ─────────────────────────────────────────────────
+  it('setAutoApproveAllTools sets the flag', () => {
+    const s = userSettingsReducer(freshState(), setAutoApproveAllTools(true));
+    expect(s.autoApproveAllTools).toBe(true);
+  });
+
+  it('toggleAutoApproveAllTools flips the flag', () => {
+    let s = userSettingsReducer(freshState(), setAutoApproveAllTools(false));
+    s = userSettingsReducer(s, toggleAutoApproveAllTools());
+    expect(s.autoApproveAllTools).toBe(true);
+    s = userSettingsReducer(s, toggleAutoApproveAllTools());
+    expect(s.autoApproveAllTools).toBe(false);
+  });
+
+  // ── Debug mode ────────────────────────────────────────────────────────────
+  it('setDebugMode sets debugMode and records user override', () => {
+    const s = userSettingsReducer(freshState(), setDebugMode(true));
+    expect(s.debugMode).toBe(true);
+    expect(s._userOverrides.debugMode).toBe(true);
+  });
+
+  it('setConfigDefaults applies debug_mode_default when no user override', () => {
+    const s = userSettingsReducer(freshState(), setConfigDefaults({ debug_mode_default: true }));
+    expect(s.debugMode).toBe(true);
+  });
+
+  it('setConfigDefaults does NOT override when user has explicitly set debug mode', () => {
+    let s = userSettingsReducer(freshState(), setDebugMode(false));
+    s = userSettingsReducer(s, setConfigDefaults({ debug_mode_default: true }));
+    // User said false, config says true — user wins
+    expect(s.debugMode).toBe(false);
+  });
+
+  // ── localStorage persistence ───────────────────────────────────────────────
+  it('settings changes are persisted to localStorage', () => {
+    userSettingsReducer(freshState(), addAlwaysAllowedTool('my_tool'));
+    const stored = JSON.parse(localStorage.getItem('template-ui-settings')!);
+    expect(stored.alwaysAllowedTools).toContain('my_tool');
+  });
+
+  it('falls back to defaults when localStorage contains malformed JSON', async () => {
+    localStorage.setItem('template-ui-settings', '{this is not valid json}');
+    // Re-import forces loadSettings() to run fresh with the malformed data in localStorage
+    vi.resetModules();
+    const { default: freshReducer } = await import('./userSettings');
+    const s = freshReducer(undefined, { type: '@@INIT' });
+    expect(s.theme).toBe('dark'); // default
+    expect(s.alwaysAllowedTools).toEqual([]); // default
+  });
+
+  it('loads persisted settings from localStorage on init', async () => {
+    // Populate localStorage before the module is re-imported
+    localStorage.setItem(
+      'template-ui-settings',
+      JSON.stringify({
+        theme: 'light',
+        alwaysAllowedTools: ['saved_tool'],
+        autoApproveAllTools: false,
+        _userOverrides: {},
+        debugMode: false,
+      }),
+    );
+    // Reset the module cache so userSettings.ts calls loadSettings() again
+    // with the updated localStorage, re-computing initialState.
+    vi.resetModules();
+    const { default: freshReducer } = await import('./userSettings');
+    const s = freshReducer(undefined, { type: '@@INIT' });
+    expect(s.theme).toBe('light');
+    expect(s.alwaysAllowedTools).toContain('saved_tool');
+  });
+});

--- a/src/frontend/test-utils/setup.ts
+++ b/src/frontend/test-utils/setup.ts
@@ -2,6 +2,70 @@ import '@testing-library/jest-dom';
 import { expect } from 'vitest';
 import { configureAxe, toHaveNoViolations } from 'jest-axe';
 
+// Node 26+ defines localStorage/sessionStorage as getter-based experimental
+// Web Storage on globalThis, but jsdom 29 does not override them.  Without
+// --localstorage-file the Node getter returns undefined, so any test code (or
+// production code running at module-load time) that calls localStorage.getItem
+// etc. would throw.  Replace both with simple in-memory implementations that
+// behave like a browser Storage object.
+class InMemoryStorage implements Storage {
+  private _store: Record<string, string> = {};
+
+  get length(): number {
+    return Object.keys(this._store).length;
+  }
+
+  key(index: number): string | null {
+    return Object.keys(this._store)[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this._store, key)
+      ? this._store[key]
+      : null;
+  }
+
+  setItem(key: string, value: string): void {
+    this._store[String(key)] = String(value);
+  }
+
+  removeItem(key: string): void {
+    delete this._store[String(key)];
+  }
+
+  clear(): void {
+    this._store = {};
+  }
+}
+
+// Node 26+ exposes an experimental localStorage getter on globalThis, but
+// it can throw when actually accessed (e.g. no --localstorage-file flag).
+// A simple undefined/null check is insufficient — we must probe the API.
+function isStorageBroken(getter: () => Storage | null | undefined): boolean {
+  try {
+    const s = getter();
+    if (s == null) return true;
+    s.getItem('__vitest_probe__'); // throws on broken Node 26+ experimental storage
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+if (isStorageBroken(() => globalThis.localStorage)) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}
+if (isStorageBroken(() => globalThis.sessionStorage)) {
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}
 // Extend vitest expect with jest-axe matchers
 expect.extend(toHaveNoViolations);
 

--- a/src/frontend/types/deep-agent.test.ts
+++ b/src/frontend/types/deep-agent.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isSubAgentToolCall,
+  extractSubAgentName,
+  extractDelegationText,
+  extractTodosFromMessages,
+  detectArtifactKind,
+} from './deep-agent';
+
+// ── isSubAgentToolCall ────────────────────────────────────────────────────────
+
+describe('isSubAgentToolCall', () => {
+  it('returns true when subagent_type arg is present', () => {
+    expect(isSubAgentToolCall({ name: 'task', args: { subagent_type: 'analyst' } })).toBe(true);
+  });
+
+  it('returns true for a known subagent name "analyst"', () => {
+    expect(isSubAgentToolCall({ name: 'analyst' })).toBe(true);
+  });
+
+  it('returns true for a known subagent name "publisher"', () => {
+    expect(isSubAgentToolCall({ name: 'publisher' })).toBe(true);
+  });
+
+  it('returns false for an unknown name with no subagent_type arg', () => {
+    expect(isSubAgentToolCall({ name: 'web_search', args: {} })).toBe(false);
+  });
+
+  it('returns false when name is "task" but no subagent_type arg', () => {
+    expect(isSubAgentToolCall({ name: 'task', args: {} })).toBe(false);
+  });
+});
+
+// ── extractSubAgentName ───────────────────────────────────────────────────────
+
+describe('extractSubAgentName', () => {
+  it('returns the subagent_type when name is "task"', () => {
+    expect(extractSubAgentName({ name: 'task', args: { subagent_type: 'researcher' } })).toBe('researcher');
+  });
+
+  it('returns the tool name when it is not "task"', () => {
+    expect(extractSubAgentName({ name: 'analyst', args: {} })).toBe('analyst');
+  });
+
+  it('returns "task" when name is "task" but subagent_type is missing', () => {
+    expect(extractSubAgentName({ name: 'task', args: {} })).toBe('task');
+  });
+});
+
+// ── extractDelegationText ─────────────────────────────────────────────────────
+
+describe('extractDelegationText', () => {
+  it('returns string args directly when non-empty', () => {
+    expect(extractDelegationText({ args: '  Search for data  ' })).toBe('Search for data');
+  });
+
+  it('returns null for empty string args', () => {
+    expect(extractDelegationText({ args: '   ' })).toBeNull();
+  });
+
+  it('returns description from object args', () => {
+    expect(extractDelegationText({ args: { description: 'Analyze data' } })).toBe('Analyze data');
+  });
+
+  it('returns null when description is empty', () => {
+    expect(extractDelegationText({ args: { description: '' } })).toBeNull();
+  });
+
+  it('returns null when args is null/undefined', () => {
+    expect(extractDelegationText({ args: undefined })).toBeNull();
+    expect(extractDelegationText({ args: null as any })).toBeNull();
+  });
+});
+
+// ── extractTodosFromMessages ──────────────────────────────────────────────────
+
+describe('extractTodosFromMessages', () => {
+  it('returns todos from the latest write_todos tool call', () => {
+    const messages = [
+      {
+        type: 'ai',
+        tool_calls: [
+          {
+            name: 'write_todos',
+            args: {
+              todos: [
+                { content: 'Research topic', status: 'completed' },
+                { content: 'Draft report', status: 'in_progress' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const todos = extractTodosFromMessages(messages);
+    expect(todos).toHaveLength(2);
+    expect(todos[0].content).toBe('Research topic');
+    expect(todos[0].status).toBe('completed');
+    expect(todos[1].status).toBe('in_progress');
+  });
+
+  it('defaults unknown status to "pending"', () => {
+    const messages = [
+      {
+        type: 'ai',
+        tool_calls: [{ name: 'write_todos', args: { todos: [{ content: 'Task', status: 'weird' }] } }],
+      },
+    ];
+    const todos = extractTodosFromMessages(messages);
+    expect(todos[0].status).toBe('pending');
+  });
+
+  it('returns [] when no messages have write_todos', () => {
+    const messages = [{ type: 'ai', tool_calls: [{ name: 'web_search', args: {} }] }];
+    expect(extractTodosFromMessages(messages)).toEqual([]);
+  });
+
+  it('returns [] for empty messages array', () => {
+    expect(extractTodosFromMessages([])).toEqual([]);
+  });
+
+  it('returns the most recent write_todos when multiple exist', () => {
+    const messages = [
+      {
+        type: 'ai',
+        tool_calls: [{ name: 'write_todos', args: { todos: [{ content: 'Old', status: 'completed' }] } }],
+      },
+      {
+        type: 'ai',
+        tool_calls: [{ name: 'write_todos', args: { todos: [{ content: 'New', status: 'pending' }] } }],
+      },
+    ];
+    // The function iterates from the end (last message first)
+    const todos = extractTodosFromMessages(messages);
+    expect(todos[0].content).toBe('New');
+  });
+});
+
+// ── detectArtifactKind ────────────────────────────────────────────────────────
+
+describe('detectArtifactKind', () => {
+  it('returns "code" for content with a code fence', () => {
+    expect(detectArtifactKind('Here is the code:\n```python\nprint("hi")\n```')).toBe('code');
+  });
+
+  it('returns "json" for valid JSON starting with {', () => {
+    expect(detectArtifactKind('{"key": "value"}')).toBe('json');
+  });
+
+  it('does NOT return "json" for an invalid string that starts with {', () => {
+    // JSON.parse throws → falls through to markdown/text classification
+    expect(detectArtifactKind('{invalid json}')).not.toBe('json');
+  });
+
+  it('returns "json" for valid JSON starting with [', () => {
+    expect(detectArtifactKind('[1,2,3]')).toBe('json');
+  });
+
+  it('returns "markdown" for content with headers', () => {
+    expect(detectArtifactKind('# Title\nSome text')).toBe('markdown');
+  });
+
+  it('returns "markdown" for content with bold text', () => {
+    expect(detectArtifactKind('This is **bold** text')).toBe('markdown');
+  });
+
+  it('returns "markdown" for content with a list', () => {
+    expect(detectArtifactKind('- item one\n- item two')).toBe('markdown');
+  });
+
+  it('returns "text" for plain prose', () => {
+    expect(detectArtifactKind('The weather is nice today.')).toBe('text');
+  });
+
+  it('returns "text" for an empty string', () => {
+    expect(detectArtifactKind('')).toBe('text');
+  });
+});

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildTestServer } from './test-utils.js';
+import { resetSettings } from '../utils/settings.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeSSEResponse(sseBody: string): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(sseBody));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+/** Stub fetch with sequential responses. Unstubs in afterEach. */
+function stubFetch(...responses: Response[]) {
+  const mock = vi.fn();
+  let idx = 0;
+  mock.mockImplementation(() => {
+    const resp = responses[idx] ?? okJson({});
+    idx++;
+    return Promise.resolve(resp);
+  });
+  vi.stubGlobal('fetch', mock);
+  return mock;
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.FEATURE_AUTH_ENABLED = 'false';
+  // auth-check.plugin.ts reads AUTH_ENABLED (legacy) to bypass session auth.
+  // Without this, the preHandler hook redirects all /api/proxy/* requests to /login.
+  process.env.AUTH_ENABLED = 'false';
+  process.env.AGENT_HOST = 'http://127.0.0.1:19999';
+  resetSettings();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.AGENT_HOST;
+  delete process.env.AUTH_ENABLED;
+  resetSettings();
+});
+
+// ── GET /api/health/agent ─────────────────────────────────────────────────────
+
+describe('GET /api/health/agent', () => {
+  it('returns status from the agent when the agent is healthy', async () => {
+    stubFetch(okJson({ status: 'healthy' }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/health/agent' });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('healthy');
+  });
+
+  it('returns status "unreachable" when the agent fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')));
+
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/health/agent' });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('unreachable');
+  });
+
+  it('returns "unhealthy" when the agent returns a non-2xx status', async () => {
+    stubFetch(new Response('Service Unavailable', { status: 503 }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/health/agent' });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('unhealthy');
+  });
+});
+
+// ── GET /api/health (BFF health) ─────────────────────────────────────────────
+
+describe('GET /api/health', () => {
+  it('returns 200 ok without contacting the agent', async () => {
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('ok');
+  });
+});
+
+// ── GET /api/config/branding ──────────────────────────────────────────────────
+
+describe('GET /api/config/branding', () => {
+  it('returns branding config from settings', async () => {
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/config/branding' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveProperty('title');
+    expect(body).toHaveProperty('colors');
+  });
+});
+
+// ── GET /api/config/features ──────────────────────────────────────────────────
+
+describe('GET /api/config/features', () => {
+  it('returns feature flags from settings', async () => {
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/config/features' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveProperty('auth_enabled');
+  });
+});
+
+// ── ALL /api/proxy/agent/* generic pass-through ───────────────────────────────
+
+describe('ALL /api/proxy/agent/* (generic pass-through)', () => {
+  it('proxies a GET to the agent and forwards the response', async () => {
+    stubFetch(okJson({ messages: [], tasks: [] }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/my-thread/state',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveProperty('messages');
+  });
+
+  it('forwards a 404 from the agent as-is', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(new Response('Not Found', { status: 404 })),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/nonexistent/state',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('returns 502 when the agent is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/t1/state',
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+});
+
+// ── Thread state LRU cache ────────────────────────────────────────────────────
+
+describe('GET /api/proxy/agent/threads/:id/state — LRU cache', () => {
+  it('returns X-Cache: MISS on the first request', async () => {
+    stubFetch(okJson({ messages: [], tasks: [] }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/cache-thread-1/state',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['x-cache']).toBe('MISS');
+  });
+
+  it('returns X-Cache: HIT and avoids a second fetch on a repeated request', async () => {
+    const mockFetch = stubFetch(
+      okJson({ messages: [], tasks: [] }), // only needed once
+    );
+
+    const server = await buildTestServer();
+    // First request
+    await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/cache-thread-2/state',
+    });
+    // Second request — should hit cache
+    const res2 = await server.inject({
+      method: 'GET',
+      url: '/api/proxy/agent/threads/cache-thread-2/state',
+    });
+
+    expect(res2.headers['x-cache']).toBe('HIT');
+    // fetch was only called once (not twice)
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── POST /api/proxy/agent/feedback ───────────────────────────────────────────
+
+describe('POST /api/proxy/agent/feedback', () => {
+  it('proxies the feedback to the agent and returns the result', async () => {
+    stubFetch(okJson({ success: true }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/feedback',
+      payload: { run_id: 'run-1', score: 1, comment: 'Good' },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 502 when the agent is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('ECONNREFUSED')));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/feedback',
+      payload: { run_id: 'run-1', score: 1 },
+    });
+
+    expect(res.statusCode).toBe(502);
+  });
+});
+
+// ── POST /api/proxy/agent/v1/stream — HITL interrupt translation ──────────────
+
+describe('POST /api/proxy/agent/v1/stream', () => {
+  it('returns 200 and emits [DONE] for a simple token stream', async () => {
+    const agentSSE =
+      `event: messages/partial\ndata: [{"type":"ai","content":"Hello"}]\n\n`;
+
+    stubFetch(
+      okJson({ thread_id: 'th1' }),         // POST /threads
+      makeSSEResponse(agentSSE),            // POST /threads/th1/runs/stream
+      okJson({ messages: [], tasks: [] }),  // GET /threads/th1/state
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th1', user_id: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.body).toContain('[DONE]');
+  });
+
+  it('emits a token chunk when the agent sends messages/partial', async () => {
+    const agentSSE =
+      `event: messages/partial\ndata: [{"type":"ai","content":"Hi there"}]\n\n`;
+
+    stubFetch(
+      okJson({ thread_id: 'th2' }),
+      makeSSEResponse(agentSSE),
+      okJson({ messages: [], tasks: [] }),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th2', user_id: 'u1' },
+    });
+
+    expect(res.body).toContain('"type":"token"');
+    expect(res.body).toContain('Hi there');
+  });
+
+  it('translates a LangGraph __interrupt__ update into an interrupt chunk', async () => {
+    const interruptValue = {
+      action_requests: [{ name: 'github_create_pr', args: { title: 'My PR' } }],
+      review_configs: [{ action_name: 'github_create_pr', allowed_decisions: ['approve', 'reject'] }],
+    };
+    const agentSSE =
+      `event: updates\ndata: ${JSON.stringify({ __interrupt__: [{ value: interruptValue, resumable: true }] })}\n\n`;
+
+    stubFetch(
+      okJson({ thread_id: 'th3' }),
+      makeSSEResponse(agentSSE),
+      okJson({ messages: [], tasks: [] }),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th3', user_id: 'u1' },
+    });
+
+    expect(res.body).toContain('"type":"interrupt"');
+    expect(res.body).toContain('github_create_pr');
+  });
+
+  it('emits an interrupt chunk from thread state when missing from the stream', async () => {
+    const interruptValue = { action_requests: [], review_configs: [] };
+    // No __interrupt__ in the stream itself
+    const agentSSE =
+      `event: messages/partial\ndata: [{"type":"ai","content":"Processing..."}]\n\n`;
+
+    // Thread state returns an interrupt in tasks
+    const threadState = {
+      messages: [],
+      tasks: [{ interrupts: [{ value: interruptValue }] }],
+    };
+
+    stubFetch(
+      okJson({ thread_id: 'th4' }),
+      makeSSEResponse(agentSSE),
+      okJson(threadState),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th4', user_id: 'u1' },
+    });
+
+    expect(res.body).toContain('"type":"interrupt"');
+  });
+
+  it('returns 500 when thread creation fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(new Response('error', { status: 500 })),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th5', user_id: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(500);
+  });
+
+  it('returns 503 when the agent SSE stream request itself fails', async () => {
+    // Step 1 (thread creation) succeeds; step 2 (SSE stream) returns 503
+    stubFetch(
+      okJson({ thread_id: 'th6' }),
+      new Response('Service Unavailable', { status: 503 }),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th6', user_id: 'u1' },
+    });
+
+    // The proxy must propagate the upstream 503 — not silently return 200
+    expect(res.statusCode).toBe(503);
+  });
+});


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Expands the `template-ui` test suite to add meaningful coverage for Human-In-The-Loop (HITL) flows, the SSE streaming pipeline, Redux slices, the Fastify proxy layer, and key UI components. Before this MR, the suite had no unit tests for the core streaming library, no tests for the HITL approval path through `AIMessageRenderer`, and no E2E coverage for interrupt flows, rate limiting, or settings persistence. The MR also fixes a production bug in `SSEProcessor` where plain-text interrupt values were silently coerced to `{}`, breaking string-valued interrupts.

## Changes

- **`SSEProcessor.ts`** — fix: preserve non-JSON plain-text interrupt values as strings instead of coercing to `{}`
- **`StreamingManager.ts`** — widen `InterruptPayload.value` type to `HITLInterruptValue | string` to match the fixed processor
- **`src/frontend/test-utils/setup.ts`** — replace `undefined/null` localStorage guard with a live probe to handle Node 26+ broken-but-present experimental storage
- **`SSEProcessor.test.ts`** (new) — 15 unit tests: token, interrupt (object/string/JSON-wrapped/resumable-false/numeric fallback), mcp_status, metadata, DONE, errors, buffering, reset, comment lines
- **`StreamingManager.test.ts`** (new) — 10 unit tests: happy path, status transitions, interrupt (object + plain string), dedup, HTTP error, cancel, null body, chunk-ID reset
- **`chats.test.ts`** (new) — 18 unit tests for the chats Redux slice covering all exported actions; replaces `as any` with typed `TestMessage` fixture
- **`userSettings.test.ts`** (new) — 11 unit tests: theme, alwaysAllowedTools, auto-approve, debug mode, config defaults, localStorage persistence and malformed-JSON fallback
- **`deep-agent.test.ts`** (new) — 17 unit tests for all 5 exported utilities including invalid-but-brace-starting JSON edge case
- **`InterruptBanner.test.tsx`** (new) — 14 unit tests for all three render branches (approval, generic input, MCP OAuth), cross-origin `postMessage` rejection guard
- **`AIMessageRenderer.test.tsx`** (new) — 7 unit tests for the production HITL path: Approve/Reject/Always-allow buttons, decision payload shape, post-click hide, null/missing-callback guards
- **`useStreamingAPI.test.ts`** (new) — 10 unit tests: `checkAndAutoApprove` matrix, initial state, `stop()` safety, `setMessages()` injection, `submit()` loading transition
- **`proxy.test.ts`** (new) — 14 server-side unit tests for the Fastify proxy: health, agent health, streaming happy path, interrupt translation, thread-state fallback, thread creation failure, stream-step failure (503 propagation)
- **`e2e/helpers/sse-mock.ts`** — add `interruptChunk`, `mockInterruptStream`, `mockResumeStream` (one-shot via `page.unroute`), `mockRateLimitResponse`
- **`e2e/helpers/local-storage.ts`** (new) — Playwright localStorage helper for pre-populating settings before page load
- **`e2e/hitl/interrupt-flow.spec.ts`** (new) — 5 E2E tests: banner renders, Approve/Reject resume flows, Input Required branch, Send submits typed text
- **`e2e/hitl/auto-approve.spec.ts`** (new) — 3 E2E tests: `alwaysAllowedTools` skip, string interrupt shown, `autoApproveAllTools` skip
- **`e2e/settings/settings-page.spec.ts`** (new) — 8 E2E tests: routing, tab navigation, theme persistence, `alwaysAllowedTools` pre-population, back navigation
- **`e2e/auth/rate-limit.spec.ts`** (new) — 4 E2E tests: 429 alert shown, Retry-After text, cancel-button blocks input, no alert on 200

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: bootstrap tests for HITL and other features; iterative fixes applied after code-review and Bugbot findings
- **Human verification**: All 219 unit tests and 21 E2E tests run locally and confirmed green; linting passes with 0 errors; Bugbot and code-reviewer findings reviewed and resolved

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

None

## Reviewer Notes

<!-- What to focus on. -->
