### PR TITLE
fix: auth routes and verify cookie signature

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       AUTH_ENABLED: 'false',
       ENVIRONMENT: 'test',
       AGENT_HOST: 'http://localhost:19999',
+      COOKIE_SIGN: 'playwright-test-secret-32-chars-min-length',
     },
   },
 });

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -241,6 +241,109 @@ describe('POST /api/proxy/agent/feedback', () => {
   });
 });
 
+// ── Public routes remain accessible without auth ──────────────────────────────
+
+describe('Public /api routes — accessible without auth', () => {
+  it('GET /api/health returns 200 when AUTH_ENABLED=true and no session', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).status).toBe('ok');
+  });
+
+  it('GET /api/config/branding returns 200 when AUTH_ENABLED=true and no session', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/config/branding' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toHaveProperty('title');
+  });
+
+  it('GET /api/config/features returns 200 when AUTH_ENABLED=true and no session', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    const server = await buildTestServer();
+    const res = await server.inject({ method: 'GET', url: '/api/config/features' });
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toHaveProperty('auth_enabled');
+  });
+});
+
+// ── POST /api/v1/stream — auth guard ─────────────────────────────────────────
+
+describe('POST /api/v1/stream — auth guard', () => {
+  it('redirects to /login when AUTH_ENABLED=true and no session exists', async () => {
+    process.env.AUTH_ENABLED = 'true';
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/stream',
+      payload: { message: 'hello', thread_id: 'th1', session_id: 's1', user_id: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers['location']).toContain('/login');
+  });
+
+  it('proxies the request when AUTH_ENABLED=false (gateway mode)', async () => {
+    const agentSSE = 'data: hello\n\n[DONE]\n\n';
+    stubFetch(makeSSEResponse(agentSSE));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/v1/stream',
+      payload: { message: 'hello', thread_id: 'th1', session_id: 's1', user_id: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+// ── GET /api/v1/history/:threadId — auth guard ────────────────────────────────
+
+describe('GET /api/v1/history/:threadId — auth guard', () => {
+  it('redirects to /login when AUTH_ENABLED=true and no session exists', async () => {
+    process.env.AUTH_ENABLED = 'true';
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/history/thread-abc',
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers['location']).toContain('/login');
+  });
+
+  it('proxies to agent and returns history when AUTH_ENABLED=false', async () => {
+    stubFetch(okJson([{ role: 'user', content: 'hi' }]));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/history/thread-abc',
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it('propagates agent error status when auth passes', async () => {
+    stubFetch(new Response('Not Found', { status: 404 }));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'GET',
+      url: '/api/v1/history/nonexistent-thread',
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
 // ── POST /api/proxy/agent/v1/stream — HITL interrupt translation ──────────────
 
 describe('POST /api/proxy/agent/v1/stream', () => {

--- a/src/server/__tests__/security.test.ts
+++ b/src/server/__tests__/security.test.ts
@@ -1,11 +1,52 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getSettings, resetSettings } from '../utils/settings.js';
+import { setupServer } from '../server.js';
 import {
   buildTestServer,
   parseCookieHeader,
   bombardEndpoint,
   generatePathTraversalPayloads,
 } from './test-utils.js';
+
+describe('Security: COOKIE_SIGN startup guard', () => {
+  // These tests call setupServer() directly so that buildTestServer's COOKIE_SIGN
+  // defaulting doesn't mask the guard under test.
+  beforeEach(() => {
+    process.env.FEATURE_AUTH_ENABLED = 'false';
+    resetSettings();
+  });
+
+  afterEach(() => {
+    delete process.env.COOKIE_SIGN;
+    delete process.env.FEATURE_AUTH_ENABLED;
+    resetSettings();
+  });
+
+  it('should throw if COOKIE_SIGN is not set', async () => {
+    delete process.env.COOKIE_SIGN;
+    await expect(setupServer()).rejects.toThrow(/COOKIE_SIGN/);
+  });
+
+  it('should throw if COOKIE_SIGN is shorter than 32 characters', async () => {
+    process.env.COOKIE_SIGN = 'tooshort';
+    await expect(setupServer()).rejects.toThrow(/COOKIE_SIGN/);
+  });
+
+  it('should throw if COOKIE_SIGN is exactly 31 characters', async () => {
+    process.env.COOKIE_SIGN = 'a'.repeat(31);
+    await expect(setupServer()).rejects.toThrow(/COOKIE_SIGN/);
+  });
+
+  it('should start successfully when COOKIE_SIGN is exactly 32 characters', async () => {
+    process.env.COOKIE_SIGN = 'a'.repeat(32);
+    await expect(setupServer()).resolves.toBeDefined();
+  });
+
+  it('should start successfully when COOKIE_SIGN is longer than 32 characters', async () => {
+    process.env.COOKIE_SIGN = 'a-very-long-and-secure-cookie-signing-secret-value';
+    await expect(setupServer()).resolves.toBeDefined();
+  });
+});
 
 describe('Security: Session Cookie Hardening', () => {
   beforeEach(() => {

--- a/src/server/__tests__/test-utils.ts
+++ b/src/server/__tests__/test-utils.ts
@@ -11,6 +11,12 @@ export async function buildTestServer(
     process.env.FEATURE_AUTH_ENABLED = 'false';
   }
 
+  // Provide a valid COOKIE_SIGN for tests unless the test itself is intentionally
+  // testing the missing/short secret guard (those tests set their own value).
+  if (!process.env.COOKIE_SIGN) {
+    process.env.COOKIE_SIGN = 'test-secret-value-that-is-32chars!!';
+  }
+
   // Apply test config via environment variables
   if (overrides?.security?.session) {
     if (overrides.security.session.http_only !== undefined) {

--- a/src/server/router/api.router.ts
+++ b/src/server/router/api.router.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { handleHistoryGet, handleStreamPost } from "../controllers/v1/agent.js";
 import { getSettings } from "../utils/settings.js";
+import authCheckPlugin from "../plugins/auth-check.plugin.js";
 
 interface StreamRequest {
   message: string;
@@ -10,6 +11,7 @@ interface StreamRequest {
 }
 
 async function apiRoutes(fastify: FastifyInstance) {
+  // Public routes — no auth required
   fastify.get("/health", async () => {
     return { status: "ok", timestamp: new Date().toISOString() };
   });
@@ -62,12 +64,17 @@ async function apiRoutes(fastify: FastifyInstance) {
     };
   });
 
-  fastify.post("/v1/stream", async (request: FastifyRequest<{ Body: StreamRequest }>, reply: FastifyReply) => {
-   handleStreamPost(fastify, request, reply);
-  });
+  // Protected routes — auth required
+  await fastify.register(async (protectedRoutes) => {
+    await protectedRoutes.register(authCheckPlugin);
 
-  fastify.get("/v1/history/:threadId", async (request: FastifyRequest<{ Params: { threadId: string } }>, reply: FastifyReply) => {
-    handleHistoryGet(fastify, request, reply);
+    protectedRoutes.post("/v1/stream", async (request: FastifyRequest<{ Body: StreamRequest }>, reply: FastifyReply) => {
+      return handleStreamPost(protectedRoutes, request, reply);
+    });
+
+    protectedRoutes.get("/v1/history/:threadId", async (request: FastifyRequest<{ Params: { threadId: string } }>, reply: FastifyReply) => {
+      return handleHistoryGet(protectedRoutes, request, reply);
+    });
   });
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -121,11 +121,17 @@ export async function setupServer(): Promise<FastifyInstance> {
     });
   }
 
+  const cookieSign = process.env.COOKIE_SIGN;
+  if (!cookieSign || cookieSign.length < 32) {
+    throw new Error(
+      "COOKIE_SIGN env var is required and must be at least 32 characters. " +
+      "Set it to a cryptographically random string before starting the server."
+    );
+  }
+
   await fastify.register(import("@fastify/cookie"));
   await fastify.register(import("@fastify/session"), {
-    secret:
-      process.env.COOKIE_SIGN ||
-      "a secret with minimum length of 32 characters",
+    secret: cookieSign,
     cookie: {
       secure: cfg.security.session.secure_cookie,
       httpOnly: cfg.security.session.http_only ?? true,


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

Fixes two auth vulnerabilities in the template-ui Fastify server. Previously, `authCheckPlugin` was applied to the entire `/api/*` router, causing unauthenticated requests to public routes (`/health`, `/config/branding`, `/config/features`) to receive a `302` redirect instead of their JSON payloads. Additionally, the session cookie secret fell back to a hardcoded insecure default when `COOKIE_SIGN` was unset. This MR scopes auth to only the protected routes and enforces a minimum-length `COOKIE_SIGN` at startup.

## Changes

- Introduced a nested `protectedRoutes` sub-router in `api.router.ts` so `authCheckPlugin` only covers `/v1/stream` and `/v1/history/:threadId`
- Public routes (`/health`, `/config/branding`, `/config/features`) remain outside the auth scope and return JSON to unauthenticated callers
- `server.ts`: validate `COOKIE_SIGN` env var at startup — throws if missing or shorter than 32 characters, eliminating the insecure hardcoded fallback
- Added proxy tests covering auth-scoped vs public route behaviour (`proxy.test.ts` +103 lines)
- Added security tests for cookie-sign validation and session handling (`security.test.ts` +41 lines)
- Extended `test-utils.ts` with helpers supporting the new test scenarios (+6 lines)

## AI Disclosure

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: bootstrap scoped auth router, `COOKIE_SIGN` validation, and accompanying unit tests
- **Human verification**: Diff reviewed manually; Bugbot scan run against uncommitted changes and confirmed no remaining findings

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

- **New required env var**: `COOKIE_SIGN` (minimum 32 characters, cryptographically random). The server will **refuse to start** if this is absent or too short — update Kind/preprod/prod secrets before deploying.
- Auth scope narrowed: `/health`, `/config/branding`, `/config/features` are now intentionally public — confirm this is acceptable for your threat model.
- Hardcoded session secret fallback removed — no rollback path without setting `COOKIE_SIGN`.

## Reviewer Notes

<!-- What to focus on. -->

- Verify the nested sub-router approach (`fastify.register` inside `apiRoutes`) doesn't interfere with the existing `authCheckPlugin` encapsulation logic in other test environments.
- Confirm `COOKIE_SIGN` is provisioned in all overlay secrets (`deployment/overlays/kind|preprod|prod`) before merging to an environment.