### PR TITLE
fix: suppress agent messages with tool calls to prevent duplicate responses

### DIFF
--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -11,6 +11,7 @@ import {
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import {
   appendMessageToChat,
+  removeLastMessageFromChat,
   mergeToolResult,
   resolveAllPendingToolCalls,
   selectChatById,
@@ -399,6 +400,12 @@ export function useStreamingAPI(threadId: string) {
               }
               dispatch(updateLastMessageInChat({ chatId: threadId, content }));
             },
+            onDraftDiscard() {
+              if (isStreamingTokensRef.current) {
+                dispatch(removeLastMessageFromChat({ chatId: threadId }));
+                isStreamingTokensRef.current = false;
+              }
+            },
             onMessage(m) {
               isStreamingTokensRef.current = false;
               if (m.type === 'human') {
@@ -660,6 +667,12 @@ export function useStreamingAPI(threadId: string) {
           }
           dispatch(updateLastMessageInChat({ chatId: threadId, content }));
         },
+        onDraftDiscard() {
+          if (isStreamingTokensRef.current) {
+            dispatch(removeLastMessageFromChat({ chatId: threadId }));
+            isStreamingTokensRef.current = false;
+          }
+        },
         onMessage(m) {
           isStreamingTokensRef.current = false;
           if (m.type === 'human') return;
@@ -759,6 +772,12 @@ export function useStreamingAPI(threadId: string) {
               return;
             }
             dispatch(updateLastMessageInChat({ chatId: threadId, content }));
+          },
+          onDraftDiscard() {
+            if (isStreamingTokensRef.current) {
+              dispatch(removeLastMessageFromChat({ chatId: threadId }));
+              isStreamingTokensRef.current = false;
+            }
           },
           onMessage(m) {
             isStreamingTokensRef.current = false;

--- a/src/frontend/lib/streaming/SSEProcessor.ts
+++ b/src/frontend/lib/streaming/SSEProcessor.ts
@@ -3,6 +3,7 @@ import type { HITLInterruptValue } from '@/types/deep-agent';
 
 export type SSEChunk =
   | { type: 'token'; content: string; chunk_id: number }
+  | { type: 'draft_discard'; chunk_id: number }
   | { type: 'message'; content: Message; chunk_id: number }
   | { type: 'interrupt'; content: { value: HITLInterruptValue | string; resumable: boolean }; chunk_id: number };
 
@@ -32,6 +33,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseSSEChunkPayload(parsed: unknown): SSEChunk | null {
   if (!isRecord(parsed)) return null;
   const type = parsed.type;
+  if (type === 'draft_discard') {
+    const chunkId = parsed.chunk_id;
+    if (typeof chunkId === 'number' && Number.isFinite(chunkId)) {
+      return { type: 'draft_discard', chunk_id: chunkId };
+    }
+    return null;
+  }
   if (type !== 'token' && type !== 'message' && type !== 'interrupt') return null;
   const chunkIdRaw = parsed.chunk_id;
   if (typeof chunkIdRaw !== 'number' || !Number.isFinite(chunkIdRaw)) {

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -40,6 +40,7 @@ export type StreamMetadataPayload = {
 
 export type StreamCallback = {
   onToken: (content: string) => void;
+  onDraftDiscard?: () => void;
   onMessage: (message: Message) => void;
   onInterrupt: (interrupt: InterruptPayload) => void;
   onError: (error: Error) => void;
@@ -91,6 +92,8 @@ export class StreamingManager {
 
           if (event.data.type === 'token') {
             callbacks.onToken(event.data.content);
+          } else if (event.data.type === 'draft_discard') {
+            callbacks.onDraftDiscard?.();
           } else if (event.data.type === 'interrupt') {
             callbacks.onInterrupt(event.data.content);
           } else {

--- a/src/frontend/redux/slices/chats.ts
+++ b/src/frontend/redux/slices/chats.ts
@@ -90,6 +90,13 @@ const chatsSlice = createSlice({
       state.streamingStates = {};
       state.error = null;
     },
+    removeLastMessageFromChat(state, action: PayloadAction<{ chatId: string }>) {
+      const { chatId } = action.payload;
+      const chat = state.chats.find((c) => c.id === chatId);
+      if (chat && chat.messages.length > 0) {
+        chat.messages.pop();
+      }
+    },
     appendMessageToChat(state, action: PayloadAction<{ chatId: string; message: Message }>) {
       const { chatId, message } = action.payload;
       const chat = state.chats.find((c) => c.id === chatId);
@@ -194,6 +201,7 @@ export const {
   deleteChat,
   clearAllChats,
   appendMessageToChat,
+  removeLastMessageFromChat,
   updateLastMessageInChat,
   mergeToolResult,
   resolveAllPendingToolCalls,

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -445,6 +445,10 @@ async function proxyRoutes(fastify: FastifyInstance) {
 
         let hasEmittedTextTokens = false;
         let interruptEmittedFromStream = false;
+        // Per-message tracking for draft_discard (suppress text from tool-call messages)
+        let currentStreamingMsgId = '';
+        let textEmittedForCurrentMsg = false;
+        const discardedMsgIds = new Set<string>();
 
         try {
           while (!clientGone) {
@@ -538,6 +542,26 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   sentMsgIds,
                 );
 
+                // Track message boundaries & detect tool_calls in partials
+                if (sseType === 'messages/partial' && Array.isArray(parsed) && parsed.length > 0) {
+                  const partialMsg = parsed[0] as Record<string, any>;
+                  const partialMsgId = partialMsg?.id ?? '';
+                  if (partialMsgId && partialMsgId !== currentStreamingMsgId) {
+                    currentStreamingMsgId = partialMsgId;
+                    textEmittedForCurrentMsg = false;
+                    prevPartial = '';
+                  }
+
+                  const partialToolCalls = extractToolCalls(partialMsg ?? {});
+                  if (partialToolCalls.length > 0 && textEmittedForCurrentMsg) {
+                    reply.raw.write(`data: ${JSON.stringify({ type: 'draft_discard', chunk_id: chunkId })}\n\n`);
+                    chunkId++;
+                    textEmittedForCurrentMsg = false;
+                    discardedMsgIds.add(partialMsgId);
+                    completedTexts.length = 0;
+                  }
+                }
+
                 if (nextPartial.length > prevPartial.length && uiChunks.length === 0) {
                   const isEchoOfPrior = completedTexts.some(
                     (ct) => nextPartial.length <= ct.length && ct.startsWith(nextPartial),
@@ -547,11 +571,17 @@ async function proxyRoutes(fastify: FastifyInstance) {
                     reply.raw.write(`data: ${JSON.stringify({ type: 'token', content: delta, chunk_id: chunkId })}\n\n`);
                     chunkId++;
                     hasEmittedTextTokens = true;
+                    textEmittedForCurrentMsg = true;
                   }
                 }
 
                 if (sseType === 'messages/complete' && uiChunks.length === 0 && nextPartial.length > 0) {
-                  completedTexts.push(nextPartial);
+                  const completeMsgId = Array.isArray(parsed) && parsed.length > 0
+                    ? ((parsed[0] as Record<string, any>)?.id ?? '')
+                    : '';
+                  if (!discardedMsgIds.has(completeMsgId)) {
+                    completedTexts.push(nextPartial);
+                  }
                 }
 
                 prevPartial = nextPartial;

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -562,7 +562,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
                     chunkId++;
                     textEmittedForCurrentMsg = false;
                     hasEmittedTextTokens = false;
-                    prevPartial = '';
+                    prevPartial = nextPartial;
                     discardedMsgIds.add(partialMsgId);
                     completedTexts.length = 0;
                   }

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -565,7 +565,6 @@ async function proxyRoutes(fastify: FastifyInstance) {
                     prevPartial = '';
                     discardedMsgIds.add(partialMsgId);
                     completedTexts.length = 0;
-                    continue;
                   }
                 }
 

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -565,6 +565,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
                     prevPartial = '';
                     discardedMsgIds.add(partialMsgId);
                     completedTexts.length = 0;
+                    continue;
                   }
                 }
 

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -534,6 +534,16 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   continue;
                 }
 
+                // Reset per-message state before translation
+                if (sseType === 'messages/partial' && Array.isArray(parsed) && parsed.length > 0) {
+                  const peekId = (parsed[0] as Record<string, any>)?.id ?? '';
+                  if (peekId && peekId !== currentStreamingMsgId) {
+                    currentStreamingMsgId = peekId;
+                    textEmittedForCurrentMsg = false;
+                    prevPartial = '';
+                  }
+                }
+
                 const [uiChunks, nextPartial] = translateMessageEvent(
                   sseType,
                   parsed,
@@ -542,21 +552,17 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   sentMsgIds,
                 );
 
-                // Track message boundaries & detect tool_calls in partials
+                // Detect tool_calls in partials and discard any text already streamed
                 if (sseType === 'messages/partial' && Array.isArray(parsed) && parsed.length > 0) {
                   const partialMsg = parsed[0] as Record<string, any>;
                   const partialMsgId = partialMsg?.id ?? '';
-                  if (partialMsgId && partialMsgId !== currentStreamingMsgId) {
-                    currentStreamingMsgId = partialMsgId;
-                    textEmittedForCurrentMsg = false;
-                    prevPartial = '';
-                  }
-
                   const partialToolCalls = extractToolCalls(partialMsg ?? {});
                   if (partialToolCalls.length > 0 && textEmittedForCurrentMsg) {
                     reply.raw.write(`data: ${JSON.stringify({ type: 'draft_discard', chunk_id: chunkId })}\n\n`);
                     chunkId++;
                     textEmittedForCurrentMsg = false;
+                    hasEmittedTextTokens = false;
+                    prevPartial = '';
                     discardedMsgIds.add(partialMsgId);
                     completedTexts.length = 0;
                   }


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Fixes duplicate agent responses in the chat UI caused by LangGraph's ReAct loop. When the model calls a tool (e.g. `write_todos`), the ReAct loop produces two LLM calls — the first emits the full answer text alongside the tool call, and the second re-generates the same answer after the tool completes. Both get streamed to the UI, causing the user to see the response duplicated (with the second copy often truncated). This is a known LangGraph design behavior ([langchain-ai/langgraph#3062](https://github.com/langchain-ai/langgraph/issues/3062)).

The fix introduces a `draft_discard` SSE event: text tokens from Call 1 stream normally (zero added latency), but the moment the proxy detects tool calls appearing in the same message, it fires `draft_discard` — the frontend removes the premature bubble, and Call 2's clean response streams in its place. Simple prompts with no tool calls are completely unaffected.

## Changes

- `proxy.router.ts` — Track per-message state (`currentStreamingMsgId`, `textEmittedForCurrentMsg`, `discardedMsgIds`). Emit `draft_discard` when `messages/partial` contains tool calls after text was already streamed. Reset `prevPartial` on message boundaries and skip `completedTexts` for discarded messages to prevent stale dedup from truncating Call 2.
- `SSEProcessor.ts` — Add `draft_discard` to the `SSEChunk` union type and parse it in `parseSSEChunkPayload`.
- `StreamingManager.ts` — Add optional `onDraftDiscard` callback to `StreamCallback` and dispatch it when a `draft_discard` chunk is received.
- `useStreamingAPI.ts` — Handle `onDraftDiscard` in all three stream paths (submit, resumeWithDecisions, resumeInterrupt) by calling `removeLastMessageFromChat` and resetting `isStreamingTokensRef`.
- `chats.ts` — Add `removeLastMessageFromChat` Redux action that pops the last message from a chat.

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code, Gemini (for research)
- **Scope**: Debugging/logging used Claud Code. For research into langgraph and causes/potential fixes used Gemini.
- **Human verification**: Manually tested against live agent with BMI calculation prompts, verified duplicate no longer appears, verified simple prompts still stream correctly, confirmed refresh shows single clean response.

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

None

## Reviewer Notes

<!-- What to focus on. -->

- The fix is purely additive in the proxy — the existing `prevPartial` / `completedTexts` dedup logic is untouched for the normal (no-tool-call) path.
- `draft_discard` only fires when two conditions are met simultaneously: (1) text tokens were already emitted for the current message AND (2) tool calls appear in a `messages/partial` event. This prevents false positives on simple prompts.
- The `removeLastMessageFromChat` action is a blind pop — safe because it only fires when `isStreamingTokensRef.current` is true, meaning the last message is always the one we just appended from token streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for draft-discard events during streaming responses.
  * Streaming responses now recognize when draft text is replaced by a tool-call result.

* **Bug Fixes**
  * Removed superseded AI draft messages from chats when discarded.
  * Prevented discarded draft text from reappearing in completed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->