### PR TITLE
fix: address PR #76 review comments

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, deep-agent]
@@ -12,6 +15,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: "22"
@@ -24,6 +29,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: "22"
@@ -36,6 +43,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: "22"
@@ -58,6 +67,8 @@ jobs:
       CI: "true"
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
           node-version: "22"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Dependency review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Branding and `agent.endpoint` / `agent.timeout_ms` changes are applied without a
 
 The config is validated at startup. Invalid values cause the server to exit with a clear error:
 
-```
+```text
 Config validation error: branding.colors.light.primary must be a valid hex color (got 'not-a-color')
 ```
 

--- a/config/compliance/README.md
+++ b/config/compliance/README.md
@@ -69,7 +69,7 @@ platform:
 
 If `agent.endpoint` is `https://public-api.example.com/agent`, the server logs:
 
-```
+```text
 OPA policy violation: agent endpoint 'https://public-api.example.com/agent'
   does not match any approved internal suffix [".svc.cluster.local", ".internal.example.com"]
 ```
@@ -139,7 +139,7 @@ deny contains msg if {
 
 **Available `input` fields:**
 
-```
+```text
 input.branding          — BrandingConfig
 input.features          — FeaturesConfig
 input.agent             — AgentConfig  (endpoint, timeout_ms, streaming)
@@ -153,7 +153,7 @@ input.platform.opa      — PlatformOpaConfig
 ```bash
 # Evaluate the deny rule against a sample input
 opa eval \
-  --data config/compliance/policy.rego \
+  --data config/compliance \
   --input <(echo '{
     "features": {"auth_enabled": true, "debug_mode_default": false},
     "agent": {"endpoint": "https://public.example.com"},
@@ -175,7 +175,7 @@ opa eval \
 
 ## File structure
 
-```
+```text
 config/compliance/
 ├── policy.rego     # Deny rules (package compliance.ui)
 ├── data.json       # Static external data available as data.* in Rego

--- a/config/ui/examples/minimal.yaml
+++ b/config/ui/examples/minimal.yaml
@@ -1,5 +1,5 @@
 # Minimal configuration — auth disabled, suitable for local development.
-# Copy to config/ui/settings.yaml and ensure AUTH_ENABLED is not set (or set to false).
+# Copy to config/ui/settings.yaml and ensure FEATURE_AUTH_ENABLED / AUTH_ENABLED is not set (or set to false).
 #
 # With this config:
 #   - No SSO credentials are required.

--- a/docs/deployment-patterns.md
+++ b/docs/deployment-patterns.md
@@ -41,11 +41,7 @@ branding:
   favicon_url: "/my-logo.svg"
 ```
 
-3. **Restart the server** (only the title is needed; for logo changes the file is served immediately but the browser may cache the old one):
-
-```bash
-npm start
-```
+3. **Save and refresh the browser** (branding is hot-reloaded; for logo changes the file is served immediately but the browser may cache the old one).
 
 4. **Verify** by opening the app — the tab title and masthead should reflect the new values.
 
@@ -105,12 +101,12 @@ Feature flags are boolean values in the `features` block. They control which cap
 
 | Flag | Type | Default | Env override | OPA-enforceable | Description |
 |---|---|---|---|---|---|
-| `features.auth_enabled` | `bool` | `true` | `FEATURE_AUTH_ENABLED` (or legacy `AUTH_ENABLED`) | `restricted_features`, `approved_auth_providers` | When `false`, bypasses SSO entirely and injects a dummy user (`developer@redhat.com`). Controlled by agent-engine during deployment — set via env var, not YAML. |
+| `features.auth_enabled` | `bool` | `true` | `FEATURE_AUTH_ENABLED` (or legacy `AUTH_ENABLED`) | `restricted_features`, `approved_auth_providers` | When `false`, bypasses SSO entirely and injects a dummy user (`developer@redhat.com`). Environment variables override the YAML value — set via env var during deployment. |
 | `features.debug_mode_default` | `bool` | `false` | `FEATURE_DEBUG_MODE_DEFAULT` | `restrict_debug_mode: true` | Default open/closed state of the debug panel. Users can toggle it. Never enable in production — OPA can enforce this. |
 
 ### Precedence
 
-```
+```text
 FEATURE_AUTH_ENABLED env var
   > AUTH_ENABLED env var (legacy)
     > features.auth_enabled in settings.yaml
@@ -119,7 +115,7 @@ FEATURE_AUTH_ENABLED env var
 
 ### When to use each flag
 
-**`auth_enabled: false`** — local development only. Skips the SSO plugin registration entirely. The dummy user is always `developer@redhat.com`. The `COOKIE_SIGN`, `SSO_CLIENT_ID`, and `SSO_CLIENT_SECRET` env vars are not required.
+**`auth_enabled: false`** — local development only. Skips the SSO plugin registration entirely. The dummy user is always `developer@redhat.com`. `SSO_CLIENT_ID` and `SSO_CLIENT_SECRET` are not required, but `COOKIE_SIGN` is still needed for session signing.
 
 **`debug_mode_default: true`** — useful when iterating on agent responses locally to see raw tool calls and streaming chunks. Should always be `false` in production (OPA `restrict_debug_mode: true` enforces this).
 
@@ -189,11 +185,10 @@ features:
   auth_enabled: false
 
 agent:
-  endpoint: "http://template-agent.default.svc.cluster.local:8082"
   timeout_ms: 30000
 ```
 
-Set `AGENT_HOST=http://template-agent.default.svc.cluster.local:8082` in the Kind ConfigMap instead if you prefer env-driven config.
+Set `AGENT_HOST=http://template-agent.default.svc.cluster.local:8082` in the Kind ConfigMap for env-driven config.
 
 ### Production (OpenShift)
 
@@ -216,10 +211,10 @@ Two copies of template-ui pointing at different agent engines. Use environment v
 
 ```bash
 # Agent A
-BRANDING_TITLE="Code Review Agent"  AGENT_ENDPOINT=http://code-review-agent:8082
+export BRANDING_TITLE="Code Review Agent"  AGENT_ENDPOINT=http://code-review-agent:8082
 
 # Agent B
-BRANDING_TITLE="Data Assistant"     AGENT_ENDPOINT=http://data-agent:8082
+export BRANDING_TITLE="Data Assistant"     AGENT_ENDPOINT=http://data-agent:8082
 ```
 
 No `settings.yaml` file is needed — env vars alone are sufficient.
@@ -244,7 +239,7 @@ The config file is watched for changes. Which settings apply live vs. need a res
 
 The BFF proxy (`src/server/router/proxy.router.ts`) resolves the agent host with this priority order:
 
-```
+```text
 agent.endpoint in settings.yaml
   >  AGENT_ENDPOINT env var
     >  AGENT_HOST env var
@@ -265,7 +260,7 @@ agent:
 
 ```bash
 # In a .env file or shell
-AGENT_ENDPOINT=https://prod-agent.example.com
+export AGENT_ENDPOINT=https://prod-agent.example.com
 ```
 
 `AGENT_ENDPOINT` takes precedence over `AGENT_HOST`. Use `AGENT_HOST` when you want to keep the legacy variable name (e.g., existing Helm values).
@@ -348,7 +343,7 @@ platform:
 
 With `fail_on_violation: false` the server starts regardless of violations. Violations are logged as warnings:
 
-```
+```text
 [warn] OPA policy violation: debug_mode_default cannot be enabled in this environment
 ```
 
@@ -369,7 +364,7 @@ platform:
 
 The `SSO_AUTH_PROVIDER` env var determines the provider (defaults to `"oidc"`). If it is set to anything not in `approved_auth_providers`, startup fails:
 
-```
+```text
 OPA policy violation: auth provider 'saml' is not in the approved list ["oidc"]
 ```
 
@@ -389,7 +384,7 @@ platform:
 
 Any `agent.endpoint` that does not end with one of these suffixes triggers a violation. An empty `agent.endpoint` (falling back to `AGENT_HOST`) is allowed.
 
-```
+```text
 OPA policy violation: agent endpoint 'https://public-api.example.com'
   does not match any approved internal suffix [".svc.cluster.local", ".internal.example.com"]
 ```

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     (function() {
       try {
         var stored = localStorage.getItem('template-ui-settings');
-        var theme = stored ? JSON.parse(stored).theme : 'dark';
+        var theme = stored ? JSON.parse(stored).theme || 'dark' : 'dark';
       } catch(e) {
         var theme = 'dark';
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
   "overrides": {
     "@grpc/grpc-js": "^1.14.4"
   },
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@eslint/js": "^9.22.0",

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -59,7 +59,9 @@ export function AnnouncementBanner() {
 
   const handleClose = useCallback(() => {
     if (payload?.message) {
-      sessionStorage.setItem(STORAGE_PREFIX + messageHash(payload.message), '1');
+      try {
+        sessionStorage.setItem(STORAGE_PREFIX + messageHash(payload.message), '1');
+      } catch { /* storage full or unavailable */ }
     }
     setDismissed(true);
   }, [payload?.message]);
@@ -71,7 +73,7 @@ export function AnnouncementBanner() {
   const variant = toVariant(payload.type);
 
   return (
-    <div className="w-full shrink-0 border-b border-[var(--pf-v5-global--BorderColor--200)]">
+    <div className="w-full shrink-0 border-b border-border">
       <Alert
         variant={variant}
         isInline

--- a/src/frontend/components/ActivityTimeline.tsx
+++ b/src/frontend/components/ActivityTimeline.tsx
@@ -58,7 +58,7 @@ export function ActivityTimeline({
   }, [isLoading, processedEvents]);
 
   return (
-    <Card isCompact isPlain className="!border-none rounded-lg !bg-neutral-700 max-h-96">
+    <Card isCompact isPlain className="border-none! rounded-lg bg-neutral-700! max-h-96">
       <CardHeader
         className="cursor-pointer"
         onClick={() => setIsTimelineCollapsed(!isTimelineCollapsed)}

--- a/src/frontend/components/ArtifactViewer.tsx
+++ b/src/frontend/components/ArtifactViewer.tsx
@@ -24,9 +24,13 @@ export function ArtifactViewer({ content, title }: ArtifactViewerProps) {
   const KindIcon = meta.icon;
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(content);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable (e.g. non-secure context) */
+    }
   };
 
   return (
@@ -40,7 +44,7 @@ export function ArtifactViewer({ content, title }: ArtifactViewerProps) {
         <Button
           variant="plain"
           size="sm"
-          className="!p-1"
+          className="p-1!"
           onClick={handleCopy}
           aria-label="Copy content"
         >

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -49,8 +49,9 @@ function stripThinkingFromPlainText(text: string): { thinking: string; display: 
   const thinkingParts: string[] = [];
   let display = text;
   const patterns: RegExp[] = [
-    /<think>([\s\S]*?)<\/redacted_thinking>/gi,
+    /<think>([\s\S]*?)<\/think>/gi,
     /<thinking>([\s\S]*?)<\/thinking>/gi,
+    /<redacted_thinking>([\s\S]*?)<\/redacted_thinking>/gi,
   ];
   for (const re of patterns) {
     display = display.replace(re, (_full, inner: string) => {
@@ -394,7 +395,7 @@ const HumanMessageBubble: React.FC<HumanMessageBubbleProps> = ({
                 <Pencil className="h-3.5 w-3.5" />
               </button>
             )}
-            <div className="text-sm leading-relaxed [&_p]:!mb-1.5 [&_p:last-child]:!mb-0">
+            <div className="text-sm leading-relaxed [&_p]:mb-1.5! [&_p:last-child]:mb-0!">
               <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
                 {plain}
               </ReactMarkdown>
@@ -857,7 +858,7 @@ export function ChatMessagesView({
         </div>
       )}
       <div className="flex-1 min-h-0 overflow-y-auto chat-scroll" ref={scrollAreaRef}>
-        <div role="log" aria-label="Chat messages" aria-live="polite" aria-busy={isLoading} className="p-4 md:p-6 space-y-5 max-w-3xl mx-auto pt-8">
+        <div role="log" aria-label="Chat messages" aria-live="off" aria-busy={isLoading} className="p-4 md:p-6 space-y-5 max-w-3xl mx-auto pt-8">
           {messages.map((message, messageIndex) => {
             if (message.type === 'tool') {
               return <Fragment key={message.id ?? `m-${messageIndex}`} />;

--- a/src/frontend/components/ErrorRecovery.tsx
+++ b/src/frontend/components/ErrorRecovery.tsx
@@ -137,7 +137,6 @@ export function ErrorRecovery({
             isDisabled={maxRetriesReached || isRetrying}
             isLoading={isRetrying}
             spinnerAriaValueText="Retrying"
-            aria-label="Retry operation"
           >
             {retryLabel}
           </Button>

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -133,7 +133,10 @@ export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBan
       if (!body.authorize_url) {
         throw new Error('No authorize_url returned');
       }
-      window.open(body.authorize_url, 'mcp-oauth', 'width=600,height=700');
+      const popup = window.open(body.authorize_url, 'mcp-oauth', 'width=600,height=700');
+      if (!popup) {
+        throw new Error('Popup blocked by browser');
+      }
     } catch (err) {
       setConnectError(err instanceof Error ? err.message : 'Connect failed');
     } finally {

--- a/src/frontend/components/McpStatusPanel.tsx
+++ b/src/frontend/components/McpStatusPanel.tsx
@@ -33,7 +33,7 @@ export function McpStatusPanel({ mcpEvents }: McpStatusPanelProps) {
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-3 pt-2" aria-label="MCP tool status">
+    <div className="max-w-3xl mx-auto px-3 pt-2" role="region" aria-label="MCP tool status">
       <ExpandableSection
         toggleText="MCP tool activity"
         isExpanded={expanded}

--- a/src/frontend/components/ReconnectingBanner.tsx
+++ b/src/frontend/components/ReconnectingBanner.tsx
@@ -17,7 +17,7 @@ export function ReconnectingBanner({ streamingState, maxRetries }: ReconnectingB
     : '';
 
   return (
-    <Alert variant="warning" isInline title="Reconnecting...">
+    <Alert variant="warning" isInline title="Reconnecting..." role="status" aria-live="polite">
       {attemptText}{midResponseWarning ? '.' : ''}{midResponseWarning}
     </Alert>
   );

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -54,6 +54,7 @@ function SidebarComponent({
 
 
   const filteredChats = useMemo(() => {
+    if (chatHistory.length <= 3) return chatHistory;
     const q = searchQuery.trim().toLowerCase();
     if (!q) return chatHistory;
     return chatHistory.filter(
@@ -68,7 +69,10 @@ function SidebarComponent({
   };
 
   const handleSaveRename = (chatId: string) => {
-    onRenameChat(chatId, editTitle);
+    const trimmed = editTitle.trim();
+    if (trimmed) {
+      onRenameChat(chatId, trimmed);
+    }
     setEditingChat(null);
     setEditTitle('');
   };

--- a/src/frontend/components/TasksSidebar.tsx
+++ b/src/frontend/components/TasksSidebar.tsx
@@ -78,7 +78,7 @@ export function TasksSidebar({ messages, isLoading }: TasksSidebarProps) {
           )}
         </CardTitle>
       </CardHeader>
-      <CardBody className="overflow-y-auto space-y-1.5 !pt-0">
+      <CardBody className="overflow-y-auto space-y-1.5 pt-0!">
         {entries.map((entry) => {
           const Icon = entry.isSubAgent ? Bot : Wrench;
           const StatusIcon = entry.hasResult ? CheckCircle : Loader2;

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -374,9 +374,9 @@ export function AppLayout({ children }: AppLayoutProps) {
           console.error('Main content error:', error, errorInfo);
         }}
       >
-        <div id="main-content" className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        <main id="main-content" className="flex-1 flex flex-col min-h-0 overflow-hidden">
           {children}
-        </div>
+        </main>
       </ErrorBoundary>
     </Page>
   );

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -20,15 +20,24 @@ export function ProfileSection() {
   const email = userData?.email || '';
   const username = userData?.preferred_username || '';
 
-  const handleDeleteAll = () => {
+  const handleDeleteAll = async () => {
     const ids = chats.map((c) => c.id);
     ids.forEach((id) => releaseStreamingManager(id));
+
+    const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
+    const failures = results.filter((r) => r === false).length;
+
+    if (failures > 0) {
+      dispatch(addToast({ title: `Failed to delete ${failures} chat${failures !== 1 ? 's' : ''} on the server`, variant: 'danger' }));
+      setConfirmDelete(false);
+      return;
+    }
+
     dispatch(clearAllChats());
     chatStorage.clearChats();
     dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
     setConfirmDelete(false);
     navigate('/');
-    ids.forEach((id) => deleteThread(id).catch(() => {}));
   };
 
   return (

--- a/src/frontend/global.css
+++ b/src/frontend/global.css
@@ -170,7 +170,10 @@ input::placeholder {
 }
 textarea:focus,
 input[type="text"]:focus,
-input[type="search"]:focus {
+input[type="search"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="url"]:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
   outline: none;
@@ -195,11 +198,11 @@ input[type="search"]:focus {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
 }
-@keyframes slideInRight {
+@keyframes slide-in-right {
   from { opacity: 0; transform: translateX(16px); }
   to { opacity: 1; transform: translateX(0); }
 }
-@keyframes pulseGlow {
+@keyframes pulse-glow {
   0%, 100% { opacity: 0.4; }
   50% { opacity: 0.8; }
 }
@@ -216,8 +219,8 @@ input[type="search"]:focus {
 .animate-fadeIn { animation: fadeIn 0.5s ease-out forwards; }
 .animate-fadeInUp { animation: fadeInUp 0.5s ease-out forwards; }
 .animate-fadeInUpSmooth { animation: fadeInUpSmooth 0.3s ease-out forwards; }
-.animate-slideInRight { animation: slideInRight 0.4s ease-out forwards; }
-.animate-pulseGlow { animation: pulseGlow 3s ease-in-out infinite; }
+.animate-slide-in-right { animation: slide-in-right 0.4s ease-out forwards; }
+.animate-pulse-glow { animation: pulse-glow 3s ease-in-out infinite; }
 .animate-float { animation: float 4s ease-in-out infinite; }
 .animate-shimmer {
   background-size: 200% 100%;

--- a/src/frontend/hooks/useDataStream.tsx
+++ b/src/frontend/hooks/useDataStream.tsx
@@ -208,6 +208,7 @@ export function useDataStream({
               } else {
                 setMessages(prev => {
                   const last = prev[prev.length - 1];
+                  if (!last || last.type !== 'ai') return prev;
                   const updated = { ...last, content: ((last.content as string) || '') + content };
                   return [...prev.slice(0, -1), updated];
                 });

--- a/src/frontend/hooks/useRateLimitState.ts
+++ b/src/frontend/hooks/useRateLimitState.ts
@@ -44,18 +44,17 @@ export function useRateLimitState(): RateLimitState {
       });
 
       tickRef.current = setInterval(() => {
-        setState((prev) => {
-          const next = prev.retryAfterSeconds - 1;
-          if (next <= 0) {
-            clearTick();
-            return { isRateLimited: false, retryAfterSeconds: 0, resetTime: null };
-          }
-          return {
+        const remaining = Math.max(0, Math.ceil((resetTime.getTime() - Date.now()) / 1000));
+        if (remaining <= 0) {
+          clearTick();
+          setState({ isRateLimited: false, retryAfterSeconds: 0, resetTime: null });
+        } else {
+          setState({
             isRateLimited: true,
-            retryAfterSeconds: next,
-            resetTime: prev.resetTime,
-          };
-        });
+            retryAfterSeconds: remaining,
+            resetTime,
+          });
+        }
       }, 1000);
     },
     [clearTick],

--- a/src/frontend/hooks/useRefreshableToken.tsx
+++ b/src/frontend/hooks/useRefreshableToken.tsx
@@ -54,6 +54,10 @@ export function useRefreshableToken() {
         try {
           const response = await fetch("/auth/refresh?forceRefresh=true");
           if (response.status === 401) {
+            if (keepTokenRefreshedIntervalRef.current) {
+              clearInterval(keepTokenRefreshedIntervalRef.current);
+              keepTokenRefreshedIntervalRef.current = null;
+            }
             notifySessionExpired();
             return;
           }

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -181,9 +181,11 @@ export function useStreamingAPI(threadId: string) {
   const chatRef = useRef(chat);
   chatRef.current = chat;
 
-  if (!managerRef.current) {
-    managerRef.current = getStreamingManager(threadId);
-  }
+  useEffect(() => {
+    if (!managerRef.current) {
+      managerRef.current = getStreamingManager(threadId);
+    }
+  }, [threadId]);
 
   const handleStreamActivityStatus = useCallback((status: StreamStatus) => {
     if (status === 'connecting' || status === 'streaming') {
@@ -732,6 +734,13 @@ export function useStreamingAPI(threadId: string) {
       let resumeStreamHadInterrupt = false;
 
       await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (!settled) {
+            settled = true;
+            resolve();
+          }
+        };
         const callbacks: StreamCallback = {
           onToken(content) {
             lastTokenTimeRef.current = Date.now();
@@ -787,18 +796,22 @@ export function useStreamingAPI(threadId: string) {
                 state: { error: error.message, isLoading: false, isConnected: false },
               }),
             );
+            finish();
           },
           onStatusChange(status) {
             const partial = nextStreamingPartialForStatus(status);
             if (partial) {
               dispatch(updateStreamingState({ chatId: threadId, state: partial }));
             }
+            if (status === 'cancelled') {
+              finish();
+            }
           },
           onDone() {
             if (!resumeStreamHadInterrupt) {
               dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
             }
-            resolve();
+            finish();
           },
         };
         void manager.stream(streamRequest, callbacks);

--- a/src/frontend/pages/HomePage.tsx
+++ b/src/frontend/pages/HomePage.tsx
@@ -5,14 +5,13 @@ import { Send } from 'lucide-react';
 import { useAppDispatch } from '../redux/hooks';
 import { addChat, ChatItem } from '../redux/slices/chats';
 
-const QUICK_PROMPTS = [
-  `What can ${window.APP_DATA?.agentName || 'Agent'} do for me?`,
-  'Help me analyze a dataset',
-  'Write a query to find anomalies',
-  'Summarize the key findings from this data',
-];
-
 export function HomePage() {
+  const QUICK_PROMPTS = [
+    `What can ${window.APP_DATA?.agentName || 'Agent'} do for me?`,
+    'Help me analyze a dataset',
+    'Write a query to find anomalies',
+    'Summarize the key findings from this data',
+  ];
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const [inputValue, setInputValue] = useState('');

--- a/src/frontend/services/agent-rest.ts
+++ b/src/frontend/services/agent-rest.ts
@@ -130,7 +130,12 @@ export async function getAllThreadsByUserId(userId: string): Promise<Thread[]> {
 
   if (!response.ok) return [];
 
-  const results = await response.json();
+  let results: any;
+  try {
+    results = await response.json();
+  } catch {
+    return [];
+  }
   if (!Array.isArray(results)) return [];
 
   return results

--- a/src/frontend/services/export-chat.ts
+++ b/src/frontend/services/export-chat.ts
@@ -41,7 +41,7 @@ export function downloadFile(content: string, filename: string, mimeType: string
   document.body.appendChild(a);
   a.click();
   a.remove();
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
 }
 
 export function slugifyExportBase(title: string): string {

--- a/src/frontend/test-utils/setup.ts
+++ b/src/frontend/test-utils/setup.ts
@@ -92,6 +92,7 @@ Object.defineProperty(window, 'USER_DATA', {
     displayName: 'Test User',
     given_name: 'Test',
     email: 'test@example.com',
+    preferred_username: 'test.user',
   },
   writable: true,
   configurable: true,

--- a/src/server/plugins/trace.plugin.ts
+++ b/src/server/plugins/trace.plugin.ts
@@ -23,7 +23,7 @@ const tracePlugin: FastifyPluginAsync = async function tracePlugin(fastify) {
     if (!traceId) {
       const xt = request.headers["x-trace-id"];
       traceId =
-        typeof xt === "string" && xt.length > 0 ? xt : randomUUID();
+        typeof xt === "string" && /^[\w.-]{1,64}$/.test(xt) ? xt : randomUUID();
     }
     request.headers["x-trace-id"] = traceId;
 

--- a/src/server/router/client.router.ts
+++ b/src/server/router/client.router.ts
@@ -6,6 +6,15 @@ import { getAgentName, getSettings } from "../utils/settings.js";
 const BUILD_VERSION = Date.now().toString(36);
 const basePath = (process.env.BASE_PATH || "").replace(/\/+$/, "");
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 function headerValue(request: FastifyRequest, name: string): string | undefined {
   const v = request.headers[name];
   return Array.isArray(v) ? v[0] : v;
@@ -76,7 +85,7 @@ async function routes(fastify: FastifyInstance) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" id="favicon" href="/favicon.ico" />
-    <title>${agentName}</title>
+    <title>${escapeHtml(agentName)}</title>
     <link rel="stylesheet" href="${basePath || ""}/dist/frontend/template-ui.css">
     <style>
     /* PF6/Tailwind v4 co-existence: inline to bypass Vite CSS purging */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -161,7 +161,7 @@ export async function setupServer(): Promise<FastifyInstance> {
 }
 
 export function startConfigWatcher(configPath: string, server: FastifyInstance) {
-  const cfg = getSettings();
+  let cfg = getSettings();
   const cleanup = watchConfig(configPath, (newSettings) => {
     server.log.info('[ConfigWatcher] Settings reloaded');
 
@@ -197,6 +197,8 @@ export function startConfigWatcher(configPath: string, server: FastifyInstance) 
     if (autoApplied.length > 0) {
       server.log.info({ settings: autoApplied }, '[ConfigWatcher] Settings applied without restart:');
     }
+
+    cfg = newSettings;
   });
 
   return cleanup;

--- a/src/server/utils/opa.ts
+++ b/src/server/utils/opa.ts
@@ -108,7 +108,11 @@ export async function createOpaEngine(
       const denials: unknown[] = first.deny ?? first.violations ?? [];
       if (!Array.isArray(denials)) return [];
 
-      return denials.map((d) => ({ message: String(d) }));
+      return denials.map((d) => ({
+        message: typeof d === "object" && d !== null && "msg" in d
+          ? String((d as { msg: unknown }).msg)
+          : String(d),
+      }));
     } catch (err) {
       log.error(`OPA evaluation error: ${err instanceof Error ? err.message : String(err)}`);
       return [];

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -223,6 +223,7 @@ function deepMerge<T extends Record<string, unknown>>(
 ): T {
   const result = { ...base } as Record<string, unknown>;
   for (const key of Object.keys(override)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     const bVal = result[key];
     const oVal = override[key];
     if (


### PR DESCRIPTION
Closes #126

## Summary

- Addresses all CodeRabbit and CodeQL review comments from PR #76
- Fixes 2 critical, 4 major, and ~40 minor issues across 35 files
- All lint, typecheck, unit tests (253/253), and build pass locally

### Critical
- Fix mismatched `<think>`/`</redacted_thinking>` regex in ChatMessagesView
- Clear refresh interval after 401 in useRefreshableToken

### Major
- Await server deletion results before showing success toast in ProfileSection
- Move `getStreamingManager` out of render into useEffect (no side effects during render)
- Ensure `resumeInterrupt` promise settles on error/cancellation

### Security & Hardening
- Add CI workflow `permissions: contents: read` and `persist-credentials: false`
- Reject prototype keys (`__proto__`, `constructor`, `prototype`) in `deepMerge`
- Escape `agentName` before HTML interpolation in client router
- Validate `x-trace-id` header against safe charset and max length

### Minor
- Tailwind v4 important syntax (`!utility` → `utility!`) across 5 files
- A11y: live regions, ARIA roles, `<main>` landmark, removed conflicting aria-label
- Guard clipboard, popup, sessionStorage, and stream message updates
- Fix rate limit timer drift, sidebar search reset, empty rename rejection
- Move QUICK_PROMPTS inside component, default dark theme when missing
- Rename CSS keyframes to kebab-case, extend focus selectors
- Docs: language tags, hot-reload alignment, auth docs, shell exports
- Add Node.js `>=22.13.0` engine requirement

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 253/253 passed
- [x] `npm run build` — successful (frontend + server)