### PR TITLE
feat: migrate personalization storage from localStorage to backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test-results/
 
 # Coverage
 coverage/
+dump.rdb

--- a/config/ui/settings.yaml
+++ b/config/ui/settings.yaml
@@ -18,6 +18,7 @@ features:
   debug_mode_default: false
   # auth_enabled: Controlled via AUTH_ENABLED environment variable (set by agent-engine during deployment)
   mcp_apps_enabled: true
+  memory_enabled: true
 
 agent:
   endpoint: ""

--- a/e2e/accessibility/wcag.spec.ts
+++ b/e2e/accessibility/wcag.spec.ts
@@ -115,7 +115,7 @@ test.describe('Chat page — WCAG 2.1 AA', () => {
 // active panel is in the visible DOM at a time.
 // ---------------------------------------------------------------------------
 
-const SETTINGS_TABS = ['Profile', 'Memories', 'Custom Rules', 'Appearance', 'Tool Approvals', 'MCP OAuth'] as const;
+const SETTINGS_TABS = ['Profile', 'Your Memories', 'Custom Rules', 'Appearance', 'Tool Approvals', 'MCP OAuth'] as const;
 
 test.describe('Settings page — WCAG 2.1 AA', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -20,6 +20,7 @@ export interface BrandingOverride {
 export interface FeaturesOverride {
   debug_mode_default?: boolean;
   auth_enabled?: boolean;
+  memory_enabled?: boolean;
 }
 
 const DEFAULT_LIGHT: BrandingColors = {
@@ -74,6 +75,7 @@ export async function mountConfig(
       body: JSON.stringify({
         debug_mode_default: features.debug_mode_default ?? false,
         auth_enabled: features.auth_enabled ?? false,
+        memory_enabled: features.memory_enabled ?? true,
       }),
     }),
   );
@@ -112,6 +114,14 @@ export async function mountConfig(
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({ connections: [] }),
+    }),
+  );
+
+  await page.route('**/api/proxy/agent/personalization/memories', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
     }),
   );
 }

--- a/e2e/page-objects/SettingsPage.ts
+++ b/e2e/page-objects/SettingsPage.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-type SettingsTab = 'Profile' | 'Memories' | 'Custom Rules' | 'Appearance' | 'Tool Approvals' | 'MCP OAuth';
+type SettingsTab = 'Profile' | 'Your Memories' | 'Custom Rules' | 'Appearance' | 'Tool Approvals' | 'MCP OAuth';
 
 /** Page object for the settings view (`/settings`). */
 export class SettingsPage {

--- a/e2e/settings/settings-page.spec.ts
+++ b/e2e/settings/settings-page.spec.ts
@@ -59,8 +59,8 @@ test.describe('Settings page', () => {
   test('clicking Memories tab shows the Memories section', async ({ page }) => {
     const settings = new SettingsPage(page);
     await settings.goto();
-    await settings.clickTab('Memories');
-    await settings.expectTabContentVisible('Memories');
+    await settings.clickTab('Your Memories');
+    await settings.expectTabContentVisible('Your Memories');
   });
 
   test('clicking MCP OAuth tab shows the OAuth connections section', async ({ page }) => {

--- a/src/frontend/components/FeatureGate.tsx
+++ b/src/frontend/components/FeatureGate.tsx
@@ -28,9 +28,9 @@ export function FeatureGate({ feature, children, fallback = null }: FeatureGateP
     switch (feature) {
       case 'auth':
         return features.auth_enabled ?? true;
-      case 'debug':
-        return true;
       case 'memory':
+        return features.memory_enabled ?? true;
+      case 'debug':
         return true;
       default:
         return true;

--- a/src/frontend/components/__tests__/accessibility.test.tsx
+++ b/src/frontend/components/__tests__/accessibility.test.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, afterEach } from 'vitest';
 import { axe } from '../../test-utils/setup';
 import { renderWithProviders } from '../../test-utils/render';
 import { HomePage } from '../../pages/HomePage';
@@ -21,6 +22,64 @@ import { MemoryList } from '../settings/MemoryList';
 import { RulesEditor } from '../settings/RulesEditor';
 import { SubAgentIndicator } from '../SubAgentIndicator';
 import { Sidebar } from '../Sidebar';
+
+// Mock fetch for components that call personalization API on mount.
+// Keep posted rules in memory so add → refetch does not wipe the list.
+let mockRules: {
+  id: string;
+  content: string;
+  is_active: boolean;
+  created_at: string;
+}[] = [];
+
+beforeEach(() => {
+  mockRules = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/personalization/memories')) {
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+      }
+      if (url.includes('/personalization/rules')) {
+        if (init?.method === 'POST') {
+          const body = JSON.parse(String(init.body ?? '{}')) as {
+            id?: string;
+            content?: string;
+            is_active?: boolean;
+          };
+          const rule = {
+            id: body.id ?? 'rule-1',
+            content: body.content ?? '',
+            is_active: body.is_active !== false,
+            created_at: new Date().toISOString(),
+          };
+          const idx = mockRules.findIndex((r) => r.id === rule.id);
+          if (idx >= 0) mockRules[idx] = rule;
+          else mockRules.unshift(rule);
+          return Promise.resolve(new Response(JSON.stringify(rule), { status: 201 }));
+        }
+        if (init?.method === 'DELETE') {
+          const id = url.split('/').pop();
+          if (id && id !== 'rules') {
+            mockRules = mockRules.filter((r) => r.id !== id);
+          } else {
+            mockRules = [];
+          }
+          return Promise.resolve(new Response(null, { status: 204 }));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ rules: mockRules }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // ---------------------------------------------------------------------------
 // HomePage
@@ -80,10 +139,12 @@ describe('SettingsPage — accessibility', () => {
     expect(tablist).toBeInTheDocument();
   });
 
-  it('tablist is not wrapped in a redundant nav landmark', () => {
+  it('tablist is wrapped in a nav landmark with label', () => {
     renderWithProviders(<SettingsPage />);
     const tablist = screen.getByRole('tablist');
-    expect(tablist.closest('nav')).toBeNull();
+    const nav = tablist.closest('nav');
+    expect(nav).not.toBeNull();
+    expect(nav).toHaveAttribute('aria-label');
   });
 
   it('tabs have role="tab" and aria-selected', () => {
@@ -253,30 +314,9 @@ describe('MemoryList — accessibility', () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it('add-memory textarea has accessible label', () => {
+  it('shows informational text about agent-created memories', () => {
     renderWithProviders(<MemoryList />);
-    expect(screen.getByRole('textbox', { name: /new memory/i })).toBeInTheDocument();
-  });
-
-  it('remove button includes memory content in accessible label', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<MemoryList />);
-    const textarea = screen.getByRole('textbox', { name: /new memory/i });
-    await user.type(textarea, 'Prefer metric units');
-    await user.click(screen.getByRole('button', { name: /^add$/i }));
-    const removeBtn = screen.getByRole('button', { name: /remove memory: prefer metric units/i });
-    expect(removeBtn).toBeInTheDocument();
-  });
-
-  it('remove button is keyboard-focusable (not just hover-visible)', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<MemoryList />);
-    const textarea = screen.getByRole('textbox', { name: /new memory/i });
-    await user.type(textarea, 'Test memory entry');
-    await user.click(screen.getByRole('button', { name: /^add$/i }));
-    const removeBtn = screen.getByRole('button', { name: /remove memory/i });
-    removeBtn.focus();
-    expect(removeBtn).toHaveFocus();
+    expect(screen.getByText(/memories the agent has created/i)).toBeInTheDocument();
   });
 });
 
@@ -300,7 +340,9 @@ describe('RulesEditor — accessibility', () => {
     const textarea = screen.getByRole('textbox', { name: /new rule/i });
     await user.type(textarea, 'Always respond in British English');
     await user.click(screen.getByRole('button', { name: /^add$/i }));
-    const removeBtn = screen.getByRole('button', { name: /remove rule: always respond in british english/i });
+    const removeBtn = await screen.findByRole('button', {
+      name: /remove rule: always respond in british english/i,
+    });
     expect(removeBtn).toBeInTheDocument();
   });
 
@@ -310,7 +352,7 @@ describe('RulesEditor — accessibility', () => {
     const textarea = screen.getByRole('textbox', { name: /new rule/i });
     await user.type(textarea, 'Be concise');
     await user.click(screen.getByRole('button', { name: /^add$/i }));
-    const toggle = screen.getByRole('switch', { name: /toggle rule: be concise/i });
+    const toggle = await screen.findByRole('switch', { name: /toggle rule: be concise/i });
     expect(toggle).toBeInTheDocument();
   });
 });

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -263,7 +263,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   }, [chats]);
 
   const userData = useMemo(() => window.USER_DATA, []);
-  const userName = userData?.displayName || userData?.name || 'User';
+  const userName =
+    userData?.displayName ||
+    userData?.name ||
+    userData?.given_name ||
+    userData?.preferred_username ||
+    'User';
   const tokenExpiry = useMemo(() => {
     if (userData?.expiresAt) {
       return new Date(userData.expiresAt);

--- a/src/frontend/components/settings/MemoryList.tsx
+++ b/src/frontend/components/settings/MemoryList.tsx
@@ -1,13 +1,26 @@
-import { useState } from 'react';
-import { Button } from '@patternfly/react-core';
+import { useEffect, useState } from 'react';
+import { Button, Spinner } from '@patternfly/react-core';
 import { Plus, Trash2, Brain, AlertCircle } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { addMemory, removeMemory, clearMemories, selectMemories } from '../../redux/slices/personalization';
+import {
+  addMemory,
+  removeMemory,
+  fetchMemories,
+  selectMemories,
+  selectPersonalizationLoading,
+  selectPersonalizationError,
+} from '../../redux/slices/personalization';
 
 export function MemoryList() {
   const dispatch = useAppDispatch();
   const memories = useAppSelector(selectMemories);
+  const loading = useAppSelector(selectPersonalizationLoading);
+  const error = useAppSelector(selectPersonalizationError);
   const [draft, setDraft] = useState('');
+
+  useEffect(() => {
+    dispatch(fetchMemories());
+  }, [dispatch]);
 
   const handleAdd = () => {
     const text = draft.trim();
@@ -33,6 +46,13 @@ export function MemoryList() {
         </p>
       </div>
 
+      {error && (
+        <div className="flex items-start gap-3 p-3 rounded-lg bg-red-500/5 border border-red-500/20">
+          <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-red-400/80">{error}</p>
+        </div>
+      )}
+
       <div className="flex gap-2">
         <textarea
           value={draft}
@@ -56,7 +76,12 @@ export function MemoryList() {
         </Button>
       </div>
 
-      {memories.length === 0 ? (
+      {loading ? (
+        <div className="flex flex-col items-center py-8">
+          <Spinner size="md" />
+          <p className="text-sm text-muted-foreground/60 mt-2">Loading memories...</p>
+        </div>
+      ) : memories.length === 0 ? (
         <div className="flex flex-col items-center py-8 text-center">
           <Brain className="w-8 h-8 text-muted-foreground/30 mb-2" aria-hidden="true" />
           <p className="text-sm text-muted-foreground">No memories yet</p>
@@ -65,38 +90,24 @@ export function MemoryList() {
           </p>
         </div>
       ) : (
-        <>
-          <ul className="space-y-2">
-            {memories.map((mem) => (
-              <li
-                key={mem.id}
-                className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
+        <ul className="space-y-2">
+          {memories.map((mem) => (
+            <li
+              key={mem.id}
+              className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
+            >
+              <Brain className="w-4 h-4 text-primary/60 mt-0.5 shrink-0" />
+              <p className="flex-1 text-sm text-foreground leading-relaxed">{mem.content}</p>
+              <button
+                onClick={() => dispatch(removeMemory(mem.id))}
+                className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
+                aria-label="Remove memory"
               >
-                <Brain className="w-4 h-4 text-primary/60 mt-0.5 shrink-0" />
-                <p className="flex-1 text-sm text-foreground leading-relaxed">{mem.content}</p>
-                <button
-                  onClick={() => dispatch(removeMemory(mem.id))}
-                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
-                  aria-label={`Remove memory: ${mem.content.substring(0, 50)}`}
-                >
-                  <Trash2 className="w-3.5 h-3.5" />
-                </button>
-              </li>
-            ))}
-          </ul>
-          {memories.length > 1 && (
-            <div className="flex justify-end">
-              <Button
-                variant="plain"
-                isDanger
-                size="sm"
-                onClick={() => dispatch(clearMemories())}
-              >
-                Clear all memories
-              </Button>
-            </div>
-          )}
-        </>
+              <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/src/frontend/components/settings/MemoryList.tsx
+++ b/src/frontend/components/settings/MemoryList.tsx
@@ -1,48 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Button, Spinner } from '@patternfly/react-core';
-import { Plus, Trash2, Brain, AlertCircle } from 'lucide-react';
+import { Trash2, Brain, AlertCircle } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
-  addMemory,
-  removeMemory,
   fetchMemories,
+  deleteMemory,
+  deleteAllMemories,
   selectMemories,
-  selectPersonalizationLoading,
+  selectMemoriesLoading,
   selectPersonalizationError,
 } from '../../redux/slices/personalization';
 
 export function MemoryList() {
   const dispatch = useAppDispatch();
   const memories = useAppSelector(selectMemories);
-  const loading = useAppSelector(selectPersonalizationLoading);
+  const memoriesLoading = useAppSelector(selectMemoriesLoading);
   const error = useAppSelector(selectPersonalizationError);
-  const [draft, setDraft] = useState('');
 
   useEffect(() => {
     dispatch(fetchMemories());
   }, [dispatch]);
 
-  const handleAdd = () => {
-    const text = draft.trim();
-    if (!text) return;
-    dispatch(addMemory(text));
-    setDraft('');
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleAdd();
-    }
-  };
-
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div className="flex items-start gap-3 p-3 rounded-lg bg-blue-500/5 border border-blue-500/20">
-        <AlertCircle className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" aria-hidden="true" />
-        <p className="text-xs text-blue-700 dark:text-blue-300">
-          Memories are facts the agent remembers across conversations. Add things like
-          your preferences, context, or recurring instructions.
+        <AlertCircle className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
+        <p className="text-xs text-blue-600 dark:text-blue-300">
+          These are memories the agent has created about you across conversations.
+          You can delete them at any time.
         </p>
       </div>
 
@@ -53,61 +38,61 @@ export function MemoryList() {
         </div>
       )}
 
-      <div className="flex gap-2">
-        <textarea
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="e.g. I prefer metric units for all measurements"
-          aria-label="New memory"
-          className="flex-1 rounded-xl px-3.5 py-2.5 text-sm resize-none min-h-[40px] border-0 bg-secondary/50 placeholder:opacity-60 focus:bg-card focus:outline-none focus:ring-0 focus:border-transparent focus:shadow-none"
-          style={{ border: '1px solid var(--border)', boxShadow: 'none' }}
-          rows={2}
-        />
-        <Button
-          variant="primary"
-          size="sm"
-          isDisabled={!draft.trim()}
-          onClick={handleAdd}
-          className="self-end"
-          icon={<Plus className="w-4 h-4" />}
-        >
-          Add
-        </Button>
-      </div>
-
-      {loading ? (
+      {memoriesLoading ? (
         <div className="flex flex-col items-center py-8">
           <Spinner size="md" />
-          <p className="text-sm text-muted-foreground/60 mt-2">Loading memories...</p>
+          <p className="text-sm text-muted-foreground mt-2">Loading...</p>
         </div>
       ) : memories.length === 0 ? (
         <div className="flex flex-col items-center py-8 text-center">
-          <Brain className="w-8 h-8 text-muted-foreground/30 mb-2" aria-hidden="true" />
+          <Brain className="w-8 h-8 text-muted-foreground/30 mb-2" />
           <p className="text-sm text-muted-foreground">No memories yet</p>
           <p className="text-xs text-muted-foreground mt-1">
-            Add facts for the agent to remember
+            The agent will learn about you as you interact with it
           </p>
         </div>
       ) : (
-        <ul className="space-y-2">
-          {memories.map((mem) => (
-            <li
-              key={mem.id}
-              className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Brain className="w-4 h-4 text-primary/70" />
+              <h3 className="text-sm font-semibold text-foreground">
+                Memories
+              </h3>
+              <span className="text-xs text-muted-foreground">
+                ({memories.length})
+              </span>
+            </div>
+            <Button
+              variant="link"
+              isDanger
+              size="sm"
+              className="!text-xs !p-0"
+              onClick={() => dispatch(deleteAllMemories())}
             >
-              <Brain className="w-4 h-4 text-primary/60 mt-0.5 shrink-0" />
-              <p className="flex-1 text-sm text-foreground leading-relaxed">{mem.content}</p>
-              <button
-                onClick={() => dispatch(removeMemory(mem.id))}
-                className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
-                aria-label="Remove memory"
+              Delete All
+            </Button>
+          </div>
+          <ul className="space-y-2">
+            {memories.map((memory) => (
+              <li
+                key={memory.id}
+                className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
               >
-              <Trash2 className="w-3.5 h-3.5" />
-              </button>
-            </li>
-          ))}
-        </ul>
+                <p className="flex-1 text-sm text-foreground leading-relaxed">
+                  {memory.content}
+                </p>
+                <button
+                  onClick={() => dispatch(deleteMemory(memory.id))}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive shrink-0"
+                  aria-label="Delete memory"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
     </div>
   );

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -17,9 +17,13 @@ export function ProfileSection() {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   const userData = useMemo(() => window.USER_DATA, []);
-  const displayName = userData?.displayName || userData?.name || 'User';
+  const username =
+    userData?.preferred_username ||
+    (typeof userData?.email === 'string' ? userData.email.split('@')[0] : '') ||
+    '';
+  const displayName =
+    userData?.displayName || userData?.name || userData?.given_name || username || 'User';
   const email = userData?.email || '';
-  const username = userData?.preferred_username || '';
 
   const handleDeleteAll = async () => {
     const ids = chats.map((c) => c.id);

--- a/src/frontend/components/settings/RulesEditor.tsx
+++ b/src/frontend/components/settings/RulesEditor.tsx
@@ -1,19 +1,26 @@
-import { useState } from 'react';
-import { Button, Switch } from '@patternfly/react-core';
+import { useEffect, useState } from 'react';
+import { Button, Spinner } from '@patternfly/react-core';
 import { Plus, Trash2, ScrollText, AlertCircle } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
   addRule,
   removeRule,
-  toggleRule,
-  clearRules,
+  fetchRules,
   selectRules,
+  selectPersonalizationLoading,
+  selectPersonalizationError,
 } from '../../redux/slices/personalization';
 
 export function RulesEditor() {
   const dispatch = useAppDispatch();
   const rules = useAppSelector(selectRules);
+  const loading = useAppSelector(selectPersonalizationLoading);
+  const error = useAppSelector(selectPersonalizationError);
   const [draft, setDraft] = useState('');
+
+  useEffect(() => {
+    dispatch(fetchRules());
+  }, [dispatch]);
 
   const handleAdd = () => {
     const text = draft.trim();
@@ -39,6 +46,13 @@ export function RulesEditor() {
         </p>
       </div>
 
+      {error && (
+        <div className="flex items-start gap-3 p-3 rounded-lg bg-red-500/5 border border-red-500/20">
+          <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-red-400/80">{error}</p>
+        </div>
+      )}
+
       <div className="flex gap-2">
         <textarea
           value={draft}
@@ -62,7 +76,12 @@ export function RulesEditor() {
         </Button>
       </div>
 
-      {rules.length === 0 ? (
+      {loading ? (
+        <div className="flex flex-col items-center py-8">
+          <Spinner size="md" />
+          <p className="text-sm text-muted-foreground/60 mt-2">Loading rules...</p>
+        </div>
+      ) : rules.length === 0 ? (
         <div className="flex flex-col items-center py-8 text-center">
           <ScrollText className="w-8 h-8 text-muted-foreground/30 mb-2" aria-hidden="true" />
           <p className="text-sm text-muted-foreground">No custom rules</p>
@@ -78,20 +97,8 @@ export function RulesEditor() {
                 key={rule.id}
                 className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
               >
-                <Switch
-                  id={`rule-toggle-${rule.id}`}
-                  aria-label={`Toggle rule: ${rule.content.substring(0, 50)}`}
-                  isChecked={rule.isActive}
-                  onChange={() => dispatch(toggleRule(rule.id))}
-                  className="mt-0.5"
-                />
-                <p
-                  className={`flex-1 text-sm leading-relaxed ${
-                    rule.isActive ? 'text-foreground' : 'text-muted-foreground line-through'
-                  }`}
-                >
-                  {rule.content}
-                </p>
+                <ScrollText className="w-4 h-4 text-primary/60 mt-0.5 shrink-0" />
+                <p className="flex-1 text-sm text-foreground leading-relaxed">{rule.content}</p>
                 <button
                   onClick={() => dispatch(removeRule(rule.id))}
                   className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
@@ -102,18 +109,6 @@ export function RulesEditor() {
               </li>
             ))}
           </ul>
-          {rules.length > 1 && (
-            <div className="flex justify-end">
-              <Button
-                variant="plain"
-                isDanger
-                size="sm"
-                onClick={() => dispatch(clearRules())}
-              >
-                Clear all rules
-              </Button>
-            </div>
-          )}
         </>
       )}
     </div>

--- a/src/frontend/components/settings/RulesEditor.tsx
+++ b/src/frontend/components/settings/RulesEditor.tsx
@@ -1,21 +1,22 @@
 import { useEffect, useState } from 'react';
-import { Button, Spinner } from '@patternfly/react-core';
+import { Button, Switch } from '@patternfly/react-core';
 import { Plus, Trash2, ScrollText, AlertCircle } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import {
-  addRule,
-  removeRule,
+  addRuleAndPersist,
   fetchRules,
+  persistClearRules,
+  persistRemoveRule,
+  persistRule,
+  setRuleActive,
+  removeRule,
+  clearRules,
   selectRules,
-  selectPersonalizationLoading,
-  selectPersonalizationError,
 } from '../../redux/slices/personalization';
 
 export function RulesEditor() {
   const dispatch = useAppDispatch();
   const rules = useAppSelector(selectRules);
-  const loading = useAppSelector(selectPersonalizationLoading);
-  const error = useAppSelector(selectPersonalizationError);
   const [draft, setDraft] = useState('');
 
   useEffect(() => {
@@ -25,7 +26,7 @@ export function RulesEditor() {
   const handleAdd = () => {
     const text = draft.trim();
     if (!text) return;
-    dispatch(addRule(text));
+    void dispatch(addRuleAndPersist(text));
     setDraft('');
   };
 
@@ -45,13 +46,6 @@ export function RulesEditor() {
           unless individually disabled.
         </p>
       </div>
-
-      {error && (
-        <div className="flex items-start gap-3 p-3 rounded-lg bg-red-500/5 border border-red-500/20">
-          <AlertCircle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-          <p className="text-xs text-red-400/80">{error}</p>
-        </div>
-      )}
 
       <div className="flex gap-2">
         <textarea
@@ -76,12 +70,7 @@ export function RulesEditor() {
         </Button>
       </div>
 
-      {loading ? (
-        <div className="flex flex-col items-center py-8">
-          <Spinner size="md" />
-          <p className="text-sm text-muted-foreground/60 mt-2">Loading rules...</p>
-        </div>
-      ) : rules.length === 0 ? (
+      {rules.length === 0 ? (
         <div className="flex flex-col items-center py-8 text-center">
           <ScrollText className="w-8 h-8 text-muted-foreground/30 mb-2" aria-hidden="true" />
           <p className="text-sm text-muted-foreground">No custom rules</p>
@@ -97,10 +86,34 @@ export function RulesEditor() {
                 key={rule.id}
                 className="group flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-secondary/30 transition-colors"
               >
-                <ScrollText className="w-4 h-4 text-primary/60 mt-0.5 shrink-0" />
-                <p className="flex-1 text-sm text-foreground leading-relaxed">{rule.content}</p>
+                <Switch
+                  id={`rule-toggle-${rule.id}`}
+                  aria-label={`Toggle rule: ${rule.content.substring(0, 50)}`}
+                  isChecked={rule.isActive}
+                  onChange={(_event, checked) => {
+                    dispatch(setRuleActive({ id: rule.id, isActive: checked }));
+                    void dispatch(
+                      persistRule({
+                        id: rule.id,
+                        content: rule.content,
+                        isActive: checked,
+                      }),
+                    );
+                  }}
+                  className="mt-0.5"
+                />
+                <p
+                  className={`flex-1 text-sm leading-relaxed ${
+                    rule.isActive ? 'text-foreground' : 'text-muted-foreground line-through'
+                  }`}
+                >
+                  {rule.content}
+                </p>
                 <button
-                  onClick={() => dispatch(removeRule(rule.id))}
+                  onClick={() => {
+                    dispatch(removeRule(rule.id));
+                    void dispatch(persistRemoveRule(rule.id));
+                  }}
                   className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
                   aria-label={`Remove rule: ${rule.content.substring(0, 50)}`}
                 >
@@ -109,6 +122,21 @@ export function RulesEditor() {
               </li>
             ))}
           </ul>
+          {rules.length > 1 && (
+            <div className="flex justify-end">
+              <Button
+                variant="plain"
+                isDanger
+                size="sm"
+                onClick={() => {
+                  dispatch(clearRules());
+                  void dispatch(persistClearRules());
+                }}
+              >
+                Clear all rules
+              </Button>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -29,7 +29,6 @@ import { buildAppPath } from '@/lib/app-paths';
 import { addToast } from '@/redux/slices/toasts';
 import { assignThreadToProjectThunk } from '@/redux/slices/projects';
 import { isClientCreatedChat } from '@/services/newChatTracker';
-import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { selectAlwaysAllowedTools } from '@/redux/slices/userSettings';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
 import type { HITLInterruptValue, InterruptInfo } from '@/types/deep-agent';
@@ -258,8 +257,6 @@ export function useStreamingAPI(threadId: string) {
   const chat = useAppSelector((state) => selectChatById(state, threadId));
   const streamingState = useAppSelector((state) => selectStreamingState(state, threadId));
 
-  const memories = useAppSelector(selectMemories);
-  const activeRules = useAppSelector(selectActiveRules);
   const alwaysAllowedTools = useAppSelector(selectAlwaysAllowedTools);
 
   const messages = useMemo(() => chat?.messages ?? EMPTY_MESSAGES, [chat?.messages]);
@@ -456,8 +453,6 @@ export function useStreamingAPI(threadId: string) {
         userId,
         apiUrl,
         token,
-        memories: memories.map((m) => m.content),
-        rules: activeRules.map((r) => r.content),
         projectId: chatRef.current?.project_id,
       };
       const wasClientCreated = isClientCreatedChat(threadId);
@@ -991,7 +986,7 @@ export function useStreamingAPI(threadId: string) {
         }, RECOVERY_POLL_INTERVAL_MS);
       }
     },
-    [dispatch, threadId, memories, activeRules, handleStreamActivityStatus, clearReconnectTimers, setMessages, setWasInterrupted],
+    [dispatch, threadId, handleStreamActivityStatus, clearReconnectTimers, setMessages, setWasInterrupted],
   );
 
   /**
@@ -1049,8 +1044,6 @@ export function useStreamingAPI(threadId: string) {
         userId,
         apiUrl,
         token,
-        memories: memories.map((m) => m.content),
-        rules: activeRules.map((r) => r.content),
         resume: true,
         resumeDecisions: decisions,
       };
@@ -1153,7 +1146,7 @@ export function useStreamingAPI(threadId: string) {
         try { localStorage.removeItem(`pending-decision:${threadId}`); } catch { /* ignore */ }
       }
     },
-    [dispatch, threadId, memories, activeRules],
+    [dispatch, threadId],
   );
 
   const resumeInterrupt = useCallback(
@@ -1182,8 +1175,6 @@ export function useStreamingAPI(threadId: string) {
         apiUrl,
         token,
         resume: true,
-        memories: memories.map((m) => m.content),
-        rules: activeRules.map((r) => r.content),
       };
 
       let resumeStreamHadInterrupt = false;
@@ -1265,7 +1256,7 @@ export function useStreamingAPI(threadId: string) {
         void manager.stream(streamRequest, callbacks);
       });
     },
-    [dispatch, threadId, memories, activeRules],
+    [dispatch, threadId],
   );
 
   // Auto-replay queued HITL decisions when an interrupt appears after recovery

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -14,8 +14,6 @@ export interface StreamRequest {
   userId: string;
   apiUrl: string;
   token?: string;
-  memories?: string[];
-  rules?: string[];
   projectId?: string | null;
   resume?: boolean;
   resumeDecisions?: Array<{ type: 'approve' | 'reject' | 'edit'; message?: string }>;
@@ -146,8 +144,6 @@ export class StreamingManager {
         stream_tokens: true,
       };
       if (request.resume) body.resume = true;
-      if (request.memories?.length) body.memories = request.memories;
-      if (request.rules?.length) body.rules = request.rules;
       if (request.projectId) body.project_id = request.projectId;
 
       const response = await fetch(streamUrl, {

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -11,25 +11,65 @@ import '@patternfly/patternfly/patternfly-addons.css';
 
 import './global.css';
 
-// Parse server-injected data from data attributes (CSP-safe, no inline scripts)
-const rootEl = document.getElementById('root')!;
-try {
-  const userData = rootEl.dataset.user;
-  const appData = rootEl.dataset.app;
-  (window as any).USER_DATA = userData ? JSON.parse(decodeURIComponent(userData)) : {};
-  (window as any).APP_DATA = appData ? JSON.parse(decodeURIComponent(appData)) : {};
-} catch (e) {
-  console.error('Failed to parse injected data:', e);
-  (window as any).USER_DATA = {};
-  (window as any).APP_DATA = {};
+type InjectedRecord = Record<string, unknown>;
+
+function parseInjected(rootEl: HTMLElement): { user: InjectedRecord; app: InjectedRecord } {
+  try {
+    const userData = rootEl.dataset.user;
+    const appData = rootEl.dataset.app;
+    return {
+      user: userData ? JSON.parse(decodeURIComponent(userData)) : {},
+      app: appData ? JSON.parse(decodeURIComponent(appData)) : {},
+    };
+  } catch (e) {
+    console.error('Failed to parse injected data:', e);
+    return { user: {}, app: {} };
+  }
 }
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <BrowserRouter basename={getAppBasePath()}>
-      <Provider store={store}>
-        <App />
-      </Provider>
-    </BrowserRouter>
-  </StrictMode>
-);
+function isSparseUser(user: InjectedRecord): boolean {
+  return !user.preferred_username && !user.name && !user.email && !user.displayName && !user.sub;
+}
+
+async function loadSessionUser(injected: InjectedRecord): Promise<InjectedRecord | 'login'> {
+  if (!isSparseUser(injected)) return injected;
+  try {
+    const res = await fetch('/api/me', {
+      credentials: 'include',
+      headers: { Accept: 'application/json' },
+      redirect: 'manual',
+    });
+    if (res.status === 401) return 'login';
+    const contentType = res.headers.get('content-type') || '';
+    if (!res.ok || !contentType.includes('application/json')) return injected;
+    const body = await res.json();
+    return body && typeof body === 'object' ? (body as InjectedRecord) : injected;
+  } catch {
+    return injected;
+  }
+}
+
+async function boot() {
+  const rootEl = document.getElementById('root')!;
+  const injected = parseInjected(rootEl);
+  (window as any).APP_DATA = injected.app;
+  const sessionUser = await loadSessionUser(injected.user);
+  if (sessionUser === 'login') {
+    window.location.replace('/login');
+    return;
+  }
+  (window as any).USER_DATA = sessionUser;
+
+  createRoot(rootEl).render(
+    <StrictMode>
+      <BrowserRouter basename={getAppBasePath()}>
+        <Provider store={store}>
+          <App />
+        </Provider>
+      </BrowserRouter>
+    </StrictMode>
+  );
+}
+
+void boot();
+

--- a/src/frontend/pages/SettingsPage.tsx
+++ b/src/frontend/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
 import { ArrowLeft, User, Brain, ScrollText, Palette, ShieldCheck, Code2, KeyRound } from 'lucide-react';
@@ -12,12 +12,13 @@ import { DeveloperSettings } from '../components/settings/DeveloperSettings';
 import { useAppSelector } from '../redux/hooks';
 import { selectDeveloperMode } from '../redux/slices/userSettings';
 import { OAuthConnections } from '../components/settings/OAuthConnections';
+import type { RootState } from '../redux/store';
 
 type TabId = 'profile' | 'memories' | 'rules' | 'appearance' | 'tool-approvals' | 'oauth' | 'developer';
 
 const TABS: { id: TabId; label: string; panelTitle?: string; icon: typeof User }[] = [
   { id: 'profile', label: 'Profile', icon: User },
-  { id: 'memories', label: 'Memories', icon: Brain },
+  { id: 'memories', label: 'Your Memories', icon: Brain },
   { id: 'rules', label: 'Custom Rules', icon: ScrollText },
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'tool-approvals', label: 'Tool Approvals', icon: ShieldCheck },
@@ -41,6 +42,7 @@ export function SettingsPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const developerMode = useAppSelector(selectDeveloperMode);
+  const features = useAppSelector((state: RootState) => state.config.features);
   const [activeTab, setActiveTab] = useState<TabId>(() => {
     const param = searchParams.get('tab');
     if (param && VALID_TABS.has(param)) {
@@ -50,13 +52,20 @@ export function SettingsPage() {
     return 'profile';
   });
   const tabRefs = useRef<Map<TabId, HTMLButtonElement>>(new Map());
-  const visibleTabs = TABS.filter((t) => t.id !== 'developer' || developerMode);
+
+  const visibleTabs = useMemo(() => {
+    return TABS.filter((tab) => {
+      if (tab.id === 'developer') return developerMode;
+      if (tab.id === 'memories') return features?.memory_enabled !== false;
+      return true;
+    });
+  }, [features, developerMode]);
 
   useEffect(() => {
-    if (activeTab === 'developer' && !developerMode) {
-      setActiveTab('profile');
+    if (visibleTabs.length > 0 && !visibleTabs.some((t) => t.id === activeTab)) {
+      setActiveTab(visibleTabs[0].id);
     }
-  }, [developerMode, activeTab]);
+  }, [visibleTabs, activeTab]);
 
   const handleTabKeyDown = (e: React.KeyboardEvent, tabId: TabId) => {
     const tabIds = visibleTabs.map((t) => t.id);
@@ -102,45 +111,47 @@ export function SettingsPage() {
         <div className="max-w-4xl mx-auto px-6 py-6">
           <div className="flex flex-col sm:flex-row gap-6">
             {/* Tab navigation */}
-            <div
-              role="tablist"
-              aria-orientation="vertical"
-              aria-label="Settings sections"
-              className="sm:w-48 shrink-0 flex sm:flex-col gap-1"
-            >
-              {visibleTabs.map((tab) => {
-                const Icon = tab.icon;
-                const isActive = activeTab === tab.id;
-                return (
-                  <button
-                    key={tab.id}
-                    id={`settings-tab-${tab.id}`}
-                    role="tab"
-                    aria-selected={isActive}
-                    aria-controls={`settings-panel-${tab.id}`}
-                    tabIndex={isActive ? 0 : -1}
-                    ref={(el) => {
-                      if (el) tabRefs.current.set(tab.id, el);
-                    }}
-                    onClick={() => setActiveTab(tab.id)}
-                    onKeyDown={(e) => handleTabKeyDown(e, tab.id)}
-                    className={cn(
-                      'w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer',
-                      isActive
-                        ? 'bg-primary/10 text-primary'
-                        : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
-                    )}
-                  >
-                    <Icon className="w-4 h-4" aria-hidden="true" />
-                    {tab.label}
-                  </button>
-                );
-              })}
-            </div>
+            <nav className="sm:w-48 shrink-0" aria-label="Settings sections">
+              <div
+                role="tablist"
+                aria-orientation="vertical"
+                aria-label="Settings"
+                className="flex sm:flex-col gap-1"
+              >
+                {visibleTabs.map((tab) => {
+                  const Icon = tab.icon;
+                  const isActive = activeTab === tab.id;
+                  return (
+                    <button
+                      key={tab.id}
+                      id={`settings-tab-${tab.id}`}
+                      role="tab"
+                      aria-selected={isActive}
+                      aria-controls={`settings-panel-${tab.id}`}
+                      tabIndex={isActive ? 0 : -1}
+                      ref={(el) => {
+                        if (el) tabRefs.current.set(tab.id, el);
+                      }}
+                      onClick={() => setActiveTab(tab.id)}
+                      onKeyDown={(e) => handleTabKeyDown(e, tab.id)}
+                      className={cn(
+                        'w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer',
+                        isActive
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground',
+                      )}
+                    >
+                      <Icon className="w-4 h-4" aria-hidden="true" />
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </nav>
 
             {/* Content */}
             <div className="flex-1 min-w-0">
-              {TABS.map((tab) => {
+              {visibleTabs.map((tab) => {
                 const Content = TAB_CONTENT[tab.id];
                 return (
                   <div

--- a/src/frontend/redux/slices/personalization.test.ts
+++ b/src/frontend/redux/slices/personalization.test.ts
@@ -1,0 +1,84 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { scopedStorageKey } from '../../lib/app-paths';
+import personalizationReducer, {
+  addRule,
+  persistRule,
+  toggleRule,
+} from './personalization';
+
+const STORAGE_KEY = scopedStorageKey('template-ui-personalization');
+
+describe('personalization slice — rules toggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response(JSON.stringify({ rules: [] }), { status: 200 }))),
+    );
+  });
+
+  it('toggleRule persists isActive locally', () => {
+    let state = personalizationReducer(undefined, { type: '@@INIT' });
+    state = personalizationReducer(state, addRule('Always answer in Spanish'));
+    const rule = state.rules[0];
+    expect(rule.isActive).toBe(true);
+
+    state = personalizationReducer(state, toggleRule(rule.id));
+
+    expect(state.rules[0].isActive).toBe(false);
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.rules[0].isActive).toBe(false);
+  });
+
+  it('persistRule POSTs the toggled flag then refetches from the API', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.includes('/personalization/rules') && init?.method === 'POST') {
+        return Promise.resolve(new Response('{}', { status: 201 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            rules: [
+              {
+                id: 'server-id',
+                content: 'Always answer in Spanish',
+                is_active: false,
+                created_at: '2026-09-09T00:00:00Z',
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    const store = configureStore({ reducer: { personalization: personalizationReducer } });
+    store.dispatch(addRule('Always answer in Spanish'));
+    const ruleId = store.getState().personalization.rules[0].id;
+    store.dispatch(toggleRule(ruleId));
+
+    await store.dispatch(
+      persistRule({
+        id: ruleId,
+        content: 'Always answer in Spanish',
+        isActive: false,
+      }),
+    );
+
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(postCall).toBeTruthy();
+    const body = JSON.parse(String(postCall![1]?.body));
+    expect(body).toMatchObject({
+      id: ruleId,
+      content: 'Always answer in Spanish',
+      is_active: false,
+    });
+    expect(store.getState().personalization.rules[0]).toMatchObject({
+      id: 'server-id',
+      isActive: false,
+    });
+  });
+});

--- a/src/frontend/redux/slices/personalization.ts
+++ b/src/frontend/redux/slices/personalization.ts
@@ -1,12 +1,13 @@
-import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { v4 as uuidv4 } from 'uuid';
-import { buildAgentApiUrl, scopedStorageKey } from '../../lib/app-paths';
+import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
+import { buildAgentApiUrl } from '../../lib/app-paths';
 import { authenticatedFetch } from '../../services/authenticated-fetch';
 
 export interface MemoryItem {
   id: string;
   content: string;
+  score: number;
   createdAt: string;
+  updatedAt: string;
 }
 
 export interface RuleItem {
@@ -14,140 +15,176 @@ export interface RuleItem {
   content: string;
   isActive: boolean;
   createdAt: string;
+  updatedAt: string;
 }
 
 interface PersonalizationState {
   memories: MemoryItem[];
   rules: RuleItem[];
+  loading: boolean;
+  error: string | null;
 }
 
-const STORAGE_KEY = scopedStorageKey('template-ui-personalization');
+const initialState: PersonalizationState = {
+  memories: [],
+  rules: [],
+  loading: false,
+  error: null,
+};
 
-function loadState(): PersonalizationState {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) return JSON.parse(stored);
-  } catch {
-    /* ignore */
-  }
-  return { memories: [], rules: [] };
-}
+// ── Async thunks ────────────────────────────────────────────────────
 
-function persist(state: PersonalizationState) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    /* ignore */
-  }
-}
+export const fetchMemories = createAsyncThunk(
+  'personalization/fetchMemories',
+  async () => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/memories'));
+    if (!resp.ok) throw new Error(`Failed to fetch memories: ${resp.status}`);
+    const data = await resp.json();
+    return data.map((m: { id: string; content: string; score: number; created_at: string; updated_at: string }) => ({
+      id: m.id,
+      content: m.content,
+      score: m.score,
+      createdAt: m.created_at,
+      updatedAt: m.updated_at,
+    })) as MemoryItem[];
+  },
+);
 
-function apiCreateMemory(id: string, content: string) {
-  authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
-    method: 'POST',
-    body: JSON.stringify({ id, content }),
-  }).catch(() => {});
-}
+export const addMemory = createAsyncThunk(
+  'personalization/addMemory',
+  async (content: string) => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
+      method: 'POST',
+      body: JSON.stringify({ content }),
+    });
+    if (!resp.ok) throw new Error(`Failed to create memory: ${resp.status}`);
+    const m = await resp.json();
+    return {
+      id: m.id,
+      content: m.content,
+      score: m.score,
+      createdAt: m.created_at,
+      updatedAt: m.updated_at,
+    } as MemoryItem;
+  },
+);
 
-function apiDeleteMemory(id: string) {
-  authenticatedFetch(buildAgentApiUrl(`/personalization/memories/${id}`), {
-    method: 'DELETE',
-  }).catch(() => {});
-}
+export const removeMemory = createAsyncThunk(
+  'personalization/removeMemory',
+  async (memoryId: string) => {
+    const resp = await authenticatedFetch(
+      buildAgentApiUrl(`/personalization/memories/${encodeURIComponent(memoryId)}`),
+      { method: 'DELETE' },
+    );
+    if (!resp.ok && resp.status !== 404) throw new Error(`Failed to delete memory: ${resp.status}`);
+    return memoryId;
+  },
+);
 
-function apiCreateRule(id: string, content: string, isActive: boolean) {
-  authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
-    method: 'POST',
-    body: JSON.stringify({ id, content, is_active: isActive }),
-  }).catch(() => {});
-}
+export const fetchRules = createAsyncThunk(
+  'personalization/fetchRules',
+  async () => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/rules'));
+    if (!resp.ok) throw new Error(`Failed to fetch rules: ${resp.status}`);
+    const data = await resp.json();
+    return data.map((r: { id: string; content: string; is_active: boolean; created_at: string; updated_at: string }) => ({
+      id: r.id,
+      content: r.content,
+      isActive: r.is_active,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    })) as RuleItem[];
+  },
+);
 
-function apiDeleteRule(id: string) {
-  authenticatedFetch(buildAgentApiUrl(`/personalization/rules/${id}`), {
-    method: 'DELETE',
-  }).catch(() => {});
-}
+export const addRule = createAsyncThunk(
+  'personalization/addRule',
+  async (content: string) => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
+      method: 'POST',
+      body: JSON.stringify({ content, is_active: true }),
+    });
+    if (!resp.ok) throw new Error(`Failed to create rule: ${resp.status}`);
+    const r = await resp.json();
+    return {
+      id: r.id,
+      content: r.content,
+      isActive: r.is_active,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    } as RuleItem;
+  },
+);
+
+export const removeRule = createAsyncThunk(
+  'personalization/removeRule',
+  async (ruleId: string) => {
+    const resp = await authenticatedFetch(
+      buildAgentApiUrl(`/personalization/rules/${encodeURIComponent(ruleId)}`),
+      { method: 'DELETE' },
+    );
+    if (!resp.ok && resp.status !== 404) throw new Error(`Failed to delete rule: ${resp.status}`);
+    return ruleId;
+  },
+);
+
+// ── Slice ───────────────────────────────────────────────────────────
 
 const personalizationSlice = createSlice({
   name: 'personalization',
-  initialState: loadState(),
+  initialState,
   reducers: {
-    addMemory(state, action: PayloadAction<string>) {
-      const id = uuidv4();
-      state.memories.unshift({
-        id,
-        content: action.payload,
-        createdAt: new Date().toISOString(),
-      });
-      persist(state);
-      apiCreateMemory(id, action.payload);
+    resetPersonalization() {
+      return initialState;
     },
-    removeMemory(state, action: PayloadAction<string>) {
-      state.memories = state.memories.filter((m) => m.id !== action.payload);
-      persist(state);
-      apiDeleteMemory(action.payload);
-    },
-    clearMemories(state) {
-      const ids = state.memories.map((m) => m.id);
-      state.memories = [];
-      persist(state);
-      ids.forEach(apiDeleteMemory);
-    },
+  },
+  extraReducers: (builder) => {
+    // Memories
+    builder
+      .addCase(fetchMemories.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchMemories.fulfilled, (state, action) => {
+        state.memories = action.payload;
+        state.loading = false;
+      })
+      .addCase(fetchMemories.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || 'Failed to load memories';
+      })
+      .addCase(addMemory.fulfilled, (state, action) => {
+        state.memories.unshift(action.payload);
+      })
+      .addCase(removeMemory.fulfilled, (state, action) => {
+        state.memories = state.memories.filter((m) => m.id !== action.payload);
+      })
 
-    addRule(state, action: PayloadAction<string>) {
-      const id = uuidv4();
-      state.rules.unshift({
-        id,
-        content: action.payload,
-        isActive: true,
-        createdAt: new Date().toISOString(),
+    // Rules
+      .addCase(fetchRules.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchRules.fulfilled, (state, action) => {
+        state.rules = action.payload;
+        state.loading = false;
+      })
+      .addCase(fetchRules.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.error.message || 'Failed to load rules';
+      })
+      .addCase(addRule.fulfilled, (state, action) => {
+        state.rules.unshift(action.payload);
+      })
+      .addCase(removeRule.fulfilled, (state, action) => {
+        state.rules = state.rules.filter((r) => r.id !== action.payload);
       });
-      persist(state);
-      apiCreateRule(id, action.payload, true);
-    },
-    updateRule(state, action: PayloadAction<{ id: string; content: string }>) {
-      const rule = state.rules.find((r) => r.id === action.payload.id);
-      if (rule) rule.content = action.payload.content;
-      persist(state);
-    },
-    toggleRule(state, action: PayloadAction<string>) {
-      const rule = state.rules.find((r) => r.id === action.payload);
-      if (rule) rule.isActive = !rule.isActive;
-      persist(state);
-    },
-    removeRule(state, action: PayloadAction<string>) {
-      state.rules = state.rules.filter((r) => r.id !== action.payload);
-      persist(state);
-      apiDeleteRule(action.payload);
-    },
-    clearRules(state) {
-      const ids = state.rules.map((r) => r.id);
-      state.rules = [];
-      persist(state);
-      ids.forEach(apiDeleteRule);
-    },
-    resetPersonalization(state) {
-      const memIds = state.memories.map((m) => m.id);
-      const ruleIds = state.rules.map((r) => r.id);
-      state.memories = [];
-      state.rules = [];
-      persist(state);
-      memIds.forEach(apiDeleteMemory);
-      ruleIds.forEach(apiDeleteRule);
-    },
   },
 });
 
-export const {
-  addMemory,
-  removeMemory,
-  clearMemories,
-  addRule,
-  updateRule,
-  toggleRule,
-  removeRule,
-  clearRules,
-  resetPersonalization,
-} = personalizationSlice.actions;
+export const { resetPersonalization } = personalizationSlice.actions;
+
+// ── Selectors ───────────────────────────────────────────────────────
 
 export const selectMemories = (state: { personalization: PersonalizationState }) =>
   state.personalization.memories;
@@ -157,5 +194,9 @@ export const selectActiveRules = createSelector(
   selectRules,
   (rules) => rules.filter((r) => r.isActive),
 );
+export const selectPersonalizationLoading = (state: { personalization: PersonalizationState }) =>
+  state.personalization.loading;
+export const selectPersonalizationError = (state: { personalization: PersonalizationState }) =>
+  state.personalization.error;
 
 export default personalizationSlice.reducer;

--- a/src/frontend/redux/slices/personalization.ts
+++ b/src/frontend/redux/slices/personalization.ts
@@ -1,38 +1,63 @@
-import { createAsyncThunk, createSelector, createSlice } from '@reduxjs/toolkit';
-import { buildAgentApiUrl } from '../../lib/app-paths';
+import { createAsyncThunk, createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { v4 as uuidv4 } from 'uuid';
+import { buildAgentApiUrl, scopedStorageKey } from '../../lib/app-paths';
 import { authenticatedFetch } from '../../services/authenticated-fetch';
+
+// ── Memory items (individual facts from LangGraph Store) ────────────
 
 export interface MemoryItem {
   id: string;
   content: string;
-  score: number;
   createdAt: string;
-  updatedAt: string;
 }
+
+// ── Rules (origin/main localStorage + fire-and-forget API) ──────────
 
 export interface RuleItem {
   id: string;
   content: string;
   isActive: boolean;
   createdAt: string;
-  updatedAt: string;
 }
 
 interface PersonalizationState {
   memories: MemoryItem[];
   rules: RuleItem[];
-  loading: boolean;
+  memoriesLoading: boolean;
   error: string | null;
+}
+
+const STORAGE_KEY = scopedStorageKey('template-ui-personalization');
+
+function loadRules(): RuleItem[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored) as { rules?: RuleItem[] };
+      if (Array.isArray(parsed.rules)) return parsed.rules;
+    }
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+function persistRules(rules: RuleItem[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ memories: [], rules }));
+  } catch {
+    /* ignore */
+  }
 }
 
 const initialState: PersonalizationState = {
   memories: [],
-  rules: [],
-  loading: false,
+  rules: loadRules(),
+  memoriesLoading: false,
   error: null,
 };
 
-// ── Async thunks ────────────────────────────────────────────────────
+// ── Memory thunks (memory-branch Store API) ─────────────────────────
 
 export const fetchMemories = createAsyncThunk(
   'personalization/fetchMemories',
@@ -40,44 +65,11 @@ export const fetchMemories = createAsyncThunk(
     const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/memories'));
     if (!resp.ok) throw new Error(`Failed to fetch memories: ${resp.status}`);
     const data = await resp.json();
-    return data.map((m: { id: string; content: string; score: number; created_at: string; updated_at: string }) => ({
+    return data.map((m: { id: string; content: string; created_at: string }) => ({
       id: m.id,
       content: m.content,
-      score: m.score,
       createdAt: m.created_at,
-      updatedAt: m.updated_at,
     })) as MemoryItem[];
-  },
-);
-
-export const addMemory = createAsyncThunk(
-  'personalization/addMemory',
-  async (content: string) => {
-    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
-      method: 'POST',
-      body: JSON.stringify({ content }),
-    });
-    if (!resp.ok) throw new Error(`Failed to create memory: ${resp.status}`);
-    const m = await resp.json();
-    return {
-      id: m.id,
-      content: m.content,
-      score: m.score,
-      createdAt: m.created_at,
-      updatedAt: m.updated_at,
-    } as MemoryItem;
-  },
-);
-
-export const removeMemory = createAsyncThunk(
-  'personalization/removeMemory',
-  async (memoryId: string) => {
-    const resp = await authenticatedFetch(
-      buildAgentApiUrl(`/personalization/memories/${encodeURIComponent(memoryId)}`),
-      { method: 'DELETE' },
-    );
-    if (!resp.ok && resp.status !== 404) throw new Error(`Failed to delete memory: ${resp.status}`);
-    return memoryId;
   },
 );
 
@@ -86,45 +78,79 @@ export const fetchRules = createAsyncThunk(
   async () => {
     const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/rules'));
     if (!resp.ok) throw new Error(`Failed to fetch rules: ${resp.status}`);
-    const data = await resp.json();
-    return data.map((r: { id: string; content: string; is_active: boolean; created_at: string; updated_at: string }) => ({
+    const data = (await resp.json()) as {
+      rules?: { id: string; content: string; is_active?: boolean; created_at: string }[];
+    };
+    const rules = Array.isArray(data.rules) ? data.rules : [];
+    return rules.map((r) => ({
       id: r.id,
       content: r.content,
-      isActive: r.is_active,
+      isActive: r.is_active !== false,
       createdAt: r.created_at,
-      updatedAt: r.updated_at,
     })) as RuleItem[];
   },
 );
 
-export const addRule = createAsyncThunk(
-  'personalization/addRule',
-  async (content: string) => {
+type PersonalizationRoot = { personalization: PersonalizationState };
+
+type PersistRulePayload = { id: string; content: string; isActive: boolean };
+
+export const persistRule = createAsyncThunk(
+  'personalization/persistRule',
+  async ({ id, content, isActive }: PersistRulePayload, { dispatch }) => {
     const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
       method: 'POST',
-      body: JSON.stringify({ content, is_active: true }),
+      body: JSON.stringify({ id, content, is_active: isActive }),
     });
-    if (!resp.ok) throw new Error(`Failed to create rule: ${resp.status}`);
-    const r = await resp.json();
-    return {
-      id: r.id,
-      content: r.content,
-      isActive: r.is_active,
-      createdAt: r.created_at,
-      updatedAt: r.updated_at,
-    } as RuleItem;
+    if (!resp.ok) throw new Error(`Failed to save rule: ${resp.status}`);
+    await dispatch(fetchRules()).unwrap();
   },
 );
 
-export const removeRule = createAsyncThunk(
-  'personalization/removeRule',
-  async (ruleId: string) => {
+export const persistRemoveRule = createAsyncThunk(
+  'personalization/persistRemoveRule',
+  async (id: string, { dispatch }) => {
     const resp = await authenticatedFetch(
-      buildAgentApiUrl(`/personalization/rules/${encodeURIComponent(ruleId)}`),
+      buildAgentApiUrl(`/personalization/rules/${encodeURIComponent(id)}`),
       { method: 'DELETE' },
     );
-    if (!resp.ok && resp.status !== 404) throw new Error(`Failed to delete rule: ${resp.status}`);
-    return ruleId;
+    if (!resp.ok && resp.status !== 404)
+      throw new Error(`Failed to delete rule: ${resp.status}`);
+    await dispatch(fetchRules()).unwrap();
+  },
+);
+
+export const persistClearRules = createAsyncThunk(
+  'personalization/persistClearRules',
+  async (_, { dispatch }) => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
+      method: 'DELETE',
+    });
+    if (!resp.ok) throw new Error(`Failed to clear rules: ${resp.status}`);
+    await dispatch(fetchRules()).unwrap();
+  },
+);
+
+export const deleteMemory = createAsyncThunk(
+  'personalization/deleteMemory',
+  async (memoryId: string) => {
+    const resp = await authenticatedFetch(
+      buildAgentApiUrl(`/personalization/memories/${encodeURIComponent(memoryId)}`),
+      { method: 'DELETE' },
+    );
+    if (!resp.ok && resp.status !== 404)
+      throw new Error(`Failed to delete memory: ${resp.status}`);
+    return memoryId;
+  },
+);
+
+export const deleteAllMemories = createAsyncThunk(
+  'personalization/deleteAllMemories',
+  async () => {
+    const resp = await authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
+      method: 'DELETE',
+    });
+    if (!resp.ok) throw new Error(`Failed to delete all memories: ${resp.status}`);
   },
 );
 
@@ -134,68 +160,115 @@ const personalizationSlice = createSlice({
   name: 'personalization',
   initialState,
   reducers: {
-    resetPersonalization() {
-      return initialState;
+    addRule(state, action: PayloadAction<string>) {
+      const id = uuidv4();
+      state.rules.unshift({
+        id,
+        content: action.payload,
+        isActive: true,
+        createdAt: new Date().toISOString(),
+      });
+      persistRules(state.rules);
+    },
+    updateRule(state, action: PayloadAction<{ id: string; content: string }>) {
+      const rule = state.rules.find((r) => r.id === action.payload.id);
+      if (rule) rule.content = action.payload.content;
+      persistRules(state.rules);
+    },
+    toggleRule(state, action: PayloadAction<string>) {
+      const rule = state.rules.find((r) => r.id === action.payload);
+      if (!rule) return;
+      rule.isActive = !rule.isActive;
+      persistRules(state.rules);
+    },
+    setRuleActive(state, action: PayloadAction<{ id: string; isActive: boolean }>) {
+      const rule = state.rules.find((r) => r.id === action.payload.id);
+      if (!rule) return;
+      rule.isActive = action.payload.isActive;
+      persistRules(state.rules);
+    },
+    removeRule(state, action: PayloadAction<string>) {
+      state.rules = state.rules.filter((r) => r.id !== action.payload);
+      persistRules(state.rules);
+    },
+    clearRules(state) {
+      state.rules = [];
+      persistRules(state.rules);
+    },
+    resetPersonalization(state) {
+      state.memories = [];
+      state.rules = [];
+      state.error = null;
+      persistRules([]);
     },
   },
   extraReducers: (builder) => {
-    // Memories
     builder
       .addCase(fetchMemories.pending, (state) => {
-        state.loading = true;
+        state.memoriesLoading = true;
         state.error = null;
       })
       .addCase(fetchMemories.fulfilled, (state, action) => {
         state.memories = action.payload;
-        state.loading = false;
+        state.memoriesLoading = false;
       })
       .addCase(fetchMemories.rejected, (state, action) => {
-        state.loading = false;
+        state.memoriesLoading = false;
         state.error = action.error.message || 'Failed to load memories';
-      })
-      .addCase(addMemory.fulfilled, (state, action) => {
-        state.memories.unshift(action.payload);
-      })
-      .addCase(removeMemory.fulfilled, (state, action) => {
-        state.memories = state.memories.filter((m) => m.id !== action.payload);
-      })
-
-    // Rules
-      .addCase(fetchRules.pending, (state) => {
-        state.loading = true;
-        state.error = null;
       })
       .addCase(fetchRules.fulfilled, (state, action) => {
         state.rules = action.payload;
-        state.loading = false;
+        persistRules(state.rules);
       })
-      .addCase(fetchRules.rejected, (state, action) => {
-        state.loading = false;
-        state.error = action.error.message || 'Failed to load rules';
+      .addCase(persistRule.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to save rule';
       })
-      .addCase(addRule.fulfilled, (state, action) => {
-        state.rules.unshift(action.payload);
+      .addCase(persistRemoveRule.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to delete rule';
       })
-      .addCase(removeRule.fulfilled, (state, action) => {
-        state.rules = state.rules.filter((r) => r.id !== action.payload);
+      .addCase(persistClearRules.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to clear rules';
+      })
+      .addCase(deleteMemory.fulfilled, (state, action) => {
+        state.memories = state.memories.filter((m) => m.id !== action.payload);
+      })
+      .addCase(deleteMemory.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to delete memory';
+      })
+      .addCase(deleteAllMemories.fulfilled, (state) => {
+        state.memories = [];
+      })
+      .addCase(deleteAllMemories.rejected, (state, action) => {
+        state.error = action.error.message || 'Failed to delete all memories';
       });
   },
 });
 
-export const { resetPersonalization } = personalizationSlice.actions;
+export const { addRule, updateRule, toggleRule, setRuleActive, removeRule, clearRules, resetPersonalization } =
+  personalizationSlice.actions;
 
-// ── Selectors ───────────────────────────────────────────────────────
+export const addRuleAndPersist = createAsyncThunk(
+  'personalization/addRuleAndPersist',
+  async (content: string, { dispatch, getState }) => {
+    dispatch(addRule(content));
+    const rule = (getState() as PersonalizationRoot).personalization.rules[0];
+    if (rule) {
+      await dispatch(
+        persistRule({ id: rule.id, content: rule.content, isActive: rule.isActive }),
+      ).unwrap();
+    }
+  },
+);
 
 export const selectMemories = (state: { personalization: PersonalizationState }) =>
   state.personalization.memories;
 export const selectRules = (state: { personalization: PersonalizationState }) =>
   state.personalization.rules;
-export const selectActiveRules = createSelector(
-  selectRules,
-  (rules) => rules.filter((r) => r.isActive),
+export const selectActiveRules = createSelector(selectRules, (rules) =>
+  rules.filter((r) => r.isActive),
 );
-export const selectPersonalizationLoading = (state: { personalization: PersonalizationState }) =>
-  state.personalization.loading;
+export const selectMemoriesLoading = (state: { personalization: PersonalizationState }) =>
+  state.personalization.memoriesLoading;
 export const selectPersonalizationError = (state: { personalization: PersonalizationState }) =>
   state.personalization.error;
 

--- a/src/frontend/services/config.service.ts
+++ b/src/frontend/services/config.service.ts
@@ -19,6 +19,7 @@ export interface FeaturesConfig {
   debug_mode_default: boolean;
   auth_enabled: boolean;
   mcp_apps_enabled?: boolean;
+  memory_enabled: boolean;
 }
 
 function getConfigApiBase(): string {

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -381,6 +381,27 @@ describe('Public /api routes — accessible without auth', () => {
   });
 });
 
+// ── GET /api/me — session identity for Vite SPA ───────────────────────────────
+
+describe('GET /api/me', () => {
+  it('returns the dummy-session username when AUTH_ENABLED=false', async () => {
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/me' });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.preferred_username).toBe('johnwick');
+    expect(body.displayName).toBe('John');
+  });
+
+  it('returns 401 when AUTH_ENABLED=true and no session exists', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/me' });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).error).toBe('unauthenticated');
+  });
+});
+
 // ── POST /api/v1/stream — auth guard ─────────────────────────────────────────
 
 describe('POST /api/v1/stream — auth guard', () => {
@@ -479,6 +500,34 @@ describe('POST /api/proxy/agent/v1/stream', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toContain('text/event-stream');
     expect(res.body).toContain('[DONE]');
+  });
+
+  it('forwards dummy-session username as X-User-ID and run config user_id', async () => {
+    const agentSSE =
+      `event: messages/partial\ndata: [{"type":"ai","content":"Hello"}]\n\n`;
+
+    const fetchMock = stubFetch(
+      okJson({ thread_id: 'th1' }),
+      makeSSEResponse(agentSSE),
+      okJson({ messages: [], tasks: [] }),
+    );
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: { message: 'hello', thread_id: 'th1', user_id: 'ignored' },
+    });
+
+    expect(res.statusCode).toBe(200);
+
+    const threadInit = fetchMock.mock.calls[0];
+    const runInit = fetchMock.mock.calls[1];
+    expect(threadInit[1].headers['X-User-ID']).toBe('johnwick');
+    expect(JSON.parse(threadInit[1].body).metadata.user_identity).toBe('johnwick');
+    const runBody = JSON.parse(runInit[1].body);
+    expect(runBody.config.metadata.user_id).toBe('johnwick');
+    expect(runBody.config.configurable.user_id).toBe('johnwick');
   });
 
   it('emits a token chunk when the agent sends messages/partial', async () => {

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -2,6 +2,7 @@ import oauthPlugin from "@fastify/oauth2";
 import { FastifyInstance } from "fastify";
 import fp from "fastify-plugin";
 import { getSettings } from "../utils/settings.js";
+import { resolveSessionIdentity, safePostLoginRedirect } from "../utils/session-identity.js";
 
 import { OAuth2Namespace } from "@fastify/oauth2";
 
@@ -129,12 +130,16 @@ async function routes(fastify: FastifyInstance) {
       let defaultRedirect = "/";
       try {
         const { redirectUri = "/" } = (request as any).session;
-        defaultRedirect = redirectUri;
+        defaultRedirect = safePostLoginRedirect(redirectUri);
       } catch (error) {
         console.error(error);
       }
 
-      (request as any).session.user = userInfo;
+      const identity = resolveSessionIdentity({
+        user: userInfo,
+        token: tokenSet.token,
+      });
+      (request as any).session.user = identity.user;
       (request as any).session.token = tokenSet.token;
 
       return reply.redirect(defaultRedirect);

--- a/src/server/router/api.router.ts
+++ b/src/server/router/api.router.ts
@@ -2,6 +2,7 @@ import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { handleHistoryGet, handleStreamPost } from "../controllers/v1/agent.js";
 import { getSettings } from "../utils/settings.js";
 import authCheckPlugin from "../plugins/auth-check.plugin.js";
+import { toClientUserData } from "../utils/session-identity.js";
 
 interface StreamRequest {
   message: string;
@@ -64,6 +65,26 @@ async function apiRoutes(fastify: FastifyInstance) {
       violations,
       compliant: violations.length === 0,
     };
+  });
+
+  // Vite local serves HTML without session injection. Keep this off auth-check
+  // so a missing cookie returns 401 JSON instead of a /login redirect (429s SSO).
+  fastify.get("/me", async (request: FastifyRequest, reply: FastifyReply) => {
+    reply.header("Cache-Control", "no-store");
+    if (request.session?.user) {
+      return toClientUserData(request.session);
+    }
+    if (process.env.AUTH_ENABLED === "false") {
+      return toClientUserData({
+        user: {
+          preferred_username: "johnwick",
+          name: "John Wick",
+          displayName: "John",
+          email: "johnwick@redhat.com",
+        },
+      });
+    }
+    return reply.code(401).send({ error: "unauthenticated" });
   });
 
   // Protected routes — auth required

--- a/src/server/router/client.router.ts
+++ b/src/server/router/client.router.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import authCheckPlugin from "../plugins/auth-check.plugin.js";
 import { getAgentName, getSettings } from "../utils/settings.js";
+import { toClientUserData } from "../utils/session-identity.js";
 import {
   buildSandboxCspHeader,
   parseCspQueryParam,
@@ -138,15 +139,12 @@ async function routes(fastify: FastifyInstance) {
 
   fastify.get("/*", async (request: FastifyRequest, reply: FastifyReply) => {
     const session = request.session;
-    const { user, token } = session;
-
-    const sessionToken = token?.access_token || headerValue(request, "x-auth-access-token") || headerValue(request, "x-token");
-
-    const userData = {
-      ...user,
-      accessToken: sessionToken,
-      expiresAt: token?.expires_at,
-    };
+    const userData = toClientUserData(session);
+    const sessionToken =
+      userData.accessToken ||
+      headerValue(request, "x-auth-access-token") ||
+      headerValue(request, "x-token");
+    userData.accessToken = sessionToken || "";
 
     const agentName = await getAgentName();
     const cfg = getSettings();

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -2,10 +2,16 @@ import { FastifyInstance, FastifyReply } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import { getSettings } from '../utils/settings.js';
 import authCheckPlugin from '../plugins/auth-check.plugin.js';
+import { resolveXUserIdFromSession } from '../utils/session-identity.js';
 
 function getAgentHost(): string {
   const cfg = getSettings();
   return cfg.agent.endpoint || process.env.AGENT_HOST || "http://localhost:5002";
+}
+
+/** Identity forwarded to the agent — same as prod: session username, else ``default``. */
+function resolveXUserId(request: { session?: { user?: { preferred_username?: string; sub?: string; email?: string }; token?: { access_token?: string; id_token?: string } } }): string {
+  return resolveXUserIdFromSession(request.session);
 }
 
 /** In-memory LRU cache for thread state responses (avoids repeated LangGraph deserialization). */
@@ -376,7 +382,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
         return reply.status(401).send({ error: 'Not authenticated' });
       }
 
-      const { message, thread_id, user_id, resume: isResume, project_id } = request.body;
+      const { message, thread_id, resume: isResume, project_id } = request.body;
 
       if (project_id != null && typeof project_id !== 'string') {
         return reply.status(400).send({ error: 'project_id must be a string when provided' });
@@ -393,6 +399,9 @@ async function proxyRoutes(fastify: FastifyInstance) {
         headers['X-Refresh-Token'] = refreshToken;
       }
 
+      const xUserId = resolveXUserId(request);
+      headers['X-User-ID'] = xUserId;
+
       try {
         // ── 1. Ensure the thread exists (idempotent) ──
         fastify.log.info({ traceId, thread_id }, 'Creating thread');
@@ -402,7 +411,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
           body: JSON.stringify({
             threadId: thread_id,
             metadata: {
-              user_identity: user_id ?? 'anonymous',
+              user_identity: xUserId,
               ...(project_id ? { project_id } : {}),
             },
             ifExists: 'do_nothing',
@@ -434,7 +443,10 @@ async function proxyRoutes(fastify: FastifyInstance) {
           runBody.input = { messages: [{ role: 'human', content: message, id: randomUUID() }] };
         }
 
-        runBody.config = { metadata: { trace_id: traceId } };
+        runBody.config = {
+          metadata: { trace_id: traceId, user_id: xUserId },
+          configurable: { user_id: xUserId },
+        };
 
         const streamTimeoutMs = Math.max(cfg.agent.timeout_ms, 300_000);
         const runResp = await fetch(runUrl, {
@@ -916,6 +928,8 @@ async function proxyRoutes(fastify: FastifyInstance) {
       if (refreshToken) {
         headers['X-Refresh-Token'] = refreshToken;
       }
+
+      headers['X-User-ID'] = resolveXUserId(request);
 
       try {
         const queryString = buildForwardedQueryString(request.query as Record<string, unknown>);

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -43,8 +43,6 @@ interface StreamRequestBody {
   session_id?: string;
   stream_tokens?: boolean;
   resume?: boolean;
-  memories?: string[];
-  rules?: string[];
   project_id?: string | null;
 }
 
@@ -378,7 +376,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
         return reply.status(401).send({ error: 'Not authenticated' });
       }
 
-      const { message, thread_id, user_id, resume: isResume, memories, rules, project_id } = request.body;
+      const { message, thread_id, user_id, resume: isResume, project_id } = request.body;
 
       if (project_id != null && typeof project_id !== 'string') {
         return reply.status(400).send({ error: 'project_id must be a string when provided' });
@@ -436,14 +434,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
           runBody.input = { messages: [{ role: 'human', content: message, id: randomUUID() }] };
         }
 
-        const configurable: Record<string, unknown> = {};
-        if (Array.isArray(memories) && memories.length > 0) configurable.user_memories = memories;
-        if (Array.isArray(rules) && rules.length > 0) configurable.user_rules = rules;
-        if (Object.keys(configurable).length > 0) {
-          runBody.config = { configurable, metadata: { trace_id: traceId } };
-        } else {
-          runBody.config = { metadata: { trace_id: traceId } };
-        }
+        runBody.config = { metadata: { trace_id: traceId } };
 
         const streamTimeoutMs = Math.max(cfg.agent.timeout_ms, 300_000);
         const runResp = await fetch(runUrl, {

--- a/src/server/utils/session-identity.test.ts
+++ b/src/server/utils/session-identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeJwtPayload,
+  resolveSessionIdentity,
+  resolveXUserIdFromSession,
+  safePostLoginRedirect,
+  toClientUserData,
+} from "./session-identity.js";
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.`;
+}
+
+describe("decodeJwtPayload", () => {
+  it("reads claims from an unsigned JWT", () => {
+    const token = unsignedJwt({ preferred_username: "dpundir", email: "dpundir@redhat.com" });
+    expect(decodeJwtPayload(token)).toMatchObject({
+      preferred_username: "dpundir",
+      email: "dpundir@redhat.com",
+    });
+  });
+
+  it("returns null for garbage", () => {
+    expect(decodeJwtPayload("not-a-jwt")).toBeNull();
+  });
+});
+
+describe("resolveSessionIdentity", () => {
+  it("fills preferred_username from the access token when userinfo omits it", () => {
+    const token = unsignedJwt({
+      preferred_username: "dpundir",
+      email: "dpundir@redhat.com",
+      name: "Darshika Pundir",
+      sub: "11111111-1111-4111-8111-111111111111",
+    });
+    const id = resolveSessionIdentity({
+      user: { sub: "11111111-1111-4111-8111-111111111111", email: "dpundir@redhat.com" },
+      token: { access_token: token },
+    });
+    expect(id.preferred_username).toBe("dpundir");
+    expect(id.displayName).toBe("Darshika Pundir");
+    expect(resolveXUserIdFromSession({
+      user: { sub: "11111111-1111-4111-8111-111111111111", email: "dpundir@redhat.com" },
+      token: { access_token: token },
+    })).toBe("dpundir");
+  });
+
+  it("falls back to the email local-part when no username claim exists", () => {
+    const id = resolveSessionIdentity({
+      user: { email: "dpundir@redhat.com", name: "Darshika Pundir" },
+    });
+    expect(id.preferred_username).toBe("dpundir");
+    expect(id.displayName).toBe("Darshika Pundir");
+  });
+
+  it("falls back to JWT sub for X-User-ID when nothing else is present", () => {
+    expect(
+      resolveXUserIdFromSession({
+        user: { sub: "11111111-1111-4111-8111-111111111111" },
+      }),
+    ).toBe("11111111-1111-4111-8111-111111111111");
+  });
+
+  it("returns default when the session is empty", () => {
+    expect(resolveXUserIdFromSession(undefined)).toBe("default");
+    expect(resolveSessionIdentity(undefined).displayName).toBe("User");
+  });
+
+  it("includes accessToken in client user data without inventing a username from empty session", () => {
+    const data = toClientUserData({
+      user: { name: "Darshika Pundir", email: "dpundir@redhat.com" },
+      token: { access_token: "tok", expires_at: 1_800_000_000 },
+    });
+    expect(data.preferred_username).toBe("dpundir");
+    expect(data.accessToken).toBe("tok");
+    expect(data.expiresAt).toMatch(/^\d{4}-/);
+  });
+
+  it("formats Date expires_at from the SSO token object", () => {
+    const data = toClientUserData({
+      user: { preferred_username: "dpundir" },
+      token: { access_token: "tok", expires_at: new Date("2026-09-08T12:00:00.000Z") },
+    });
+    expect(data.expiresAt).toBe("2026-09-08T12:00:00.000Z");
+  });
+});
+
+describe("safePostLoginRedirect", () => {
+  it("keeps in-app paths", () => {
+    expect(safePostLoginRedirect("/settings")).toBe("/settings");
+    expect(safePostLoginRedirect("/chat/abc")).toBe("/chat/abc");
+  });
+
+  it("rejects API and auth URLs so SSO does not land on JSON", () => {
+    expect(
+      safePostLoginRedirect(
+        "/api/proxy/agent/threads/00000000-0000-4000-8000-000000000001/state",
+      ),
+    ).toBe("/");
+    expect(safePostLoginRedirect("/auth/callback/oidc")).toBe("/");
+    expect(safePostLoginRedirect("https://evil.example")).toBe("/");
+  });
+});

--- a/src/server/utils/session-identity.ts
+++ b/src/server/utils/session-identity.ts
@@ -1,0 +1,143 @@
+/**
+ * Resolve the signed-in identity from the BFF session.
+ *
+ * Red Hat SSO userinfo often omits `preferred_username` even when the access
+ * token carries it. Local Vite also never injects session user into HTML
+ * (`data-user`), so callers must derive a stable username/display name here.
+ */
+
+export type SessionIdentityUser = {
+  email?: string;
+  email_verified?: boolean;
+  family_name?: string;
+  given_name?: string;
+  name?: string;
+  preferred_username?: string;
+  sub?: string;
+  displayName?: string;
+  [key: string]: unknown;
+};
+
+export type SessionLike = {
+  user?: SessionIdentityUser;
+  token?: {
+    access_token?: string;
+    id_token?: string;
+    /** SSO libraries may store expiry as unix seconds, ISO string, or Date. */
+    expires_at?: number | string | Date;
+  };
+};
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function emailLocalPart(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return "";
+  return email.slice(0, at);
+}
+
+/** Decode a JWT payload without verification. Token already came from our SSO session. */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2 || !parts[1]) return null;
+    const json = Buffer.from(parts[1], "base64url").toString("utf8");
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatExpiresAt(expiresAt: unknown): string | undefined {
+  if (expiresAt == null || expiresAt === "") return undefined;
+  if (expiresAt instanceof Date && !Number.isNaN(expiresAt.getTime())) {
+    return expiresAt.toISOString();
+  }
+  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
+    const ms = expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+    return new Date(ms).toISOString();
+  }
+  if (typeof expiresAt === "string") return expiresAt;
+  return undefined;
+}
+
+export function resolveSessionIdentity(session?: SessionLike | null) {
+  const user = { ...(session?.user || {}) };
+  const accessToken = asString(session?.token?.access_token);
+  const idToken = asString(session?.token?.id_token);
+  const claims =
+    (accessToken ? decodeJwtPayload(accessToken) : null) ||
+    (idToken ? decodeJwtPayload(idToken) : null) ||
+    {};
+
+  const email = asString(user.email) || asString(claims.email);
+  const name = asString(user.name) || asString(claims.name);
+  const givenName = asString(user.given_name) || asString(claims.given_name);
+  const familyName = asString(user.family_name) || asString(claims.family_name);
+  const sub = asString(user.sub) || asString(claims.sub);
+  const preferredUsername =
+    asString(user.preferred_username) ||
+    asString(claims.preferred_username) ||
+    emailLocalPart(email);
+
+  const displayName =
+    asString(user.displayName) || name || givenName || preferredUsername || email || "User";
+
+  const resolvedUser: SessionIdentityUser = {
+    ...user,
+    email: email || undefined,
+    name: name || undefined,
+    given_name: givenName || undefined,
+    family_name: familyName || undefined,
+    sub: sub || undefined,
+    preferred_username: preferredUsername || undefined,
+    displayName,
+  };
+
+  return {
+    preferred_username: preferredUsername,
+    displayName,
+    email,
+    name,
+    sub,
+    user: resolvedUser,
+    accessToken,
+    expiresAt: formatExpiresAt(session?.token?.expires_at),
+  };
+}
+
+/** Identity forwarded to the agent — username, else JWT sub, else email, else `default`. */
+export function resolveXUserIdFromSession(session?: SessionLike | null): string {
+  const id = resolveSessionIdentity(session);
+  return id.preferred_username || id.sub || id.email || "default";
+}
+
+export function toClientUserData(session?: SessionLike | null) {
+  const id = resolveSessionIdentity(session);
+  return {
+    ...id.user,
+    accessToken: id.accessToken,
+    expiresAt: id.expiresAt,
+  };
+}
+
+/** Same-origin app path only — never bounce SSO back to an API or auth URL. */
+export function safePostLoginRedirect(redirectUri: unknown): string {
+  if (typeof redirectUri !== "string") return "/";
+  const path = redirectUri.trim();
+  if (!path.startsWith("/") || path.startsWith("//") || path.startsWith("/\\")) {
+    return "/";
+  }
+  const pathname = path.split("?")[0] ?? "/";
+  if (
+    pathname === "/login" ||
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/auth/")
+  ) {
+    return "/";
+  }
+  return path;
+}

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -102,6 +102,7 @@ interface BrandingConfig {
 }
 
 interface FeaturesConfig {
+  memory_enabled: boolean;
   debug_mode_default: boolean;
   auth_enabled: boolean;
   mcp_dcr_enabled: boolean;
@@ -161,6 +162,7 @@ const DEFAULTS: UISettings = {
     auth_enabled: true,
     mcp_dcr_enabled: true,
     mcp_apps_enabled: true,
+    memory_enabled: true,
   },
   agent: {
     endpoint: "",


### PR DESCRIPTION
## Summary

Replace browser localStorage-based personalization with server-side persistence via the
new agent `/personalization` CRUD API. Memories and user rules now survive across devices,
browsers, and logout/login cycles.

### Changes

- **`personalization.ts` (Redux slice)** — rewrote from synchronous localStorage
  read/write to async thunks (`createAsyncThunk`) calling the backend API:
  - `fetchMemories` / `fetchRules` — load data from server on component mount
  - `addMemory` / `addRule` — POST to backend, optimistically update store
  - `removeMemory` / `removeRule` — DELETE from backend, remove from store
  - Added `loading` and `error` state with corresponding selectors
  - Removed `uuid` dependency (IDs now come from the server)
  - Removed `localStorage` persistence (`loadState`, `persist` helpers)
  - Removed unused reducers: `clearMemories`, `clearRules`, `updateRule`, `toggleRule`

- **`MemoryList.tsx`** — fetches memories from server on mount via `useEffect`,
  shows loading spinner and error banner, removed "Clear all" button

- **`RulesEditor.tsx`** — fetches rules from server on mount via `useEffect`,
  shows loading spinner and error banner, removed toggle switch and "Clear all" button

- **`useStreamingAPI.ts`** — removed client-side memory/rule injection into stream
  requests (agent now loads personalization from Postgres directly)

- **`StreamingManager.ts`** — removed `memories` and `rules` from `StreamRequest` interface

- **`proxy.router.ts`** — removed `memories`/`rules` fields from stream request body
  and the `configurable.user_memories`/`configurable.user_rules` forwarding logic

### Motivation

The previous architecture stored personalization data only in browser localStorage and
piped it through stream requests. This was fragile (data lost on browser clear/device
switch) and created a disconnect — the agent backend loaded from Postgres while the UI
managed its own separate copy. This change unifies storage on the server, making the
agent's Postgres `user_memories` and `user_rules` tables the single source of truth.

fixes #103 