### PR TITLE
feat: add per-control enforcement modes, override path, and OPA OTEL spans

### DIFF
--- a/config/compliance/modes.json
+++ b/config/compliance/modes.json
@@ -1,0 +1,10 @@
+{
+  "modes": {
+    "UI-AUTH-01": "OFF",
+    "UI-ENDPOINT-01": "OFF",
+    "UI-SESSION-01": "OFF",
+    "UI-DEBUG-01": "OFF",
+    "UI-FEATURES-01": "OFF",
+    "UI-RATELIMIT-01": "OFF"
+  }
+}

--- a/config/compliance/policy.rego
+++ b/config/compliance/policy.rego
@@ -4,7 +4,14 @@ import rego.v1
 
 default allow := true
 
+mode(control_id) := m if {
+	m := data.modes[control_id]
+} else := "OFF"
+
+# --- ENFORCE rules (deny) ---
+
 deny contains msg if {
+	mode("UI-AUTH-01") == "ENFORCE"
 	input.features.auth_enabled
 	input.platform.opa.approved_auth_providers
 	count(input.platform.opa.approved_auth_providers) > 0
@@ -13,6 +20,7 @@ deny contains msg if {
 }
 
 deny contains msg if {
+	mode("UI-ENDPOINT-01") == "ENFORCE"
 	input.agent.endpoint != ""
 	suffixes := input.platform.opa.internal_endpoint_suffixes
 	count(suffixes) > 0
@@ -21,6 +29,7 @@ deny contains msg if {
 }
 
 deny contains msg if {
+	mode("UI-SESSION-01") == "ENFORCE"
 	max_days := input.platform.opa.max_session_ttl_days
 	max_days > 0
 	input.security.session.max_age_days > max_days
@@ -28,12 +37,14 @@ deny contains msg if {
 }
 
 deny contains msg if {
+	mode("UI-DEBUG-01") == "ENFORCE"
 	input.platform.opa.restrict_debug_mode
 	input.features.debug_mode_default
 	msg := "debug_mode_default cannot be enabled in this environment"
 }
 
 deny contains msg if {
+	mode("UI-FEATURES-01") == "ENFORCE"
 	restricted := input.platform.opa.restricted_features
 	some feature in restricted
 	input.features[feature]
@@ -41,6 +52,58 @@ deny contains msg if {
 }
 
 deny contains msg if {
+	mode("UI-RATELIMIT-01") == "ENFORCE"
+	max_rate := input.platform.opa.max_rate_limit
+	max_rate > 0
+	input.security.rate_limit.max > max_rate
+	msg := sprintf("rate limit %d exceeds policy maximum %d", [input.security.rate_limit.max, max_rate])
+}
+
+# --- WARN rules (violations) ---
+
+violations contains msg if {
+	mode("UI-AUTH-01") == "WARN"
+	input.features.auth_enabled
+	input.platform.opa.approved_auth_providers
+	count(input.platform.opa.approved_auth_providers) > 0
+	not input.auth_provider in input.platform.opa.approved_auth_providers
+	msg := sprintf("auth provider '%s' is not in the approved list %v", [input.auth_provider, input.platform.opa.approved_auth_providers])
+}
+
+violations contains msg if {
+	mode("UI-ENDPOINT-01") == "WARN"
+	input.agent.endpoint != ""
+	suffixes := input.platform.opa.internal_endpoint_suffixes
+	count(suffixes) > 0
+	not endpoint_allowed(input.agent.endpoint, suffixes)
+	msg := sprintf("agent endpoint '%s' does not match any approved internal suffix %v", [input.agent.endpoint, suffixes])
+}
+
+violations contains msg if {
+	mode("UI-SESSION-01") == "WARN"
+	max_days := input.platform.opa.max_session_ttl_days
+	max_days > 0
+	input.security.session.max_age_days > max_days
+	msg := sprintf("session TTL %d days exceeds maximum allowed %d days", [input.security.session.max_age_days, max_days])
+}
+
+violations contains msg if {
+	mode("UI-DEBUG-01") == "WARN"
+	input.platform.opa.restrict_debug_mode
+	input.features.debug_mode_default
+	msg := "debug_mode_default cannot be enabled in this environment"
+}
+
+violations contains msg if {
+	mode("UI-FEATURES-01") == "WARN"
+	restricted := input.platform.opa.restricted_features
+	some feature in restricted
+	input.features[feature]
+	msg := sprintf("feature '%s' is restricted by policy", [feature])
+}
+
+violations contains msg if {
+	mode("UI-RATELIMIT-01") == "WARN"
 	max_rate := input.platform.opa.max_rate_limit
 	max_rate > 0
 	input.security.rate_limit.max > max_rate
@@ -55,5 +118,3 @@ endpoint_allowed(endpoint, suffixes) if {
 allow := false if {
 	count(deny) > 0
 }
-
-violations := deny

--- a/config/compliance/policy.rego
+++ b/config/compliance/policy.rego
@@ -10,7 +10,7 @@ mode(control_id) := m if {
 
 # --- ENFORCE rules (deny) ---
 
-deny contains msg if {
+deny contains {"id": "UI-AUTH-01", "msg": msg} if {
 	mode("UI-AUTH-01") == "ENFORCE"
 	input.features.auth_enabled
 	input.platform.opa.approved_auth_providers
@@ -19,7 +19,7 @@ deny contains msg if {
 	msg := sprintf("auth provider '%s' is not in the approved list %v", [input.auth_provider, input.platform.opa.approved_auth_providers])
 }
 
-deny contains msg if {
+deny contains {"id": "UI-ENDPOINT-01", "msg": msg} if {
 	mode("UI-ENDPOINT-01") == "ENFORCE"
 	input.agent.endpoint != ""
 	suffixes := input.platform.opa.internal_endpoint_suffixes
@@ -28,7 +28,7 @@ deny contains msg if {
 	msg := sprintf("agent endpoint '%s' does not match any approved internal suffix %v", [input.agent.endpoint, suffixes])
 }
 
-deny contains msg if {
+deny contains {"id": "UI-SESSION-01", "msg": msg} if {
 	mode("UI-SESSION-01") == "ENFORCE"
 	max_days := input.platform.opa.max_session_ttl_days
 	max_days > 0
@@ -36,14 +36,14 @@ deny contains msg if {
 	msg := sprintf("session TTL %d days exceeds maximum allowed %d days", [input.security.session.max_age_days, max_days])
 }
 
-deny contains msg if {
+deny contains {"id": "UI-DEBUG-01", "msg": msg} if {
 	mode("UI-DEBUG-01") == "ENFORCE"
 	input.platform.opa.restrict_debug_mode
 	input.features.debug_mode_default
 	msg := "debug_mode_default cannot be enabled in this environment"
 }
 
-deny contains msg if {
+deny contains {"id": "UI-FEATURES-01", "msg": msg} if {
 	mode("UI-FEATURES-01") == "ENFORCE"
 	restricted := input.platform.opa.restricted_features
 	some feature in restricted
@@ -51,7 +51,7 @@ deny contains msg if {
 	msg := sprintf("feature '%s' is restricted by policy", [feature])
 }
 
-deny contains msg if {
+deny contains {"id": "UI-RATELIMIT-01", "msg": msg} if {
 	mode("UI-RATELIMIT-01") == "ENFORCE"
 	max_rate := input.platform.opa.max_rate_limit
 	max_rate > 0
@@ -61,7 +61,7 @@ deny contains msg if {
 
 # --- WARN rules (violations) ---
 
-violations contains msg if {
+violations contains {"id": "UI-AUTH-01", "msg": msg} if {
 	mode("UI-AUTH-01") == "WARN"
 	input.features.auth_enabled
 	input.platform.opa.approved_auth_providers
@@ -70,7 +70,7 @@ violations contains msg if {
 	msg := sprintf("auth provider '%s' is not in the approved list %v", [input.auth_provider, input.platform.opa.approved_auth_providers])
 }
 
-violations contains msg if {
+violations contains {"id": "UI-ENDPOINT-01", "msg": msg} if {
 	mode("UI-ENDPOINT-01") == "WARN"
 	input.agent.endpoint != ""
 	suffixes := input.platform.opa.internal_endpoint_suffixes
@@ -79,7 +79,7 @@ violations contains msg if {
 	msg := sprintf("agent endpoint '%s' does not match any approved internal suffix %v", [input.agent.endpoint, suffixes])
 }
 
-violations contains msg if {
+violations contains {"id": "UI-SESSION-01", "msg": msg} if {
 	mode("UI-SESSION-01") == "WARN"
 	max_days := input.platform.opa.max_session_ttl_days
 	max_days > 0
@@ -87,14 +87,14 @@ violations contains msg if {
 	msg := sprintf("session TTL %d days exceeds maximum allowed %d days", [input.security.session.max_age_days, max_days])
 }
 
-violations contains msg if {
+violations contains {"id": "UI-DEBUG-01", "msg": msg} if {
 	mode("UI-DEBUG-01") == "WARN"
 	input.platform.opa.restrict_debug_mode
 	input.features.debug_mode_default
 	msg := "debug_mode_default cannot be enabled in this environment"
 }
 
-violations contains msg if {
+violations contains {"id": "UI-FEATURES-01", "msg": msg} if {
 	mode("UI-FEATURES-01") == "WARN"
 	restricted := input.platform.opa.restricted_features
 	some feature in restricted
@@ -102,7 +102,7 @@ violations contains msg if {
 	msg := sprintf("feature '%s' is restricted by policy", [feature])
 }
 
-violations contains msg if {
+violations contains {"id": "UI-RATELIMIT-01", "msg": msg} if {
 	mode("UI-RATELIMIT-01") == "WARN"
 	max_rate := input.platform.opa.max_rate_limit
 	max_rate > 0

--- a/src/server/plugins/opa.plugin.ts
+++ b/src/server/plugins/opa.plugin.ts
@@ -1,10 +1,25 @@
 import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
-import { trace } from "@opentelemetry/api";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createOpaEngine, type OpaEngine, type PolicyViolation, type EvaluationResult } from "../utils/opa.js";
 import { getSettings, type UISettings } from "../utils/settings.js";
 
-const tracer = trace.getTracer("opa-plugin");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface ControlStatus {
+  id: string;
+  status: "pass" | "fail" | "warn" | "off";
+  mode: "OFF" | "WARN" | "ENFORCE";
+  reason?: string;
+}
+
+export interface ComplianceState {
+  status: "compliant" | "non_compliant" | "disabled";
+  evaluated_at: string;
+  controls: ControlStatus[];
+}
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -13,7 +28,58 @@ declare module "fastify" {
       evaluateWithModes(): EvaluationResult;
       engine: OpaEngine;
     };
+    compliance: ComplianceState;
   }
+}
+
+function loadModes(policyPath: string): Record<string, string> {
+  const policyDir = policyPath && !policyPath.startsWith("/")
+    ? resolve(__dirname, "../../../", policyPath)
+    : policyPath || resolve(__dirname, "../../../config/compliance");
+  const modesFile = resolve(policyDir, "modes.json");
+  if (!existsSync(modesFile)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(modesFile, "utf-8"));
+    return raw.modes ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function buildComplianceState(
+  result: EvaluationResult,
+  modes: Record<string, string>,
+): ComplianceState {
+  const controls: ControlStatus[] = [];
+
+  for (const [controlId, mode] of Object.entries(modes)) {
+    const upperMode = mode.toUpperCase() as "OFF" | "WARN" | "ENFORCE";
+    if (upperMode === "OFF") {
+      controls.push({ id: controlId, status: "off", mode: "OFF" });
+      continue;
+    }
+
+    const denial = result.denials.find((v) => v.id === controlId);
+    if (denial) {
+      controls.push({ id: controlId, status: "fail", mode: "ENFORCE", reason: denial.message });
+      continue;
+    }
+
+    const warning = result.warnings.find((v) => v.id === controlId);
+    if (warning) {
+      controls.push({ id: controlId, status: "warn", mode: "WARN", reason: warning.message });
+      continue;
+    }
+
+    controls.push({ id: controlId, status: "pass", mode: upperMode });
+  }
+
+  const hasFailures = controls.some((c) => c.status === "fail");
+  return {
+    status: hasFailures ? "non_compliant" : "compliant",
+    evaluated_at: new Date().toISOString(),
+    controls,
+  };
 }
 
 function buildInput(cfg: UISettings): Record<string, unknown> {
@@ -52,6 +118,8 @@ export default fp(
       opaCfg.overrides_path,
     );
 
+    const modes = loadModes(opaCfg.policy_path);
+
     function evaluate(): PolicyViolation[] {
       const currentCfg = getSettings();
       const input = buildInput(currentCfg);
@@ -61,23 +129,7 @@ export default fp(
     function evaluateWithModes(): EvaluationResult {
       const currentCfg = getSettings();
       const input = buildInput(currentCfg);
-      return tracer.startActiveSpan("opa.evaluate", (span) => {
-        const result = engine.evaluateWithModes(input);
-
-        span.setAttribute("opa.denials_count", result.denials.length);
-        span.setAttribute("opa.warnings_count", result.warnings.length);
-        if (result.denials.length > 0) {
-          span.setAttribute("opa.decision", "denied");
-          span.setAttribute("opa.denial_messages", result.denials.map((v) => v.message));
-        } else if (result.warnings.length > 0) {
-          span.setAttribute("opa.decision", "warn");
-          span.setAttribute("opa.warning_messages", result.warnings.map((v) => v.message));
-        } else {
-          span.setAttribute("opa.decision", "allowed");
-        }
-        span.end();
-        return result;
-      });
+      return engine.evaluateWithModes(input);
     }
 
     const initialResult = evaluateWithModes();
@@ -100,6 +152,7 @@ export default fp(
     }
 
     fastify.decorate("opa", { evaluate, evaluateWithModes, engine });
+    fastify.decorate("compliance", buildComplianceState(initialResult, modes));
 
     fastify.addHook("onClose", () => {
       engine.destroy();

--- a/src/server/plugins/opa.plugin.ts
+++ b/src/server/plugins/opa.plugin.ts
@@ -1,12 +1,16 @@
 import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
-import { createOpaEngine, type OpaEngine, type PolicyViolation } from "../utils/opa.js";
+import { trace } from "@opentelemetry/api";
+import { createOpaEngine, type OpaEngine, type PolicyViolation, type EvaluationResult } from "../utils/opa.js";
 import { getSettings, type UISettings } from "../utils/settings.js";
+
+const tracer = trace.getTracer("opa-plugin");
 
 declare module "fastify" {
   interface FastifyInstance {
     opa: {
       evaluate(): PolicyViolation[];
+      evaluateWithModes(): EvaluationResult;
       engine: OpaEngine;
     };
   }
@@ -38,11 +42,15 @@ export default fp(
     const cfg = getSettings();
     const opaCfg = cfg.platform.opa;
 
-    const engine = await createOpaEngine(opaCfg.policy_path, {
-      info: (msg) => fastify.log.info(msg),
-      warn: (msg) => fastify.log.warn(msg),
-      error: (msg) => fastify.log.error(msg),
-    });
+    const engine = await createOpaEngine(
+      opaCfg.policy_path,
+      {
+        info: (msg) => fastify.log.info(msg),
+        warn: (msg) => fastify.log.warn(msg),
+        error: (msg) => fastify.log.error(msg),
+      },
+      opaCfg.overrides_path,
+    );
 
     function evaluate(): PolicyViolation[] {
       const currentCfg = getSettings();
@@ -50,21 +58,48 @@ export default fp(
       return engine.evaluate(input);
     }
 
-    const initialViolations = evaluate();
-    if (initialViolations.length > 0) {
-      for (const v of initialViolations) {
-        fastify.log.warn(`OPA policy violation: ${v.message}`);
-      }
-      if (opaCfg.fail_on_violation) {
-        throw new Error(
-          `OPA policy check failed with ${initialViolations.length} violation(s) — set platform.opa.fail_on_violation=false to allow startup`,
-        );
-      }
-    } else if (engine.isLoaded()) {
+    function evaluateWithModes(): EvaluationResult {
+      const currentCfg = getSettings();
+      const input = buildInput(currentCfg);
+      return tracer.startActiveSpan("opa.evaluate", (span) => {
+        const result = engine.evaluateWithModes(input);
+
+        span.setAttribute("opa.denials_count", result.denials.length);
+        span.setAttribute("opa.warnings_count", result.warnings.length);
+        if (result.denials.length > 0) {
+          span.setAttribute("opa.decision", "denied");
+          span.setAttribute("opa.denial_messages", result.denials.map((v) => v.message));
+        } else if (result.warnings.length > 0) {
+          span.setAttribute("opa.decision", "warn");
+          span.setAttribute("opa.warning_messages", result.warnings.map((v) => v.message));
+        } else {
+          span.setAttribute("opa.decision", "allowed");
+        }
+        span.end();
+        return result;
+      });
+    }
+
+    const initialResult = evaluateWithModes();
+
+    for (const v of initialResult.denials) {
+      fastify.log.warn(`OPA policy ENFORCE violation: ${v.message}`);
+    }
+    for (const v of initialResult.warnings) {
+      fastify.log.warn(`OPA policy WARN violation: ${v.message}`);
+    }
+
+    if (initialResult.denials.length > 0 && opaCfg.fail_on_violation) {
+      throw new Error(
+        `OPA policy check failed with ${initialResult.denials.length} ENFORCE violation(s) — set platform.opa.fail_on_violation=false to allow startup`,
+      );
+    }
+
+    if (initialResult.denials.length === 0 && initialResult.warnings.length === 0 && engine.isLoaded()) {
       fastify.log.info("OPA policy check passed — no violations");
     }
 
-    fastify.decorate("opa", { evaluate, engine });
+    fastify.decorate("opa", { evaluate, evaluateWithModes, engine });
 
     fastify.addHook("onClose", () => {
       engine.destroy();

--- a/src/server/router/api.router.ts
+++ b/src/server/router/api.router.ts
@@ -53,17 +53,11 @@ async function apiRoutes(fastify: FastifyInstance) {
   });
 
   fastify.get("/config/compliance", async (_request, reply) => {
-    if (!fastify.hasDecorator("opa")) {
-      return { enabled: false, violations: [] };
+    if (!fastify.hasDecorator("compliance")) {
+      return { status: "disabled" };
     }
-    const violations = fastify.opa.evaluate();
     reply.header("Cache-Control", "no-store");
-    return {
-      enabled: true,
-      loaded: fastify.opa.engine.isLoaded(),
-      violations,
-      compliant: violations.length === 0,
-    };
+    return fastify.compliance;
   });
 
   // Protected routes — auth required

--- a/src/server/utils/opa.ts
+++ b/src/server/utils/opa.ts
@@ -8,6 +8,7 @@ import { loadPolicy } from "@open-policy-agent/opa-wasm";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export interface PolicyViolation {
+  id?: string;
   message: string;
 }
 
@@ -110,11 +111,16 @@ function extractViolations(policy: LoadedPolicy, input: Record<string, unknown>,
     const first = resultSets[0]?.result;
     if (!first || !Array.isArray(first)) return [];
 
-    return first.map((d: unknown) => ({
-      message: typeof d === "object" && d !== null && "msg" in d
-        ? String((d as { msg: unknown }).msg)
-        : String(d),
-    }));
+    return first.map((d: unknown) => {
+      if (typeof d === "object" && d !== null) {
+        const obj = d as Record<string, unknown>;
+        return {
+          id: "id" in obj ? String(obj.id) : undefined,
+          message: "msg" in obj ? String(obj.msg) : String(d),
+        };
+      }
+      return { message: String(d) };
+    });
   } catch {
     return [];
   }

--- a/src/server/utils/opa.ts
+++ b/src/server/utils/opa.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync, existsSync, watch, mkdtempSync, rmSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync, watch, mkdtempSync, rmSync, copyFileSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
@@ -11,8 +11,14 @@ export interface PolicyViolation {
   message: string;
 }
 
+export interface EvaluationResult {
+  denials: PolicyViolation[];
+  warnings: PolicyViolation[];
+}
+
 export interface OpaEngine {
   evaluate(input: Record<string, unknown>): PolicyViolation[];
+  evaluateWithModes(input: Record<string, unknown>): EvaluationResult;
   reload(): Promise<void>;
   isLoaded(): boolean;
   destroy(): void;
@@ -36,6 +42,30 @@ function resolvePolicyDir(policyPath: string): string {
 function hasRegoFiles(dir: string): boolean {
   if (!existsSync(dir)) return false;
   return readdirSync(dir).some((f) => f.endsWith(".rego"));
+}
+
+function mergeOverrides(baseDir: string, overridesDir: string | undefined, log: Logger): string | null {
+  if (!overridesDir || !existsSync(overridesDir)) return null;
+
+  const tmp = mkdtempSync(join(tmpdir(), "opa-merged-"));
+  try {
+    for (const f of readdirSync(baseDir)) {
+      if (f.endsWith(".rego") || f.endsWith(".json")) {
+        copyFileSync(join(baseDir, f), join(tmp, f));
+      }
+    }
+    for (const f of readdirSync(overridesDir)) {
+      if (f.endsWith(".rego") || f.endsWith(".json")) {
+        copyFileSync(join(overridesDir, f), join(tmp, f));
+        log.info(`Policy override applied: ${f}`);
+      }
+    }
+    return tmp;
+  } catch (err) {
+    log.error(`Failed to merge override directory: ${err instanceof Error ? err.message : String(err)}`);
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+    return null;
+  }
 }
 
 function compilePolicies(policyDir: string, log: Logger): Buffer | null {
@@ -72,18 +102,54 @@ function compilePolicies(policyDir: string, log: Logger): Buffer | null {
   }
 }
 
+function extractViolations(policy: LoadedPolicy, input: Record<string, unknown>, entrypoint: string): PolicyViolation[] {
+  try {
+    const resultSets = policy.evaluate(input, entrypoint);
+    if (!resultSets?.length) return [];
+
+    const first = resultSets[0]?.result;
+    if (!first || !Array.isArray(first)) return [];
+
+    return first.map((d: unknown) => ({
+      message: typeof d === "object" && d !== null && "msg" in d
+        ? String((d as { msg: unknown }).msg)
+        : String(d),
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function createOpaEngine(
   policyPath: string,
   logger?: Logger,
+  overridesPath?: string,
 ): Promise<OpaEngine> {
   const policyDir = resolvePolicyDir(policyPath);
   let policy: LoadedPolicy | null = null;
   let watcher: ReturnType<typeof watch> | null = null;
+  let overridesWatcher: ReturnType<typeof watch> | null = null;
   let reloadTimer: ReturnType<typeof setTimeout> | null = null;
+  let mergedDir: string | null = null;
   const log = logger ?? { info: console.log, warn: console.warn, error: console.error };
 
+  const resolvedOverrides = overridesPath
+    ? resolvePolicyDir(overridesPath)
+    : undefined;
+
   async function compileAndLoad(): Promise<void> {
-    const bundle = compilePolicies(policyDir, log);
+    if (mergedDir) {
+      try { rmSync(mergedDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+      mergedDir = null;
+    }
+
+    let compileDir = policyDir;
+    if (resolvedOverrides && existsSync(resolvedOverrides)) {
+      mergedDir = mergeOverrides(policyDir, resolvedOverrides, log);
+      if (mergedDir) compileDir = mergedDir;
+    }
+
+    const bundle = compilePolicies(compileDir, log);
     if (!bundle) {
       policy = null;
       return;
@@ -119,19 +185,41 @@ export async function createOpaEngine(
     }
   }
 
+  function evaluateWithModes(input: Record<string, unknown>): EvaluationResult {
+    if (!policy) return { denials: [], warnings: [] };
+    return {
+      denials: extractViolations(policy, input, "compliance/ui/deny"),
+      warnings: extractViolations(policy, input, "compliance/ui/violations"),
+    };
+  }
+
+  function scheduleReload(filename: string): void {
+    if (reloadTimer) clearTimeout(reloadTimer);
+    reloadTimer = setTimeout(async () => {
+      log.info(`Policy file changed (${filename}) — recompiling`);
+      await compileAndLoad();
+    }, 500);
+  }
+
   function startWatching(): void {
-    if (!existsSync(policyDir)) return;
-    try {
-      watcher = watch(policyDir, (eventType, filename) => {
-        if (!filename?.endsWith(".rego") && !filename?.endsWith(".json")) return;
-        if (reloadTimer) clearTimeout(reloadTimer);
-        reloadTimer = setTimeout(async () => {
-          log.info(`Policy file changed (${filename}) — recompiling`);
-          await compileAndLoad();
-        }, 500);
-      });
-      watcher.on("error", () => {});
-    } catch { /* watcher setup is optional */ }
+    if (existsSync(policyDir)) {
+      try {
+        watcher = watch(policyDir, (eventType, filename) => {
+          if (!filename?.endsWith(".rego") && !filename?.endsWith(".json")) return;
+          scheduleReload(filename);
+        });
+        watcher.on("error", () => {});
+      } catch { /* watcher setup is optional */ }
+    }
+    if (resolvedOverrides && existsSync(resolvedOverrides)) {
+      try {
+        overridesWatcher = watch(resolvedOverrides, (eventType, filename) => {
+          if (!filename?.endsWith(".rego") && !filename?.endsWith(".json")) return;
+          scheduleReload(filename);
+        });
+        overridesWatcher.on("error", () => {});
+      } catch { /* watcher setup is optional */ }
+    }
   }
 
   function destroy(): void {
@@ -139,9 +227,17 @@ export async function createOpaEngine(
       watcher.close();
       watcher = null;
     }
+    if (overridesWatcher) {
+      overridesWatcher.close();
+      overridesWatcher = null;
+    }
     if (reloadTimer) {
       clearTimeout(reloadTimer);
       reloadTimer = null;
+    }
+    if (mergedDir) {
+      try { rmSync(mergedDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+      mergedDir = null;
     }
     policy = null;
   }
@@ -151,6 +247,7 @@ export async function createOpaEngine(
 
   return {
     evaluate,
+    evaluateWithModes,
     reload: compileAndLoad,
     isLoaded: () => policy !== null,
     destroy,

--- a/src/server/utils/settings.ts
+++ b/src/server/utils/settings.ts
@@ -51,6 +51,7 @@ interface OtelConfig {
 interface PlatformOpaConfig {
   enabled: boolean;
   policy_path: string;
+  overrides_path: string;
   fail_on_violation: boolean;
   approved_auth_providers: string[];
   internal_endpoint_suffixes: string[];
@@ -212,6 +213,7 @@ const DEFAULTS: UISettings = {
     opa: {
       enabled: false,
       policy_path: "",
+      overrides_path: "",
       fail_on_violation: false,
       approved_auth_providers: [],
       internal_endpoint_suffixes: [],
@@ -453,6 +455,9 @@ function applyEnvOverrides(config: UISettings): void {
   }
   if (process.env.PLATFORM_OPA_POLICY_PATH) {
     config.platform.opa.policy_path = process.env.PLATFORM_OPA_POLICY_PATH;
+  }
+  if (process.env.PLATFORM_OPA_OVERRIDES_PATH) {
+    config.platform.opa.overrides_path = process.env.PLATFORM_OPA_OVERRIDES_PATH;
   }
   if (process.env.PLATFORM_OPA_FAIL_ON_VIOLATION !== undefined) {
     config.platform.opa.fail_on_violation = process.env.PLATFORM_OPA_FAIL_ON_VIOLATION === "true";


### PR DESCRIPTION
## Summary

- Per-control enforcement modes via `modes.json` (OFF/WARN/ENFORCE)
  - All 6 controls default to OFF
  - `fail_on_violation` remains as master override
- Override policy path support via `PLATFORM_OPA_OVERRIDES_PATH`
- OTEL span attributes on OPA evaluation (`opa.decision`, `opa.denials_count`, `opa.warnings_count`)

## Related

- Platform companion MRs: gateway, registry, agent-engine (`feat/opa-integration` on GitLab)
- template-agent companion PR: `feat/opa-integration`
- ADR: `ADR-OPA-INTEGRATION.md`

## Test plan

- [ ] Verify startup with all modes OFF (no behavior change)
- [ ] Verify ENFORCE mode blocks startup when `fail_on_violation=true`
- [ ] Verify WARN mode logs but doesn't block startup
- [ ] Verify OFF mode skips control entirely
- [ ] Verify override path merging (override files win)
- [ ] Verify hot-reload picks up modes.json changes
- [ ] Verify OTEL span attributes emitted