### PR TITLE
fix: freeze message textbox while agent is processing

### DIFF
--- a/src/frontend/components/InputForm.tsx
+++ b/src/frontend/components/InputForm.tsx
@@ -56,16 +56,21 @@ export const InputForm = forwardRef<HTMLTextAreaElement, InputFormProps>(functio
           className="mb-1"
         />
       )}
-      <div className="relative rounded-2xl border border-border bg-card shadow-card focus-within:border-primary/40 focus-within:shadow-elevated transition-all duration-200">
+      <div className={`relative rounded-2xl border shadow-card transition-all duration-200 ${
+        isLoading
+          ? "border-muted bg-muted/30"
+          : "border-border bg-card focus-within:border-primary/40 focus-within:shadow-elevated"
+      }`}>
         <textarea
           ref={ref}
           autoFocus
           value={internalInputValue}
           onChange={(e) => setInternalInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Ask me anything about the data..."
+          disabled={isLoading}
+          placeholder={isLoading ? "Waiting for response..." : "Ask me anything about the data..."}
           aria-label="Type a message"
-          className="w-full resize-none border-0 bg-transparent px-4 pt-3.5 pb-12 text-sm leading-relaxed min-h-[56px] max-h-[200px] rounded-2xl placeholder:opacity-60 focus:outline-none focus:ring-0 focus:border-transparent focus:shadow-none"
+          className={`w-full resize-none border-0 bg-transparent px-4 pt-3.5 pb-12 text-sm leading-relaxed min-h-[56px] max-h-[200px] rounded-2xl placeholder:opacity-60 focus:outline-none focus:ring-0 focus:border-transparent focus:shadow-none ${isLoading ? "cursor-not-allowed opacity-50" : ""}`}
           style={{ boxShadow: 'none' }}
           rows={1}
         />

--- a/src/frontend/hooks/useStreamingAPI.test.ts
+++ b/src/frontend/hooks/useStreamingAPI.test.ts
@@ -288,4 +288,48 @@ describe('_startRecoveryPolling — deadline fires independently of pending requ
 
     expect(onRecovered).not.toHaveBeenCalled();
   });
+
+  it('discards a pending result that resolves after the poller is cancelled', async () => {
+    const { getThreadStateAndInterrupt } = await import('@/services/agent-rest');
+    const mockedFn = vi.mocked(getThreadStateAndInterrupt);
+
+    // Control when the request resolves
+    let resolveRequest!: (v: { messages: Message[]; interrupt: null }) => void;
+    mockedFn.mockImplementationOnce(() => new Promise((r) => { resolveRequest = r; }));
+
+    const intervalRef = { current: null } as React.MutableRefObject<ReturnType<typeof setInterval> | null>;
+    const deadlineRef = { current: null } as React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
+    const wasInterruptedRef = { current: false };
+    const onRecovered = vi.fn();
+
+    _startRecoveryPolling(
+      THREAD_ID,
+      store.dispatch,
+      onRecovered,
+      intervalRef,
+      deadlineRef,
+      wasInterruptedRef,
+      5000,
+      RECOVERY_POLL_TIMEOUT_MS,
+    );
+
+    // Trigger the first poll
+    vi.advanceTimersByTime(5000);
+
+    // Simulate stop() — clear refs before the request resolves
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = null;
+    if (deadlineRef.current) clearTimeout(deadlineRef.current);
+    deadlineRef.current = null;
+
+    // Now resolve the in-flight request — it should be discarded
+    resolveRequest({
+      messages: [{ type: 'ai', content: 'stale', id: 'stale-1' } as unknown as Message],
+      interrupt: null,
+    });
+    await vi.runAllTimersAsync();
+
+    // Stale result must not trigger onRecovered or dispatch state
+    expect(onRecovered).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend/hooks/useStreamingAPI.test.ts
+++ b/src/frontend/hooks/useStreamingAPI.test.ts
@@ -5,12 +5,12 @@ import { renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
 import { configureStore } from '@reduxjs/toolkit';
-import chatsReducer, { addChat } from '../redux/slices/chats';
+import chatsReducer, { addChat, selectStreamingState } from '../redux/slices/chats';
 import configReducer from '../redux/slices/config';
 import personalizationReducer from '../redux/slices/personalization';
 import toastsReducer from '../redux/slices/toasts';
 import userSettingsReducer, { addAlwaysAllowedTool } from '../redux/slices/userSettings';
-import { useStreamingAPI } from './useStreamingAPI';
+import { useStreamingAPI, RECOVERY_POLL_TIMEOUT_MS, _startRecoveryPolling } from './useStreamingAPI';
 
 // ── Store factory ─────────────────────────────────────────────────────────────
 
@@ -228,5 +228,60 @@ describe('useStreamingAPI — initial state and stop()', () => {
 
     // Clean up the in-flight request
     act(() => result.current.stop());
+  });
+});
+
+// ── Recovery timeout independence ────────────────────────────────────────────
+
+vi.mock('@/services/agent-rest', () => ({
+  getThreadState: vi.fn(() => new Promise(() => {})),
+  getThreadStateAndInterrupt: vi.fn(() => new Promise(() => {})),
+}));
+
+describe('_startRecoveryPolling — deadline fires independently of pending request', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    store = makeStore();
+    seedChat(store);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sets isLoading=false after timeout even when getThreadStateAndInterrupt never resolves', () => {
+    const intervalRef = { current: null } as React.MutableRefObject<ReturnType<typeof setInterval> | null>;
+    const wasInterruptedRef = { current: false };
+    const onRecovered = vi.fn();
+
+    _startRecoveryPolling(
+      THREAD_ID,
+      store.dispatch,
+      onRecovered,
+      intervalRef,
+      wasInterruptedRef,
+      5000,
+      RECOVERY_POLL_TIMEOUT_MS,
+    );
+
+    expect(intervalRef.current).not.toBeNull();
+
+    // Advance past the deadline — the one-shot timeout must fire
+    // even though the polling request is still pending
+    vi.advanceTimersByTime(RECOVERY_POLL_TIMEOUT_MS + 1000);
+
+    // Deadline should have cleaned up the interval
+    expect(intervalRef.current).toBeNull();
+
+    // Redux state should reflect the timeout
+    const state = selectStreamingState(store.getState(), THREAD_ID);
+    expect(state.isLoading).toBe(false);
+    expect(state.error).toBe('Agent is unavailable. Please try again.');
+
+    expect(onRecovered).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/hooks/useStreamingAPI.test.ts
+++ b/src/frontend/hooks/useStreamingAPI.test.ts
@@ -255,6 +255,7 @@ describe('_startRecoveryPolling — deadline fires independently of pending requ
 
   it('sets isLoading=false after timeout even when getThreadStateAndInterrupt never resolves', () => {
     const intervalRef = { current: null } as React.MutableRefObject<ReturnType<typeof setInterval> | null>;
+    const deadlineRef = { current: null } as React.MutableRefObject<ReturnType<typeof setTimeout> | null>;
     const wasInterruptedRef = { current: false };
     const onRecovered = vi.fn();
 
@@ -263,19 +264,22 @@ describe('_startRecoveryPolling — deadline fires independently of pending requ
       store.dispatch,
       onRecovered,
       intervalRef,
+      deadlineRef,
       wasInterruptedRef,
       5000,
       RECOVERY_POLL_TIMEOUT_MS,
     );
 
     expect(intervalRef.current).not.toBeNull();
+    expect(deadlineRef.current).not.toBeNull();
 
     // Advance past the deadline — the one-shot timeout must fire
     // even though the polling request is still pending
     vi.advanceTimersByTime(RECOVERY_POLL_TIMEOUT_MS + 1000);
 
-    // Deadline should have cleaned up the interval
+    // Deadline should have cleaned up both timers
     expect(intervalRef.current).toBeNull();
+    expect(deadlineRef.current).toBeNull();
 
     // Redux state should reflect the timeout
     const state = selectStreamingState(store.getState(), THREAD_ID);

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -148,19 +148,20 @@ export function _startRecoveryPolling(
   dispatch: AppDispatch,
   onRecovered: (msgs: Message[]) => void,
   intervalRef: React.MutableRefObject<ReturnType<typeof setInterval> | null>,
+  deadlineRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
   wasInterruptedRef: React.MutableRefObject<boolean>,
   pollIntervalMs: number,
   timeoutMs: number,
 ) {
   if (intervalRef.current) clearInterval(intervalRef.current);
+  if (deadlineRef.current) clearTimeout(deadlineRef.current);
   wasInterruptedRef.current = true;
   let polling = false;
   let expired = false;
-  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
 
-  deadlineTimer = setTimeout(() => {
+  deadlineRef.current = setTimeout(() => {
     expired = true;
-    deadlineTimer = null;
+    deadlineRef.current = null;
     if (intervalRef.current) clearInterval(intervalRef.current);
     intervalRef.current = null;
     dispatch(updateStreamingState({
@@ -182,7 +183,7 @@ export function _startRecoveryPolling(
       const { messages: msgs, interrupt } = await getThreadStateAndInterrupt(threadId);
       if (expired) return;
       if (interrupt) {
-        if (deadlineTimer) { clearTimeout(deadlineTimer); deadlineTimer = null; }
+        if (deadlineRef.current) { clearTimeout(deadlineRef.current); deadlineRef.current = null; }
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
         wasInterruptedRef.current = false;
@@ -202,7 +203,7 @@ export function _startRecoveryPolling(
       if (msgs.length === 0) return;
       const lastMsg = msgs[msgs.length - 1];
       if (lastMsg.type === 'ai' && lastMsg.content) {
-        if (deadlineTimer) { clearTimeout(deadlineTimer); deadlineTimer = null; }
+        if (deadlineRef.current) { clearTimeout(deadlineRef.current); deadlineRef.current = null; }
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
         wasInterruptedRef.current = false;
@@ -299,6 +300,7 @@ export function useStreamingAPI(threadId: string) {
   const wasInterruptedRef = useRef(false);
   const messagesRef = useRef<Message[]>(EMPTY_MESSAGES);
   const recoveryIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const recoveryDeadlineRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([]);
   const clearReconnectTimers = useCallback(() => {
     for (const id of reconnectTimersRef.current) clearTimeout(id);
@@ -347,6 +349,10 @@ export function useStreamingAPI(threadId: string) {
         clearInterval(recoveryIntervalRef.current);
         recoveryIntervalRef.current = null;
       }
+      if (recoveryDeadlineRef.current) {
+        clearTimeout(recoveryDeadlineRef.current);
+        recoveryDeadlineRef.current = null;
+      }
       if (staleIntervalRef.current != null) {
         clearInterval(staleIntervalRef.current);
         staleIntervalRef.current = null;
@@ -391,6 +397,10 @@ export function useStreamingAPI(threadId: string) {
       if (recoveryIntervalRef.current) {
         clearInterval(recoveryIntervalRef.current);
         recoveryIntervalRef.current = null;
+      }
+      if (recoveryDeadlineRef.current) {
+        clearTimeout(recoveryDeadlineRef.current);
+        recoveryDeadlineRef.current = null;
       }
       setIsStreamStale(false);
       setMcpEvents([]);
@@ -909,7 +919,7 @@ export function useStreamingAPI(threadId: string) {
                   state: { isLoading: false, error: null },
                 }));
               }
-            }, recoveryIntervalRef, wasInterruptedRef, RECOVERY_POLL_INTERVAL_MS, RECOVERY_POLL_TIMEOUT_MS);
+            }, recoveryIntervalRef, recoveryDeadlineRef, wasInterruptedRef, RECOVERY_POLL_INTERVAL_MS, RECOVERY_POLL_TIMEOUT_MS);
           }
           break;
         }
@@ -1259,6 +1269,10 @@ export function useStreamingAPI(threadId: string) {
     if (recoveryIntervalRef.current) {
       clearInterval(recoveryIntervalRef.current);
       recoveryIntervalRef.current = null;
+    }
+    if (recoveryDeadlineRef.current) {
+      clearTimeout(recoveryDeadlineRef.current);
+      recoveryDeadlineRef.current = null;
     }
     dispatch(
       updateStreamingState({

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -585,6 +585,16 @@ export function useStreamingAPI(threadId: string) {
                     const id = recoveryIntervalRef.current;
                     recoveryIntervalRef.current = null;
                     if (id) clearInterval(id);
+                    dispatch(updateStreamingState({
+                      chatId: threadId,
+                      state: {
+                        isLoading: false,
+                        isConnected: false,
+                        isReconnecting: false,
+                        reconnectAttempt: 0,
+                        error: 'Agent is unavailable. Please try again.',
+                      },
+                    }));
                     return;
                   }
                   polling = true;
@@ -756,6 +766,16 @@ export function useStreamingAPI(threadId: string) {
                     const id = recoveryIntervalRef.current;
                     recoveryIntervalRef.current = null;
                     if (id) clearInterval(id);
+                    dispatch(updateStreamingState({
+                      chatId: threadId,
+                      state: {
+                        isLoading: false,
+                        isConnected: false,
+                        isReconnecting: false,
+                        reconnectAttempt: 0,
+                        error: 'Agent is unavailable. Please try again.',
+                      },
+                    }));
                     return;
                   }
                   polling = true;
@@ -895,6 +915,16 @@ export function useStreamingAPI(threadId: string) {
             const id = recoveryIntervalRef.current;
             recoveryIntervalRef.current = null;
             if (id) clearInterval(id);
+            dispatch(updateStreamingState({
+              chatId: threadId,
+              state: {
+                isLoading: false,
+                isConnected: false,
+                isReconnecting: false,
+                reconnectAttempt: 0,
+                error: 'Agent is unavailable. Please try again.',
+              },
+            }));
             return;
           }
           polling = true;

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -162,6 +162,16 @@ function _startRecoveryPolling(
     if (Date.now() - startTime > timeoutMs) {
       if (intervalRef.current) clearInterval(intervalRef.current);
       intervalRef.current = null;
+      dispatch(updateStreamingState({
+        chatId: threadId,
+        state: {
+          isLoading: false,
+          isConnected: false,
+          isReconnecting: false,
+          reconnectAttempt: 0,
+          error: 'Agent is unavailable. Please try again.',
+        },
+      }));
       return;
     }
     polling = true;

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -80,7 +80,7 @@ const HISTORY_REFETCH_THRESHOLD_MS = 10000;
 /** Poll interval when waiting for a recovered run to complete (ms) */
 const RECOVERY_POLL_INTERVAL_MS = 5000;
 /** Max time to poll for recovery before giving up (ms) */
-const RECOVERY_POLL_TIMEOUT_MS = 120000;
+export const RECOVERY_POLL_TIMEOUT_MS = 120000;
 
 function computeRetryDelayMs(retryAttemptNumber: number): number {
   const capped = Math.min(BASE_DELAY_MS * 2 ** retryAttemptNumber, 30000);
@@ -143,7 +143,7 @@ function _tryReplayQueuedDecision(threadId: string): Array<{ type: 'approve' | '
   }
 }
 
-function _startRecoveryPolling(
+export function _startRecoveryPolling(
   threadId: string,
   dispatch: AppDispatch,
   onRecovered: (msgs: Message[]) => void,
@@ -154,30 +154,35 @@ function _startRecoveryPolling(
 ) {
   if (intervalRef.current) clearInterval(intervalRef.current);
   wasInterruptedRef.current = true;
-  const startTime = Date.now();
   let polling = false;
+  let expired = false;
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+  deadlineTimer = setTimeout(() => {
+    expired = true;
+    deadlineTimer = null;
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = null;
+    dispatch(updateStreamingState({
+      chatId: threadId,
+      state: {
+        isLoading: false,
+        isConnected: false,
+        isReconnecting: false,
+        reconnectAttempt: 0,
+        error: 'Agent is unavailable. Please try again.',
+      },
+    }));
+  }, timeoutMs);
 
   intervalRef.current = setInterval(async () => {
-    if (polling) return;
-    if (Date.now() - startTime > timeoutMs) {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      intervalRef.current = null;
-      dispatch(updateStreamingState({
-        chatId: threadId,
-        state: {
-          isLoading: false,
-          isConnected: false,
-          isReconnecting: false,
-          reconnectAttempt: 0,
-          error: 'Agent is unavailable. Please try again.',
-        },
-      }));
-      return;
-    }
+    if (polling || expired) return;
     polling = true;
     try {
       const { messages: msgs, interrupt } = await getThreadStateAndInterrupt(threadId);
+      if (expired) return;
       if (interrupt) {
+        if (deadlineTimer) { clearTimeout(deadlineTimer); deadlineTimer = null; }
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
         wasInterruptedRef.current = false;
@@ -197,6 +202,7 @@ function _startRecoveryPolling(
       if (msgs.length === 0) return;
       const lastMsg = msgs[msgs.length - 1];
       if (lastMsg.type === 'ai' && lastMsg.content) {
+        if (deadlineTimer) { clearTimeout(deadlineTimer); deadlineTimer = null; }
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
         wasInterruptedRef.current = false;

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -176,12 +176,12 @@ export function _startRecoveryPolling(
     }));
   }, timeoutMs);
 
-  intervalRef.current = setInterval(async () => {
+  const myInterval = intervalRef.current = setInterval(async () => {
     if (polling || expired) return;
     polling = true;
     try {
       const { messages: msgs, interrupt } = await getThreadStateAndInterrupt(threadId);
-      if (expired) return;
+      if (expired || intervalRef.current !== myInterval) return;
       if (interrupt) {
         if (deadlineRef.current) { clearTimeout(deadlineRef.current); deadlineRef.current = null; }
         if (intervalRef.current) clearInterval(intervalRef.current);

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -946,7 +946,7 @@ export function useStreamingAPI(threadId: string) {
         }, RECOVERY_POLL_INTERVAL_MS);
       }
     },
-    [dispatch, threadId, memories, activeRules, handleStreamActivityStatus, clearReconnectTimers],
+    [dispatch, threadId, memories, activeRules, handleStreamActivityStatus, clearReconnectTimers, setMessages, setWasInterrupted],
   );
 
   /**

--- a/src/frontend/pages/ChatPage.tsx
+++ b/src/frontend/pages/ChatPage.tsx
@@ -591,7 +591,7 @@ export function ChatPage({ threadId }: { threadId: string }) {
               key={threadId}
               messages={thread.messages}
               streamEvents={thread.streamEvents}
-              isLoading={thread.isLoading}
+              isLoading={thread.isLoading || !!thread.pendingInterrupt}
               pendingInterrupt={
                 thread.pendingInterrupt &&
                 typeof thread.pendingInterrupt.value === 'object' &&


### PR DESCRIPTION
## Summary

Closes #151

- Freeze (disable) the message textarea while the agent is processing a response, preventing users from sending concurrent messages
- Add visual feedback: muted border/background, reduced opacity, "Waiting for response..." placeholder
- Fix three recovery polling timeout sites in `useStreamingAPI.ts` that left `isLoading` stuck as `true` when the agent became permanently unavailable — now dispatches `isLoading: false` with an error message after the 120s timeout

## Test plan

- [ ] Send a message and verify the textbox is disabled while the agent responds
- [ ] Verify the placeholder shows "Waiting for response..." during processing
- [ ] Verify the stop button still works to cancel processing
- [ ] Verify the textbox unfreezes after the agent responds
- [ ] Kill the agent pod mid-processing and verify the textbox unfreezes after ~120s with an error message
- [ ] Verify the textbox unfreezes if the agent recovers via LeaseReaper before timeout

Signed-off-by: Naveen Saharan <nsaharan@redhat.com>