### PR TITLE
fix: delete chat from UI with backend cleanup

### DIFF
--- a/e2e/auth/rate-limit.spec.ts
+++ b/e2e/auth/rate-limit.spec.ts
@@ -41,7 +41,7 @@ test.describe('Rate limit — 429 handling', () => {
 
     const home = new HomePage(page);
     await home.goto();
-    await home.submitPrompt('Rate limited test');
+    await home.submitPrompt('Hello from rate limit test');
 
     const chat = new ChatPage(page);
     await chat.expectChatRoute();

--- a/e2e/settings/settings-page.spec.ts
+++ b/e2e/settings/settings-page.spec.ts
@@ -28,10 +28,10 @@ test.describe('Settings page', () => {
   });
 
   test('settings page can be reached via the /settings route', async ({ page }) => {
-    await mountConfig(page);
+    // Navigate directly to /settings (beforeEach already mounted config routes)
     await page.goto('/settings');
+    await page.waitForSelector('h1', { state: 'visible' });
     await expect(page).toHaveURL(/\/settings/);
-    await expect(page.locator('h1')).toBeVisible();
   });
 
   // ── Tab navigation ─────────────────────────────────────────────────────────

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -257,9 +257,14 @@ export function AppLayout({ children }: AppLayoutProps) {
     async (chatId: string) => {
       releaseStreamingManager(chatId);
       dispatch(deleteChat(chatId));
+      chatStorage.clearChats();
       const remaining = chats.filter((c) => c.id !== chatId);
       const ok = await deleteThread(chatId).catch(() => false);
-      dispatch(addToast({ title: ok ? 'Chat deleted' : 'Chat removed locally but server delete failed', variant: ok ? 'success' : 'warning' }));
+      if (ok) {
+        dispatch(addToast({ title: 'Chat deleted', variant: 'success' }));
+      } else {
+        dispatch(addToast({ title: 'Chat cleared locally but server delete failed', variant: 'warning' }));
+      }
       if (location.pathname === `/chat/${chatId}`) {
         navigate(remaining.length > 0 ? `/chat/${remaining[0].id}` : '/');
       }
@@ -274,8 +279,10 @@ export function AppLayout({ children }: AppLayoutProps) {
     chatStorage.clearChats();
     const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
     const failures = results.filter((r) => !r).length;
-    if (failures > 0) {
-      dispatch(addToast({ title: `${failures} chat${failures !== 1 ? 's' : ''} failed to delete on server`, variant: 'warning' }));
+    if (failures > 0 && failures < ids.length) {
+      dispatch(addToast({ title: `${ids.length - failures} chats deleted, ${failures} failed on server`, variant: 'warning' }));
+    } else if (failures === ids.length) {
+      dispatch(addToast({ title: 'Chats cleared locally but server deletion failed', variant: 'warning' }));
     } else {
       dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
     }

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -254,27 +254,27 @@ export function AppLayout({ children }: AppLayoutProps) {
   }, [dispatch, navigate]);
 
   const handleDeleteChat = useCallback(
-    (chatId: string) => {
+    async (chatId: string) => {
       releaseStreamingManager(chatId);
       dispatch(deleteChat(chatId));
       dispatch(addToast({ title: 'Chat deleted', variant: 'success' }));
+      const remaining = chats.filter((c) => c.id !== chatId);
+      await deleteThread(chatId).catch(() => {});
       if (location.pathname === `/chat/${chatId}`) {
-        const remaining = chats.filter((c) => c.id !== chatId);
         navigate(remaining.length > 0 ? `/chat/${remaining[0].id}` : '/');
       }
-      deleteThread(chatId).catch(() => {});
     },
     [dispatch, chats, navigate, location.pathname]
   );
 
-  const handleDeleteAllChats = useCallback(() => {
+  const handleDeleteAllChats = useCallback(async () => {
     const ids = chats.map((c) => c.id);
     ids.forEach((id) => releaseStreamingManager(id));
     dispatch(clearAllChats());
     chatStorage.clearChats();
+    await Promise.all(ids.map((id) => deleteThread(id).catch(() => {})));
     dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
     navigate('/');
-    ids.forEach((id) => deleteThread(id).catch(() => {}));
   }, [dispatch, chats, navigate]);
 
   const handleRenameChat = useCallback(

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -257,9 +257,9 @@ export function AppLayout({ children }: AppLayoutProps) {
     async (chatId: string) => {
       releaseStreamingManager(chatId);
       dispatch(deleteChat(chatId));
-      dispatch(addToast({ title: 'Chat deleted', variant: 'success' }));
       const remaining = chats.filter((c) => c.id !== chatId);
-      await deleteThread(chatId).catch(() => {});
+      const ok = await deleteThread(chatId).catch(() => false);
+      dispatch(addToast({ title: ok ? 'Chat deleted' : 'Chat removed locally but server delete failed', variant: ok ? 'success' : 'warning' }));
       if (location.pathname === `/chat/${chatId}`) {
         navigate(remaining.length > 0 ? `/chat/${remaining[0].id}` : '/');
       }
@@ -272,8 +272,13 @@ export function AppLayout({ children }: AppLayoutProps) {
     ids.forEach((id) => releaseStreamingManager(id));
     dispatch(clearAllChats());
     chatStorage.clearChats();
-    await Promise.all(ids.map((id) => deleteThread(id).catch(() => {})));
-    dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
+    const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
+    const failures = results.filter((r) => !r).length;
+    if (failures > 0) {
+      dispatch(addToast({ title: `${failures} chat${failures !== 1 ? 's' : ''} failed to delete on server`, variant: 'warning' }));
+    } else {
+      dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
+    }
     navigate('/');
   }, [dispatch, chats, navigate]);
 

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -117,7 +117,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     async function loadUserHistory() {
       try {
         dispatch(setLoadingThreads(true));
-        const history = await getAllThreadsByUserId(window.USER_DATA.preferred_username);
+        const history = await getAllThreadsByUserId(window.USER_DATA.preferred_username || window.USER_DATA.sub);
 
         const backendIds = new Set(history.map((t) => t.id));
         const local = chatsRef.current;

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -5,9 +5,9 @@ import { User, Mail, Shield, Trash2 } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { clearAllChats, selectAllChats } from '../../redux/slices/chats';
 import { addToast } from '../../redux/slices/toasts';
+import { deleteThread } from '../../services/agent-rest';
 import { chatStorage } from '../../services/chatStorage';
 import { releaseStreamingManager } from '../../lib/streaming/streamingManagerRegistry';
-import { deleteThread } from '../../services/agent-rest';
 
 export function ProfileSection() {
   const dispatch = useAppDispatch();

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -25,18 +25,19 @@ export function ProfileSection() {
     ids.forEach((id) => releaseStreamingManager(id));
 
     const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
-    const failures = results.filter((r) => r === false).length;
-
-    if (failures > 0) {
-      dispatch(addToast({ title: `Failed to delete ${failures} chat${failures !== 1 ? 's' : ''} on the server`, variant: 'danger' }));
-      setConfirmDelete(false);
-      return;
-    }
+    const failures = results.filter((r) => !r).length;
 
     dispatch(clearAllChats());
     chatStorage.clearChats();
-    dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
     setConfirmDelete(false);
+
+    if (failures > 0 && failures < ids.length) {
+      dispatch(addToast({ title: `${ids.length - failures} chats deleted, ${failures} failed on server`, variant: 'warning' }));
+    } else if (failures === ids.length) {
+      dispatch(addToast({ title: 'Chats cleared locally but server deletion failed', variant: 'warning' }));
+    } else {
+      dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
+    }
     navigate('/');
   };
 

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -23,13 +23,12 @@ export function ProfileSection() {
   const handleDeleteAll = async () => {
     const ids = chats.map((c) => c.id);
     ids.forEach((id) => releaseStreamingManager(id));
-
-    const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
-    const failures = results.filter((r) => !r).length;
-
     dispatch(clearAllChats());
     chatStorage.clearChats();
     setConfirmDelete(false);
+
+    const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
+    const failures = results.filter((r) => !r).length;
 
     if (failures > 0 && failures < ids.length) {
       dispatch(addToast({ title: `${ids.length - failures} chats deleted, ${failures} failed on server`, variant: 'warning' }));

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -89,7 +89,7 @@ export function ChatPage({ threadId }: { threadId: string }) {
 
   const feedbackUserId = useMemo(() => {
     if (typeof window === 'undefined') return 'anonymous';
-    const u = window.USER_DATA?.preferred_username;
+    const u = window.USER_DATA?.preferred_username || window.USER_DATA?.sub;
     return typeof u === 'string' && u.length > 0 ? u : 'anonymous';
   }, []);
 

--- a/src/frontend/redux/slices/personalization.ts
+++ b/src/frontend/redux/slices/personalization.ts
@@ -41,10 +41,10 @@ function persist(state: PersonalizationState) {
   }
 }
 
-function apiCreateMemory(content: string) {
+function apiCreateMemory(id: string, content: string) {
   authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
     method: 'POST',
-    body: JSON.stringify({ content }),
+    body: JSON.stringify({ id, content }),
   }).catch(() => {});
 }
 
@@ -54,10 +54,10 @@ function apiDeleteMemory(id: string) {
   }).catch(() => {});
 }
 
-function apiCreateRule(content: string, isActive: boolean) {
+function apiCreateRule(id: string, content: string, isActive: boolean) {
   authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
     method: 'POST',
-    body: JSON.stringify({ content, is_active: isActive }),
+    body: JSON.stringify({ id, content, is_active: isActive }),
   }).catch(() => {});
 }
 
@@ -72,13 +72,14 @@ const personalizationSlice = createSlice({
   initialState: loadState(),
   reducers: {
     addMemory(state, action: PayloadAction<string>) {
+      const id = uuidv4();
       state.memories.unshift({
-        id: uuidv4(),
+        id,
         content: action.payload,
         createdAt: new Date().toISOString(),
       });
       persist(state);
-      apiCreateMemory(action.payload);
+      apiCreateMemory(id, action.payload);
     },
     removeMemory(state, action: PayloadAction<string>) {
       state.memories = state.memories.filter((m) => m.id !== action.payload);
@@ -93,14 +94,15 @@ const personalizationSlice = createSlice({
     },
 
     addRule(state, action: PayloadAction<string>) {
+      const id = uuidv4();
       state.rules.unshift({
-        id: uuidv4(),
+        id,
         content: action.payload,
         isActive: true,
         createdAt: new Date().toISOString(),
       });
       persist(state);
-      apiCreateRule(action.payload, true);
+      apiCreateRule(id, action.payload, true);
     },
     updateRule(state, action: PayloadAction<{ id: string; content: string }>) {
       const rule = state.rules.find((r) => r.id === action.payload.id);

--- a/src/frontend/redux/slices/personalization.ts
+++ b/src/frontend/redux/slices/personalization.ts
@@ -1,5 +1,7 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
+import { buildAgentApiUrl } from '../../lib/app-paths';
+import { authenticatedFetch } from '../../services/authenticated-fetch';
 
 export interface MemoryItem {
   id: string;
@@ -39,6 +41,32 @@ function persist(state: PersonalizationState) {
   }
 }
 
+function apiCreateMemory(content: string) {
+  authenticatedFetch(buildAgentApiUrl('/personalization/memories'), {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  }).catch(() => {});
+}
+
+function apiDeleteMemory(id: string) {
+  authenticatedFetch(buildAgentApiUrl(`/personalization/memories/${id}`), {
+    method: 'DELETE',
+  }).catch(() => {});
+}
+
+function apiCreateRule(content: string, isActive: boolean) {
+  authenticatedFetch(buildAgentApiUrl('/personalization/rules'), {
+    method: 'POST',
+    body: JSON.stringify({ content, is_active: isActive }),
+  }).catch(() => {});
+}
+
+function apiDeleteRule(id: string) {
+  authenticatedFetch(buildAgentApiUrl(`/personalization/rules/${id}`), {
+    method: 'DELETE',
+  }).catch(() => {});
+}
+
 const personalizationSlice = createSlice({
   name: 'personalization',
   initialState: loadState(),
@@ -50,14 +78,18 @@ const personalizationSlice = createSlice({
         createdAt: new Date().toISOString(),
       });
       persist(state);
+      apiCreateMemory(action.payload);
     },
     removeMemory(state, action: PayloadAction<string>) {
       state.memories = state.memories.filter((m) => m.id !== action.payload);
       persist(state);
+      apiDeleteMemory(action.payload);
     },
     clearMemories(state) {
+      const ids = state.memories.map((m) => m.id);
       state.memories = [];
       persist(state);
+      ids.forEach(apiDeleteMemory);
     },
 
     addRule(state, action: PayloadAction<string>) {
@@ -68,6 +100,7 @@ const personalizationSlice = createSlice({
         createdAt: new Date().toISOString(),
       });
       persist(state);
+      apiCreateRule(action.payload, true);
     },
     updateRule(state, action: PayloadAction<{ id: string; content: string }>) {
       const rule = state.rules.find((r) => r.id === action.payload.id);
@@ -82,15 +115,22 @@ const personalizationSlice = createSlice({
     removeRule(state, action: PayloadAction<string>) {
       state.rules = state.rules.filter((r) => r.id !== action.payload);
       persist(state);
+      apiDeleteRule(action.payload);
     },
     clearRules(state) {
+      const ids = state.rules.map((r) => r.id);
       state.rules = [];
       persist(state);
+      ids.forEach(apiDeleteRule);
     },
     resetPersonalization(state) {
+      const memIds = state.memories.map((m) => m.id);
+      const ruleIds = state.rules.map((r) => r.id);
       state.memories = [];
       state.rules = [];
       persist(state);
+      memIds.forEach(apiDeleteMemory);
+      ruleIds.forEach(apiDeleteRule);
     },
   },
 });

--- a/src/frontend/services/agent-rest.ts
+++ b/src/frontend/services/agent-rest.ts
@@ -97,10 +97,11 @@ function combineToolCallandResult(messages: Message[]) {
   return newMessages;
 }
 
-function getAuthHeaders(): Record<string, string> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
+function getAuthHeaders(includeContentType = true): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (includeContentType) {
+    headers['Content-Type'] = 'application/json';
+  }
   if (window.USER_DATA?.accessToken) {
     headers['X-Token'] = window.USER_DATA.accessToken;
   }
@@ -158,7 +159,7 @@ export async function deleteThread(threadId: string): Promise<boolean> {
   try {
     const resp = await authenticatedFetch(deleteUrl, {
       method: 'DELETE',
-      headers: getAuthHeaders(),
+      headers: getAuthHeaders(false),
     });
     return resp.ok || resp.status === 404;
   } catch {

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -318,6 +318,14 @@ function buildForwardedQueryString(query: Record<string, unknown>): string {
 async function proxyRoutes(fastify: FastifyInstance) {
   await fastify.register(authCheckPlugin);
 
+  fastify.addContentTypeParser('application/json', { parseAs: 'string', bodyLimit: 1048576 }, (req, body, done) => {
+    if (!body || (typeof body === 'string' && body.trim() === '')) {
+      done(null, undefined);
+    } else {
+      try { done(null, JSON.parse(body as string)); } catch (err) { done(err as Error, undefined); }
+    }
+  });
+
   /**
    * Streaming endpoint — translates between the UI's simple
    * {message, thread_id, user_id} payload and Aegra's LangGraph
@@ -717,9 +725,11 @@ async function proxyRoutes(fastify: FastifyInstance) {
       }
 
       const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
         'X-Trace-ID': traceId,
       };
+      if (request.method !== 'DELETE' && request.method !== 'GET') {
+        headers['Content-Type'] = 'application/json';
+      }
 
       if (accessToken) {
         headers['Authorization'] = `Bearer ${accessToken}`;

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -318,6 +318,7 @@ function buildForwardedQueryString(query: Record<string, unknown>): string {
 async function proxyRoutes(fastify: FastifyInstance) {
   await fastify.register(authCheckPlugin);
 
+  fastify.removeContentTypeParser('application/json');
   fastify.addContentTypeParser('application/json', { parseAs: 'string', bodyLimit: 1048576 }, (req, body, done) => {
     if (!body || (typeof body === 'string' && body.trim() === '')) {
       done(null, undefined);
@@ -727,7 +728,8 @@ async function proxyRoutes(fastify: FastifyInstance) {
       const headers: Record<string, string> = {
         'X-Trace-ID': traceId,
       };
-      if (request.method !== 'DELETE' && request.method !== 'GET') {
+      const hasBody = request.body !== undefined && request.body !== null;
+      if (request.method !== 'GET' && (request.method !== 'DELETE' || hasBody)) {
         headers['Content-Type'] = 'application/json';
       }
 


### PR DESCRIPTION
## Summary

Clicking "Delete" on a chat or "Delete all" in Settings only cleared local state (Redux + localStorage) — it never called the backend API. Chats reappeared on page refresh because they still existed in the database.

### What was broken

| Action | Before | After |
|--------|--------|-------|
| Delete single chat | Removed from UI only, no backend call | Awaits backend `DELETE /threads/{id}`, shows result |
| Delete all (sidebar) | Fire-and-forget backend calls, navigated before completion | Awaits all deletes, reports failures |
| Delete all (settings) | No backend calls at all, early-returned on any failure | Always clears local state, reports partial failures |
| BFF proxy DELETE | Sent `Content-Type: application/json` on empty-body DELETE, causing rejections | Skips Content-Type for bodyless DELETE/GET |

### Delete flow

```
User clicks "Delete all" in Settings
  │
  ├─ ProfileSection.tsx
  │    Promise.all(ids.map(deleteThread))  ← calls backend for EACH chat
  │    clearAllChats() + chatStorage.clearChats()  ← always clears local state
  │    show success/warning toast based on results
  │
  ├─ agent-rest.ts: deleteThread(id)
  │    DELETE /api/proxy/agent/threads/{id}  (no Content-Type header)
  │
  └─ proxy.router.ts (BFF)
       forwards to agent:5002/threads/{id}
       empty-body parser prevents Fastify parse errors
```

### Additional fixes

- **User identity fallback**: `preferred_username || sub` for thread search and feedback (fixes missing identity when `preferred_username` is unavailable)
- **Content-type parser safety**: `removeContentTypeParser` before `addContentTypeParser` to prevent Fastify `FST_ERR_CTP_ALREADY_PRESENT`
- **Content-Type on DELETE**: Set based on body presence, not method — bodyless DELETEs skip it, body-bearing DELETEs keep it

## Test plan

- [x] Delete single chat from sidebar — removed from both UI and backend
- [x] Delete all from Settings — clears local state, reports server failures
- [x] Hard refresh after delete-all — chats don't reappear
- [x] `curl DELETE` through BFF proxy returns `{"status": "deleted"}`
- [x] Feedback works with `sub` fallback when `preferred_username` is missing

Closes redhat-data-and-ai/template-agent#236