### PR TITLE
fix: embed branding into server rendered HTML

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -9,7 +9,7 @@ import { SettingsPage } from './pages/SettingsPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ToastNotifications } from './components/ToastNotifications';
 import { useThemeSync } from './hooks/useThemeSync';
-import { loadConfig } from './redux/slices/config';
+import { loadConfig, setBranding, setFeatures } from './redux/slices/config';
 import { setConfigDefaults } from './redux/slices/userSettings';
 import type { RootState, AppDispatch } from './redux/store';
 
@@ -22,9 +22,19 @@ export default function App() {
 
   // Load config at app init
   useEffect(() => {
+    // Seed branding/features from server-injected HTML data
+    const serverBranding = (window as any).APP_DATA?.branding;
+    const serverFeatures = (window as any).APP_DATA?.features;
+    if (serverBranding) {
+      dispatch(setBranding(serverBranding));
+    }
+    if (serverFeatures) {
+      dispatch(setFeatures(serverFeatures));
+      dispatch(setConfigDefaults({ debug_mode_default: serverFeatures.debug_mode_default }));
+    }
+
     dispatch(loadConfig()).then((result: any) => {
       if (result.meta.requestStatus === 'fulfilled' && result.payload?.features) {
-        // Apply feature flag defaults to user settings
         dispatch(setConfigDefaults({
           debug_mode_default: result.payload.features.debug_mode_default,
         }));

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -23,8 +23,8 @@ export default function App() {
   // Load config at app init
   useEffect(() => {
     // Seed branding/features from server-injected HTML data
-    const serverBranding = (window as any).APP_DATA?.branding;
-    const serverFeatures = (window as any).APP_DATA?.features;
+    const serverBranding = window.APP_DATA?.branding;
+    const serverFeatures = window.APP_DATA?.features;
     if (serverBranding) {
       dispatch(setBranding(serverBranding));
     }

--- a/src/frontend/services/config.service.ts
+++ b/src/frontend/services/config.service.ts
@@ -26,7 +26,7 @@ function getConfigApiBase(): string {
 }
 
 export const fetchBranding = async (): Promise<BrandingConfig> => {
-  const res = await fetch(`${getConfigApiBase()}/branding`);
+  const res = await fetch(`${getConfigApiBase()}/branding`, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error("Failed to load branding config");
   }
@@ -34,7 +34,7 @@ export const fetchBranding = async (): Promise<BrandingConfig> => {
 };
 
 export const fetchFeatures = async (): Promise<FeaturesConfig> => {
-  const res = await fetch(`${getConfigApiBase()}/features`);
+  const res = await fetch(`${getConfigApiBase()}/features`, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error("Failed to load features config");
   }

--- a/src/frontend/types/user.ts
+++ b/src/frontend/types/user.ts
@@ -16,11 +16,15 @@ export interface UserData {
   sub: string;
 }
 
+import type { BrandingConfig, FeaturesConfig } from '../services/config.service';
+
 export interface AppData {
   apiUrl: string;
   refreshableToken: string;
   agentName: string;
   basePath?: string;
+  branding?: BrandingConfig;
+  features?: FeaturesConfig;
 }
 
 // Extend the Window interface to include USER_DATA and APP_DATA

--- a/src/server/router/client.router.ts
+++ b/src/server/router/client.router.ts
@@ -71,11 +71,14 @@ async function routes(fastify: FastifyInstance) {
     };
 
     const agentName = await getAgentName();
+    const cfg = getSettings();
     const appData = {
       apiUrl: basePath ? `${basePath}/api/proxy/agent` : "",
       basePath: basePath || "/",
       refreshableToken: "",
       agentName,
+      branding: cfg.branding,
+      features: cfg.features,
     };
 
     reply.type("text/html");


### PR DESCRIPTION
## Description

<!-- What does this MR do and why? Jira: DVRS-XXXX -->

This PR renders the UI branding configuration onto the server-rendered HTML. This allows AI Factory deployed template-ui pods to consume the branding without having to call a separate api endpoint.

## Changes

- src/server/router/client.router.ts — server side: The deep-agent branch already calls getSettings() in client.router.ts (for the MCP OAuth callback handler). The fix branch re-uses that same cfg in the SPA route handler and injects branding and features directly into appData, which gets embedded in the data-app attribute on the #root div at HTML render time:
- src/frontend/App.tsx — client side: The useEffect at app init now reads those server-injected values first, dispatches setBranding and setFeatures into Redux before the async loadConfig() call kicks off, and also seeds debug_mode_default from the server data immediately:

## AI Disclosure

<!-- Helps reviewers calibrate: AI-generated code has different failure modes than hand-written code. -->

- **AI used**: Yes
- **Tool(s)**: Claude Code
- **Scope**: identified bug and created initial fix
- **Human verification**: manually refined fix in 2nd commit and review line by line

## Checklist

- [x] I have reviewed my own diff
- [x] Tests pass with adequate coverage
- [x] Docs and config updated if needed
- [x] AI output verified for correctness and hallucinated dependencies

## Deployment & Security Impact

<!--
Deployment: new env vars, config changes, migrations, resource scaling, downtime risk, rollback steps.
Security: auth/token changes, new endpoints exposed, input validation, secrets handling, RBAC changes.
-->

None

## Reviewer Notes

<!-- What to focus on. -->

None