### PR TITLE
feat: Added projects feature

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -6,6 +6,7 @@ import { AppLayout } from './components/layout/AppLayout';
 import { HomePage } from './pages/HomePage';
 import { ChatRoutePage } from './pages/ChatPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { ProjectChatPage } from './pages/ProjectChatPage';
 import { EvalDatasetPage } from './pages/EvalDatasetPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ToastNotifications } from './components/ToastNotifications';
@@ -103,6 +104,7 @@ export default function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/chat" element={<Navigate to="/" replace />} />
           <Route path="/chat/:threadId" element={<ChatRoutePage />} />
+          <Route path="/project/:projectId" element={<ProjectChatPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/eval/dataset" element={<EvalDatasetPage />} />
         </Routes>

--- a/src/frontend/components/ProjectEditModal.tsx
+++ b/src/frontend/components/ProjectEditModal.tsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from 'react';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+  TextInput,
+  TextArea,
+  FormGroup,
+} from '@patternfly/react-core';
+
+interface ProjectEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (name: string, description: string) => boolean | void | 'error' | Promise<boolean | void | 'error'>;
+  initialName?: string;
+  initialDescription?: string;
+  title?: string;
+}
+
+export function ProjectEditModal({
+  isOpen,
+  onClose,
+  onSave,
+  initialName = '',
+  initialDescription = '',
+  title = 'New Project',
+}: ProjectEditModalProps) {
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialName);
+      setDescription(initialDescription);
+      setError(null);
+      setSaving(false);
+    }
+  }, [isOpen, initialName, initialDescription]);
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || saving) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const ok = await onSave(trimmed, description.trim());
+      if (ok === false) {
+        setError('A project with that name already exists');
+        return;
+      }
+      if (ok === 'error') {
+        setError('Could not save project');
+        return;
+      }
+      onClose();
+    } catch {
+      setError('Could not save project');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={isOpen}
+      onClose={onClose}
+      aria-label={title}
+    >
+      <ModalHeader title={title} />
+      <ModalBody>
+        <FormGroup label="Name" isRequired fieldId="project-name">
+          <TextInput
+            id="project-name"
+            value={name}
+            validated={error ? 'error' : 'default'}
+            onChange={(_e, val) => {
+              setName(val);
+              setError(null);
+            }}
+            onKeyDown={(e) => e.key === 'Enter' && void handleSave()}
+            autoFocus
+          />
+          {error && (
+            <p className="text-sm text-destructive mt-1" role="alert">
+              {error}
+            </p>
+          )}
+        </FormGroup>
+        <FormGroup label="Description" fieldId="project-desc" className="mt-3">
+          <TextArea
+            id="project-desc"
+            value={description}
+            onChange={(_e, val) => setDescription(val)}
+            rows={3}
+          />
+        </FormGroup>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant="primary"
+          onClick={() => void handleSave()}
+          isDisabled={!name.trim() || saving}
+        >
+          Save
+        </Button>
+        <Button variant="link" onClick={onClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/frontend/components/Sidebar.test.tsx
+++ b/src/frontend/components/Sidebar.test.tsx
@@ -1,0 +1,304 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils/render';
+import { Sidebar } from './Sidebar';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const sidebarProps = {
+  chatHistory: [],
+  onNewChat: vi.fn(),
+  onSelectChat: vi.fn(),
+  onDeleteChat: vi.fn(),
+  onRenameChat: vi.fn(),
+};
+
+describe('Sidebar — create project', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('opens the project page after a project is created', async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn().mockResolvedValue('proj-1');
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} onCreateProject={onCreateProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+    const dialog = await screen.findByRole('dialog', { name: /new project/i });
+    const nameInput = dialog.querySelector('#project-name');
+    expect(nameInput).toBeTruthy();
+    await user.type(nameInput as HTMLElement, 'Alpha');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onCreateProject).toHaveBeenCalledWith('Alpha', '');
+      expect(mockNavigate).toHaveBeenCalledWith('/project/proj-1');
+    });
+  });
+
+  it('does not navigate when create fails', async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn().mockResolvedValue(null);
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} onCreateProject={onCreateProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+    const dialog = await screen.findByRole('dialog', { name: /new project/i });
+    const nameInput = dialog.querySelector('#project-name');
+    expect(nameInput).toBeTruthy();
+    await user.type(nameInput as HTMLElement, 'Alpha');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(onCreateProject).toHaveBeenCalled();
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic save error when create throws', async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn().mockRejectedValue(new Error('network'));
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} onCreateProject={onCreateProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+    const dialog = await screen.findByRole('dialog', { name: /new project/i });
+    const nameInput = dialog.querySelector('#project-name');
+    await user.type(nameInput as HTMLElement, 'Alpha');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/could not save project/i);
+    expect(screen.getByRole('dialog', { name: /new project/i })).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows a red warning and stays open when the name already exists', async () => {
+    const user = userEvent.setup();
+    const onCreateProject = vi.fn();
+
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        onCreateProject={onCreateProject}
+        projects={[
+          { id: 'p1', name: 'Alpha', description: null, threadCount: 0 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /create project/i }));
+    const dialog = await screen.findByRole('dialog', { name: /new project/i });
+    const nameInput = dialog.querySelector('#project-name');
+    await user.type(nameInput as HTMLElement, 'Alpha');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    const warning = await screen.findByRole('alert');
+    expect(warning).toHaveTextContent(/already exists/i);
+    expect(warning.className).toMatch(/destructive|danger|red/i);
+    expect(onCreateProject).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog', { name: /new project/i })).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('Sidebar — delete project', () => {
+  const projects = [
+    { id: 'p1', name: 'Alpha', description: null, threadCount: 2 },
+  ];
+
+  it('offers Unassign and delete and keeps the project until confirmed', async () => {
+    const user = userEvent.setup();
+    const onDeleteProject = vi.fn().mockResolvedValue(true);
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} projects={projects} onDeleteProject={onDeleteProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete project: alpha/i }));
+    const dialog = await screen.findByRole('dialog', { name: /delete project/i });
+    expect(dialog).toHaveTextContent(/unassign/i);
+
+    await user.click(screen.getByRole('button', { name: /unassign and delete/i }));
+    await waitFor(() => {
+      expect(onDeleteProject).toHaveBeenCalledWith('p1', { keepThreads: true });
+    });
+  });
+
+  it('Delete still permanently removes conversations', async () => {
+    const user = userEvent.setup();
+    const onDeleteProject = vi.fn().mockResolvedValue(true);
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} projects={projects} onDeleteProject={onDeleteProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete project: alpha/i }));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(onDeleteProject).toHaveBeenCalledWith('p1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: /delete project/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the delete dialog open when delete fails', async () => {
+    const user = userEvent.setup();
+    const onDeleteProject = vi.fn().mockResolvedValue(false);
+
+    renderWithProviders(
+      <Sidebar {...sidebarProps} projects={projects} onDeleteProject={onDeleteProject} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete project: alpha/i }));
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(onDeleteProject).toHaveBeenCalledWith('p1');
+    });
+    expect(screen.getByRole('dialog', { name: /delete project/i })).toBeInTheDocument();
+  });
+
+  it('unassign-all icon on the project row unassigns chats', async () => {
+    const user = userEvent.setup();
+    const onUnassignAll = vi.fn().mockResolvedValue(true);
+
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        projects={projects}
+        onUnassignAll={onUnassignAll}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /unassign all chats from alpha/i }));
+    expect(onUnassignAll).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /^unassign$/i }));
+    await waitFor(() => {
+      expect(onUnassignAll).toHaveBeenCalledWith('p1');
+    });
+  });
+
+  it('hides the unassign-all icon when the project has no chats', () => {
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        projects={[{ id: 'p1', name: 'Alpha', description: null, threadCount: 0 }]}
+        onUnassignAll={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /unassign all chats from alpha/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+const sampleChat = {
+  id: 'c1',
+  title: 'Research thread',
+  timestamp: new Date('2026-01-01'),
+  preview: 'hello',
+};
+
+describe('Sidebar — add chat to project', () => {
+  it('assigns an unassigned chat from the add-to-project menu', async () => {
+    const user = userEvent.setup();
+    const onAssignThread = vi.fn().mockResolvedValue(true);
+
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        chatHistory={[sampleChat]}
+        projects={[{ id: 'p1', name: 'Alpha', description: null, threadCount: 0 }]}
+        onAssignThread={onAssignThread}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /add to project: research thread/i }));
+    await user.click(await screen.findByRole('menuitem', { name: 'Alpha' }));
+
+    await waitFor(() => {
+      expect(onAssignThread).toHaveBeenCalledWith('c1', 'p1');
+    });
+  });
+
+  it('lists a chat whose project no longer exists under Chats', () => {
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        chatHistory={[{ ...sampleChat, project_id: 'deleted-project' }]}
+        projects={[{ id: 'p1', name: 'Alpha', description: null, threadCount: 0 }]}
+        onAssignThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Research thread')).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: /alpha chats/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add to project: research thread/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /unassign chat: research thread/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('gives the project chat list a fixed height that can scroll', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        chatHistory={[{ ...sampleChat, project_id: 'p1' }]}
+        projects={[{ id: 'p1', name: 'Alpha', description: null, threadCount: 1 }]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /expand alpha/i }));
+
+    const list = screen.getByRole('list', { name: /alpha chats/i });
+    expect(list.className).toMatch(/max-h-48/);
+    expect(list.className).toMatch(/overflow-y-auto/);
+  });
+
+  it('unassigns a project chat instead of offering add-to-project', async () => {
+    const user = userEvent.setup();
+    const onAssignThread = vi.fn().mockResolvedValue(true);
+
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps}
+        chatHistory={[{ ...sampleChat, project_id: 'p1' }]}
+        projects={[{ id: 'p1', name: 'Alpha', description: null, threadCount: 1 }]}
+        onAssignThread={onAssignThread}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /expand alpha/i }));
+
+    expect(
+      screen.queryByRole('button', { name: /add to project: research thread/i }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /unassign chat: research thread/i }));
+
+    await waitFor(() => {
+      expect(onAssignThread).toHaveBeenCalledWith('c1', null);
+    });
+  });
+});

--- a/src/frontend/components/Sidebar.tsx
+++ b/src/frontend/components/Sidebar.tsx
@@ -2,7 +2,12 @@ import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Label,
+  MenuToggle,
+  type MenuToggleElement,
   Modal,
   ModalBody,
   ModalFooter,
@@ -11,12 +16,27 @@ import {
   SearchInput,
   Tooltip,
 } from '@patternfly/react-core';
-import { Loader2, MessageSquare, Trash2, Edit3, Plus, Settings, LogOut } from 'lucide-react';
+import {
+  Loader2,
+  MessageSquare,
+  Trash2,
+  Edit3,
+  Plus,
+  Settings,
+  LogOut,
+  Folder,
+  FolderPlus,
+  FolderMinus,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
 import { logout } from '../services/logout';
 import { cn } from '@/lib/utils';
-import type { SidebarChatItem } from '../types/chat';
+import type { SidebarChatItem, SidebarProject } from '../types/chat';
 import type { SubAgentInfo } from '../types/deep-agent';
 import { useAgentHealth } from '../hooks/useAgentHealth';
+import { useSidebarDragDrop } from '../hooks/useSidebarDragDrop';
+import { ProjectEditModal } from './ProjectEditModal';
 
 interface SidebarProps {
   userName?: string;
@@ -24,11 +44,19 @@ interface SidebarProps {
   chatHistory: SidebarChatItem[];
   tokenExpiry?: Date;
   activeSubAgent?: SubAgentInfo | null;
-  onNewChat: () => void;
+  onNewChat: (projectId?: string) => void;
   onSelectChat: (chatId: string) => void;
   onDeleteChat: (chatId: string) => void;
-  onDeleteAllChats: () => void;
   onRenameChat: (chatId: string, newTitle: string) => void;
+  projects?: SidebarProject[];
+  onCreateProject?: (name: string, description?: string) => Promise<string | null>;
+  onUpdateProject?: (projectId: string, name?: string, description?: string) => Promise<boolean>;
+  onDeleteProject?: (
+    projectId: string,
+    options?: { keepThreads?: boolean },
+  ) => Promise<boolean>;
+  onAssignThread?: (threadId: string, projectId: string | null) => Promise<boolean>;
+  onUnassignAll?: (projectId: string) => Promise<boolean>;
 }
 
 function SidebarComponent({
@@ -41,9 +69,13 @@ function SidebarComponent({
   onNewChat,
   onSelectChat,
   onDeleteChat,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onDeleteAllChats,
   onRenameChat,
+  projects = [],
+  onCreateProject,
+  onUpdateProject,
+  onDeleteProject,
+  onAssignThread,
+  onUnassignAll,
 }: SidebarProps) {
   const navigate = useNavigate();
   const agentHealth = useAgentHealth();
@@ -51,10 +83,19 @@ function SidebarComponent({
   const [editingChat, setEditingChat] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState('');
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
+  const [unassigningProjectId, setUnassigningProjectId] = useState<string | null>(null);
+  const [unassignBusy, setUnassignBusy] = useState(false);
+  const [projectDeleteBusy, setProjectDeleteBusy] = useState(false);
+  const [projectModalOpen, setProjectModalOpen] = useState(false);
+  const [editingProject, setEditingProject] = useState<SidebarProject | null>(null);
+  const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
+  const [assignMenuChatId, setAssignMenuChatId] = useState<string | null>(null);
 
+  const assignHandler = onAssignThread ?? (async () => false);
+  const drag = useSidebarDragDrop(assignHandler);
 
   const filteredChats = useMemo(() => {
-    if (chatHistory.length <= 3) return chatHistory;
     const q = searchQuery.trim().toLowerCase();
     if (!q) return chatHistory;
     return chatHistory.filter(
@@ -62,6 +103,42 @@ function SidebarComponent({
         chat.title.toLowerCase().includes(q) || chat.preview.toLowerCase().includes(q)
     );
   }, [chatHistory, searchQuery]);
+
+  const knownProjectIds = useMemo(
+    () => new Set(projects.map((p) => p.id)),
+    [projects],
+  );
+
+  const unassignedChats = useMemo(
+    () =>
+      filteredChats.filter(
+        (c) => !c.project_id || !knownProjectIds.has(c.project_id),
+      ),
+    [filteredChats, knownProjectIds],
+  );
+
+  const chatsByProject = useMemo(() => {
+    const map: Record<string, SidebarChatItem[]> = {};
+    for (const chat of filteredChats) {
+      if (chat.project_id && knownProjectIds.has(chat.project_id)) {
+        (map[chat.project_id] ??= []).push(chat);
+      }
+    }
+    return map;
+  }, [filteredChats, knownProjectIds]);
+
+  const isProjectExpanded = (projectId: string) => {
+    if (expandedProjects[projectId] !== undefined) return expandedProjects[projectId];
+    const chats = chatsByProject[projectId] ?? [];
+    return chats.some((c) => c.id === currentChatId);
+  };
+
+  const toggleProject = (projectId: string) => {
+    setExpandedProjects((prev) => ({
+      ...prev,
+      [projectId]: !isProjectExpanded(projectId),
+    }));
+  };
 
   const handleRename = (chatId: string, title: string) => {
     setEditingChat(chatId);
@@ -77,16 +154,148 @@ function SidebarComponent({
     setEditTitle('');
   };
 
+  const renderChatRow = (chat: SidebarChatItem) => {
+    const isActive = currentChatId === chat.id;
+    const isDragging = drag.draggedThreadId === chat.id;
+
+    return (
+      <li
+        key={chat.id}
+        draggable={editingChat !== chat.id}
+        onDragStart={(e) => drag.handleDragStart(e, chat.id)}
+        onDragEnd={drag.handleDragEnd}
+        className={cn(
+          'relative group rounded-lg transition-colors',
+          isActive ? 'bg-secondary text-foreground' : 'hover:bg-secondary/50',
+          isDragging && 'opacity-50',
+        )}
+      >
+        {editingChat === chat.id ? (
+          <div className="flex items-center gap-2 px-2.5 py-2">
+            <input
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              onBlur={() => handleSaveRename(chat.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSaveRename(chat.id);
+                if (e.key === 'Escape') {
+                  setEditingChat(null);
+                  setEditTitle('');
+                }
+              }}
+              aria-label={`Rename chat: ${chat.title}`}
+              className="flex-1 bg-transparent text-sm text-foreground border border-border rounded px-1.5 py-0.5 outline-none focus:border-primary"
+              autoFocus
+            />
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => onSelectChat(chat.id)}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                'w-full text-left text-sm px-2.5 py-2 pr-24 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                isActive ? 'text-foreground' : 'text-foreground/70 hover:text-foreground',
+              )}
+            >
+              <span className="block truncate">{chat.title}</span>
+              {isActive && activeSubAgent && (
+                <span className="flex items-center gap-1.5 mt-0.5">
+                  <Label
+                    isCompact
+                    color="blue"
+                    icon={<Loader2 className="w-2.5 h-2.5 animate-spin" />}
+                  >
+                    <span className="capitalize">{activeSubAgent.name}</span>
+                  </Label>
+                </span>
+              )}
+            </button>
+
+            <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+              {onAssignThread &&
+              chat.project_id &&
+              knownProjectIds.has(chat.project_id) ? (
+                <Button
+                  variant="plain"
+                  size="sm"
+                  className="h-7 w-7 !p-0 text-muted-foreground hover:text-foreground focus-visible:opacity-100"
+                  onClick={() => void onAssignThread(chat.id, null)}
+                  aria-label={`Unassign chat: ${chat.title}`}
+                >
+                  <FolderMinus className="w-3 h-3" />
+                </Button>
+              ) : onAssignThread && projects.length > 0 ? (
+                <Dropdown
+                  isOpen={assignMenuChatId === chat.id}
+                  onOpenChange={(open) => setAssignMenuChatId(open ? chat.id : null)}
+                  onSelect={(_event, value) => {
+                    if (typeof value === 'string') {
+                      void onAssignThread(chat.id, value);
+                    }
+                    setAssignMenuChatId(null);
+                  }}
+                  popperProps={{ position: 'right' }}
+                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                    <MenuToggle
+                      ref={toggleRef}
+                      variant="plain"
+                      onClick={() =>
+                        setAssignMenuChatId((id) => (id === chat.id ? null : chat.id))
+                      }
+                      isExpanded={assignMenuChatId === chat.id}
+                      aria-label={`Add to project: ${chat.title}`}
+                      icon={<FolderPlus className="w-3 h-3" />}
+                      className="h-7 w-7 !p-0 text-muted-foreground hover:text-foreground"
+                    />
+                  )}
+                >
+                  <DropdownList>
+                    {projects.map((project) => (
+                      <DropdownItem key={project.id} value={project.id}>
+                        {project.name}
+                      </DropdownItem>
+                    ))}
+                  </DropdownList>
+                </Dropdown>
+              ) : null}
+              <Button
+                variant="plain"
+                size="sm"
+                className="h-7 w-7 !p-0 text-muted-foreground hover:text-foreground focus-visible:opacity-100"
+                onClick={() => handleRename(chat.id, chat.title)}
+                aria-label={`Rename chat: ${chat.title}`}
+              >
+                <Edit3 className="w-3 h-3" />
+              </Button>
+              <Button
+                variant="plain"
+                size="sm"
+                className="h-7 w-7 !p-0 text-muted-foreground hover:text-destructive focus-visible:opacity-100"
+                onClick={() => setDeletingChatId(chat.id)}
+                aria-label={`Delete chat: ${chat.title}`}
+              >
+                <Trash2 className="w-3 h-3" />
+              </Button>
+            </div>
+          </>
+        )}
+      </li>
+    );
+  };
+
+  const deletingThreadCount =
+    projects.find((p) => p.id === deletingProjectId)?.threadCount ?? 0;
+
   return (
     <div className="flex flex-col h-full min-h-0 bg-sidebar border-r border-sidebar-border text-sidebar-foreground">
-      {/* New Chat button */}
       <div className="shrink-0 p-3 pb-2">
-        <Button variant="primary" isBlock onClick={onNewChat} aria-label="Start new chat" icon={<Plus className="w-4 h-4" />}>
+        <Button variant="primary" isBlock onClick={() => onNewChat()} aria-label="Start new chat" icon={<Plus className="w-4 h-4" />}>
           New Chat
         </Button>
       </div>
 
-      {/* Search */}
       {chatHistory.length > 3 && (
         <div className="shrink-0 px-3 py-1.5">
           <SearchInput
@@ -98,126 +307,174 @@ function SidebarComponent({
         </div>
       )}
 
-      {/* Separator + label */}
-      <div className="shrink-0 px-3 pt-3 pb-1.5">
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Recent chats</p>
-      </div>
-
-      {/* Chat list */}
-      {filteredChats.length === 0 ? (
-        <div className="flex-1 flex flex-col items-center justify-center py-10 px-4 text-center">
-          <MessageSquare className="w-6 h-6 text-muted-foreground/40 mb-2" aria-hidden="true" />
-          <p className="text-sm text-muted-foreground">
-            {chatHistory.length === 0 ? 'No chats yet' : 'No matching threads'}
-          </p>
+      <div className="flex-1 min-h-0 overflow-y-auto chat-scroll">
+        <div className="shrink-0 px-3 pt-3 pb-1.5 flex items-center justify-between">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Projects</p>
+          {onCreateProject && (
+            <Button
+              variant="plain"
+              size="sm"
+              className="h-6 w-6 !p-0 text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                setEditingProject(null);
+                setProjectModalOpen(true);
+              }}
+              aria-label="Create project"
+            >
+              <FolderPlus className="w-3.5 h-3.5" />
+            </Button>
+          )}
         </div>
-      ) : (
-        <ul
-          aria-label="Chat history"
-          className="flex-1 min-h-0 overflow-y-auto chat-scroll px-1.5 space-y-0.5 list-none"
-        >
-          {filteredChats.map((chat) => {
-            const isActive = currentChatId === chat.id;
 
-            const focusNeighbor = (delta: number) => {
-              const idx = filteredChats.findIndex((c) => c.id === chat.id);
-              const next = filteredChats[idx + delta];
-              if (!next) return;
-              document.getElementById(`sidebar-chat-btn-${next.id}`)?.focus();
-            };
-
-            const onBtnKeyDown = (e: React.KeyboardEvent) => {
-              if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                focusNeighbor(1);
-              } else if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                focusNeighbor(-1);
-              }
-            };
-
-            return (
-              <li
-                key={chat.id}
-                className={cn(
-                  'relative group rounded-lg transition-colors',
-                  isActive
-                    ? 'bg-secondary text-foreground'
-                    : 'hover:bg-secondary/50',
-                )}
-              >
-                {editingChat === chat.id ? (
-                  <div className="flex items-center gap-2 px-2.5 py-2">
-                    <input
-                      value={editTitle}
-                      onChange={(e) => setEditTitle(e.target.value)}
-                      onBlur={() => handleSaveRename(chat.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') handleSaveRename(chat.id);
-                        if (e.key === 'Escape') {
-                          setEditingChat(null);
-                          setEditTitle('');
-                        }
-                      }}
-                      aria-label={`Rename chat: ${chat.title}`}
-                      className="flex-1 bg-transparent text-sm text-foreground border border-border rounded px-1.5 py-0.5 outline-none focus:border-primary"
-                      autoFocus
-                    />
-                  </div>
-                ) : (
-                  <>
-                    <button
-                      id={`sidebar-chat-btn-${chat.id}`}
-                      type="button"
-                      onClick={() => onSelectChat(chat.id)}
-                      onKeyDown={onBtnKeyDown}
-                      aria-current={isActive ? 'page' : undefined}
-                      className={cn(
-                        'w-full text-left text-sm px-2.5 py-2 pr-16 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                        isActive ? 'text-foreground' : 'text-foreground/70 hover:text-foreground',
-                      )}
-                    >
-                      <span className="block truncate">{chat.title}</span>
-                      {isActive && activeSubAgent && (
-                        <span className="flex items-center gap-1.5 mt-0.5">
-                          <Label
-                            isCompact
-                            color="blue"
-                            icon={<Loader2 className="w-2.5 h-2.5 animate-spin" />}
-                          >
-                            <span className="capitalize">{activeSubAgent.name}</span>
-                          </Label>
+        {projects.length === 0 ? (
+          <p className="px-3 pb-2 text-xs text-muted-foreground">No projects yet</p>
+        ) : (
+          <ul className="px-1.5 space-y-0.5 list-none mb-2" aria-label="Projects">
+            {projects.map((project) => {
+              const expanded = isProjectExpanded(project.id);
+              const projectChats = chatsByProject[project.id] ?? [];
+              const isDropTarget = drag.dragOverTarget === project.id;
+              return (
+                <li key={project.id}>
+                  <div
+                    onDragOver={(e) => drag.handleDragOver(e, project.id)}
+                    onDragLeave={drag.handleDragLeave}
+                    onDrop={(e) => void drag.handleDrop(e, project.id)}
+                    className={cn(
+                      'rounded-lg transition-colors',
+                      isDropTarget && 'ring-2 ring-primary/50 bg-primary/5',
+                    )}
+                  >
+                    <div className="group relative flex items-center">
+                      <button
+                        type="button"
+                        onClick={() => toggleProject(project.id)}
+                        className="shrink-0 p-1.5 text-muted-foreground hover:text-foreground"
+                        aria-expanded={expanded}
+                        aria-label={`${expanded ? 'Collapse' : 'Expand'} ${project.name}`}
+                      >
+                        {expanded ? (
+                          <ChevronDown className="w-3.5 h-3.5" />
+                        ) : (
+                          <ChevronRight className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/project/${project.id}`)}
+                        className="flex-1 min-w-0 flex items-center gap-1.5 py-1.5 pr-24 text-left text-sm hover:text-foreground"
+                      >
+                        <Folder className="w-3.5 h-3.5 shrink-0 text-muted-foreground" />
+                        <span className="truncate font-medium">{project.name}</span>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {project.threadCount}
                         </span>
-                      )}
-                    </button>
-
-                    <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                      <Button
-                        variant="plain"
-                        size="sm"
-                        className="h-7 w-7 !p-0 text-muted-foreground hover:text-foreground focus-visible:opacity-100"
-                        onClick={() => handleRename(chat.id, chat.title)}
-                        aria-label={`Rename chat: ${chat.title}`}
-                      >
-                        <Edit3 className="w-3 h-3" />
-                      </Button>
-                      <Button
-                        variant="plain"
-                        size="sm"
-                        className="h-7 w-7 !p-0 text-muted-foreground hover:text-destructive focus-visible:opacity-100"
-                        onClick={() => setDeletingChatId(chat.id)}
-                        aria-label={`Delete chat: ${chat.title}`}
-                      >
-                        <Trash2 className="w-3 h-3" />
-                      </Button>
+                      </button>
+                      <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                        <Button
+                          variant="plain"
+                          size="sm"
+                          className="h-6 w-6 !p-0 text-muted-foreground hover:text-foreground"
+                          onClick={() => onNewChat(project.id)}
+                          aria-label={`New chat in ${project.name}`}
+                        >
+                          <Plus className="w-3 h-3" />
+                        </Button>
+                        {onUnassignAll && project.threadCount > 0 && (
+                          <Button
+                            variant="plain"
+                            size="sm"
+                            className="h-6 w-6 !p-0 text-muted-foreground hover:text-foreground"
+                            onClick={() => setUnassigningProjectId(project.id)}
+                            aria-label={`Unassign all chats from ${project.name}`}
+                          >
+                            <FolderMinus className="w-3 h-3" />
+                          </Button>
+                        )}
+                        {onUpdateProject && (
+                          <Button
+                            variant="plain"
+                            size="sm"
+                            className="h-6 w-6 !p-0 text-muted-foreground hover:text-foreground"
+                            onClick={() => {
+                              setEditingProject(project);
+                              setProjectModalOpen(true);
+                            }}
+                            aria-label={`Edit project: ${project.name}`}
+                          >
+                            <Edit3 className="w-3 h-3" />
+                          </Button>
+                        )}
+                        {onDeleteProject && (
+                          <Button
+                            variant="plain"
+                            size="sm"
+                            className="h-6 w-6 !p-0 text-muted-foreground hover:text-destructive"
+                            onClick={() => setDeletingProjectId(project.id)}
+                            aria-label={`Delete project: ${project.name}`}
+                          >
+                            <Trash2 className="w-3 h-3" />
+                          </Button>
+                        )}
+                      </div>
                     </div>
-                  </>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                    {expanded && (
+                      <div
+                        className="border-s border-sidebar-border/80"
+                        style={{
+                          marginInlineStart: '1.75rem',
+                          paddingInlineStart: '0.5rem',
+                        }}
+                      >
+                        <ul
+                          className="pb-1 space-y-0.5 list-none max-h-48 overflow-y-auto chat-scroll"
+                          aria-label={`${project.name} chats`}
+                        >
+                          {projectChats.length === 0 ? (
+                            <li className="px-2.5 py-1 text-xs text-muted-foreground">No chats</li>
+                          ) : (
+                            projectChats.map((chat) => renderChatRow(chat))
+                          )}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div
+          onDragOver={(e) => drag.handleDragOver(e, 'unassigned')}
+          onDragLeave={drag.handleDragLeave}
+          onDrop={(e) => void drag.handleDrop(e, null)}
+          className={cn(
+            'rounded-lg mx-1.5 transition-colors',
+            drag.dragOverTarget === 'unassigned' && 'ring-2 ring-primary/50 bg-primary/5',
+          )}
+        >
+          <div className="shrink-0 px-1.5 pt-3 pb-1.5">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Chats</p>
+          </div>
+
+          {unassignedChats.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
+              <MessageSquare className="w-6 h-6 text-muted-foreground/40 mb-2" aria-hidden="true" />
+              <p className="text-sm text-muted-foreground">
+                {chatHistory.length === 0 ? 'No chats yet' : 'No unassigned chats'}
+              </p>
+            </div>
+          ) : (
+            <ul
+              aria-label="Chat history"
+              className="px-0 space-y-0.5 list-none pb-2"
+            >
+              {unassignedChats.map((chat) => renderChatRow(chat))}
+            </ul>
+          )}
+        </div>
+      </div>
 
       <div className="shrink-0 px-3 py-2 border-t border-sidebar-border">
         <Tooltip
@@ -250,7 +507,6 @@ function SidebarComponent({
         </Tooltip>
       </div>
 
-      {/* Footer */}
       <div className="shrink-0 p-3 border-t border-sidebar-border">
         <div className="flex items-center gap-2.5">
           <div className="w-8 h-8 rounded-full bg-primary/15 flex items-center justify-center text-sm font-semibold text-primary">
@@ -308,6 +564,145 @@ function SidebarComponent({
         </ModalFooter>
       </Modal>
 
+      <Modal
+        variant={ModalVariant.small}
+        isOpen={deletingProjectId !== null}
+        onClose={() => {
+          if (!projectDeleteBusy) setDeletingProjectId(null);
+        }}
+        aria-label="Delete project confirmation"
+      >
+        <ModalHeader title="Delete project" />
+        <ModalBody>
+          Delete this project and all of its conversations? This cannot be undone.
+          {deletingThreadCount > 0 && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              To keep the conversations, use Unassign and delete — they will move to Chats.
+            </p>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          {deletingThreadCount > 0 && (
+            <Button
+              variant="secondary"
+              isDisabled={projectDeleteBusy}
+              onClick={() => {
+                if (!deletingProjectId) return;
+                void (async () => {
+                  setProjectDeleteBusy(true);
+                  try {
+                    const ok = await onDeleteProject?.(deletingProjectId, {
+                      keepThreads: true,
+                    });
+                    if (ok) setDeletingProjectId(null);
+                  } finally {
+                    setProjectDeleteBusy(false);
+                  }
+                })();
+              }}
+            >
+              Unassign and delete
+            </Button>
+          )}
+          <Button
+            variant="danger"
+            isDisabled={projectDeleteBusy}
+            onClick={() => {
+              if (!deletingProjectId) return;
+              void (async () => {
+                setProjectDeleteBusy(true);
+                try {
+                  const ok = await onDeleteProject?.(deletingProjectId);
+                  if (ok) setDeletingProjectId(null);
+                } finally {
+                  setProjectDeleteBusy(false);
+                }
+              })();
+            }}
+          >
+            Delete
+          </Button>
+          <Button
+            variant="link"
+            isDisabled={projectDeleteBusy}
+            onClick={() => setDeletingProjectId(null)}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      <Modal
+        variant={ModalVariant.small}
+        isOpen={unassigningProjectId !== null}
+        onClose={() => {
+          if (!unassignBusy) setUnassigningProjectId(null);
+        }}
+        aria-label="Unassign all conversations confirmation"
+      >
+        <ModalHeader title="Unassign all conversations" />
+        <ModalBody>Move every conversation in this project back to Chats?</ModalBody>
+        <ModalFooter>
+          <Button
+            variant="danger"
+            isDisabled={unassignBusy}
+            onClick={() => {
+              if (!unassigningProjectId || !onUnassignAll) return;
+              void (async () => {
+                setUnassignBusy(true);
+                try {
+                  const ok = await onUnassignAll(unassigningProjectId);
+                  if (ok) setUnassigningProjectId(null);
+                } finally {
+                  setUnassignBusy(false);
+                }
+              })();
+            }}
+          >
+            Unassign
+          </Button>
+          <Button
+            variant="link"
+            isDisabled={unassignBusy}
+            onClick={() => setUnassigningProjectId(null)}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      <ProjectEditModal
+        isOpen={projectModalOpen}
+        onClose={() => {
+          setProjectModalOpen(false);
+          setEditingProject(null);
+        }}
+        title={editingProject ? 'Edit Project' : 'New Project'}
+        initialName={editingProject?.name ?? ''}
+        initialDescription={editingProject?.description ?? ''}
+        onSave={async (name, description) => {
+          const taken = projects.some(
+            (p) =>
+              p.name.trim().toLowerCase() === name.toLowerCase() &&
+              p.id !== editingProject?.id,
+          );
+          if (taken) return false;
+
+          try {
+            if (editingProject) {
+              const ok = await onUpdateProject?.(editingProject.id, name, description);
+              return ok !== false;
+            }
+            const id = await onCreateProject?.(name, description);
+            if (!id) return false;
+            setExpandedProjects((prev) => ({ ...prev, [id]: true }));
+            navigate(`/project/${id}`);
+            return true;
+          } catch {
+            return 'error';
+          }
+        }}
+      />
     </div>
   );
 }

--- a/src/frontend/components/__tests__/accessibility.test.tsx
+++ b/src/frontend/components/__tests__/accessibility.test.tsx
@@ -426,7 +426,6 @@ describe('Sidebar — accessibility', () => {
     onNewChat: () => {},
     onSelectChat: () => {},
     onDeleteChat: () => {},
-    onDeleteAllChats: () => {},
     onRenameChat: () => {},
   };
 

--- a/src/frontend/components/layout/AppLayout.test.tsx
+++ b/src/frontend/components/layout/AppLayout.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createTestStore } from '../../test-utils/createTestStore';
+import { addChat } from '../../redux/slices/chats';
+import { setProjects } from '../../redux/slices/projects';
+import { AppLayout } from './AppLayout';
+import { chatStorage } from '../../services/chatStorage';
+import { getAllThreadsByUserId } from '../../services/agent-rest';
+import { getProjects, getThreadsByProject } from '../../services/projects-api';
+
+const mocks = vi.hoisted(() => ({
+  deleteProject: vi.fn(),
+  deleteThread: vi.fn(),
+  getProjects: vi.fn(),
+  getThreadsByProject: vi.fn(),
+}));
+
+vi.mock('../../hooks/useProjects', () => ({
+  useProjects: () => ({
+    sidebarProjects: [{ id: 'p1', name: 'Alpha', description: null, threadCount: 2 }],
+    createProject: vi.fn(),
+    updateProject: vi.fn(),
+    deleteProject: mocks.deleteProject,
+    assignThreadToProject: vi.fn(),
+    unassignAllThreads: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
+
+vi.mock('../../services/chatStorage', () => ({
+  chatStorage: {
+    loadChats: () => [],
+    saveChats: vi.fn(),
+    clearChats: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/agent-rest', () => ({
+  getAllThreadsByUserId: vi.fn(async () => [
+    {
+      id: 'c1',
+      title: 'Chat',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      project_id: 'p1',
+      messages: [],
+    },
+  ]),
+  getThreadState: vi.fn(async () => []),
+  deleteThread: mocks.deleteThread,
+}));
+
+vi.mock('../../services/projects-api', () => ({
+  getProjects: mocks.getProjects,
+  getThreadsByProject: mocks.getThreadsByProject,
+}));
+
+vi.mock('../../lib/streaming/streamingManagerRegistry', () => ({
+  releaseStreamingManager: vi.fn(),
+}));
+
+vi.mock('../Sidebar', () => ({
+  Sidebar: ({
+    onDeleteProject,
+    onDeleteChat,
+  }: {
+    onDeleteProject: (id: string, options?: { keepThreads?: boolean }) => Promise<boolean>;
+    onDeleteChat: (id: string) => void;
+  }) => (
+    <>
+      <button type="button" onClick={() => { void onDeleteProject('p1'); }}>
+        delete-project
+      </button>
+      <button type="button" onClick={() => { void onDeleteChat('c1'); }}>
+        delete-chat
+      </button>
+    </>
+  ),
+}));
+
+function seedStore() {
+  const store = createTestStore();
+  store.dispatch(
+    setProjects([
+      {
+        project_id: 'p1',
+        project_name: 'Alpha',
+        project_description: null,
+        username: 'u1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-01',
+        thread_count: 2,
+      },
+    ]),
+  );
+  store.dispatch(
+    addChat({
+      id: 'c1',
+      title: 'Chat',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      preview: '',
+      messages: [],
+      historicalActivities: {},
+      feedback: {},
+      project_id: 'p1',
+    }),
+  );
+  return store;
+}
+
+function renderLayout(store: ReturnType<typeof createTestStore>) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <AppLayout>
+          <div>child</div>
+        </AppLayout>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('AppLayout — project delete and chat count', () => {
+  beforeEach(() => {
+    mocks.deleteProject.mockReset();
+    mocks.deleteThread.mockReset();
+    mocks.getProjects.mockReset();
+    mocks.getThreadsByProject.mockReset();
+    mocks.getProjects.mockResolvedValue([]);
+    mocks.getThreadsByProject.mockResolvedValue([]);
+  });
+
+  it('does not wipe local chats when the project is already gone', async () => {
+    const user = userEvent.setup();
+    mocks.deleteProject.mockResolvedValue({
+      ok: true,
+      deletedThreadIds: [],
+      keepThreads: false,
+      missing: true,
+    });
+    const store = seedStore();
+    renderLayout(store);
+
+    await user.click(screen.getByRole('button', { name: 'delete-project' }));
+
+    await waitFor(() => {
+      expect(mocks.deleteProject).toHaveBeenCalledWith('p1', { keepThreads: false });
+    });
+    expect(store.getState().chats.chats.some((c) => c.id === 'c1')).toBe(true);
+    expect(store.getState().chats.chats.find((c) => c.id === 'c1')?.project_id).toBeNull();
+  });
+
+  it('persists an empty chat list after hard-delete of the last chats', async () => {
+    const user = userEvent.setup();
+    mocks.deleteProject.mockResolvedValue({
+      ok: true,
+      deletedThreadIds: ['c1'],
+      keepThreads: false,
+      missing: false,
+    });
+    const store = seedStore();
+    renderLayout(store);
+
+    await waitFor(() => {
+      expect(store.getState().chats.chats.some((c) => c.id === 'c1')).toBe(true);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'delete-project' }));
+
+    await waitFor(() => {
+      expect(store.getState().chats.chats).toHaveLength(0);
+    });
+    expect(chatStorage.clearChats).toHaveBeenCalled();
+  });
+
+  it('restores the project conversation count when server chat delete fails', async () => {
+    const user = userEvent.setup();
+    mocks.deleteThread.mockResolvedValue(false);
+    const store = seedStore();
+    renderLayout(store);
+
+    await waitFor(() => {
+      expect(store.getState().chats.chats.some((c) => c.id === 'c1')).toBe(true);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'delete-chat' }));
+
+    await waitFor(() => {
+      expect(mocks.deleteThread).toHaveBeenCalledWith('c1');
+    });
+    expect(store.getState().projects.projects[0].thread_count).toBe(2);
+    expect(store.getState().chats.chats.some((c) => c.id === 'c1')).toBe(false);
+  });
+});
+
+describe('AppLayout — project thread hydration', () => {
+  beforeEach(() => {
+    mocks.getProjects.mockReset();
+    mocks.getThreadsByProject.mockReset();
+    vi.mocked(getAllThreadsByUserId).mockReset();
+    vi.mocked(getAllThreadsByUserId).mockResolvedValue([
+      {
+        id: 'c1',
+        title: 'Chat',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        project_id: 'p1',
+        messages: [],
+      },
+    ]);
+  });
+
+  it('adds chats that search omitted but the project endpoint returned', async () => {
+    mocks.getProjects.mockResolvedValue([
+      {
+        project_id: 'p1',
+        project_name: 'Alpha',
+        project_description: null,
+        username: 'u1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-01',
+        thread_count: 2,
+      },
+    ]);
+    mocks.getThreadsByProject.mockResolvedValue([
+      {
+        id: 'c-old',
+        title: 'Old folder chat',
+        messages: [],
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        project_id: 'p1',
+      },
+    ]);
+    const store = seedStore();
+    renderLayout(store);
+
+    await waitFor(() => {
+      expect(store.getState().chats.chats.some((c) => c.id === 'c-old')).toBe(true);
+    });
+    expect(store.getState().chats.chats.find((c) => c.id === 'c-old')?.project_id).toBe('p1');
+    expect(getProjects).toHaveBeenCalled();
+    expect(getThreadsByProject).toHaveBeenCalledWith('p1');
+  });
+});

--- a/src/frontend/components/layout/AppLayout.tsx
+++ b/src/frontend/components/layout/AppLayout.tsx
@@ -29,7 +29,6 @@ import {
   selectStreamingState,
   addChat,
   deleteChat,
-  clearAllChats,
   updateChat,
   setChats,
   setLoadingThreads,
@@ -37,13 +36,16 @@ import {
   ChatItem,
 } from '../../redux/slices/chats';
 import { addToast } from '../../redux/slices/toasts';
+import { updateProjectThreadCount } from '../../redux/slices/projects';
 import { SidebarChatItem } from '../../types/chat';
 import { chatStorage } from '../../services/chatStorage';
-import { getAllThreadsByUserId, getThreadState, deleteThread } from '../../services/agent-rest';
+import { getAllThreadsByUserId, getThreadState, deleteThread, type Thread } from '../../services/agent-rest';
+import { getProjects, getThreadsByProject } from '../../services/projects-api';
 import { setAuthExpiredCallback } from '../../services/authenticated-fetch';
 import { markChatAsClientCreated, isClientCreatedChat } from '../../services/newChatTracker';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { releaseStreamingManager } from '../../lib/streaming/streamingManagerRegistry';
+import { useProjects } from '../../hooks/useProjects';
 import type { RootState } from '../../redux/store';
 
 function toSafeDate(value: unknown): Date {
@@ -63,6 +65,34 @@ function toSafeISOString(value: unknown): string {
   return toSafeDate(value).toISOString();
 }
 
+async function withProjectThreads(history: Thread[]): Promise<Thread[]> {
+  try {
+    const projects = await getProjects();
+    const extras = (
+      await Promise.allSettled(
+        projects.map((p) => getThreadsByProject(p.project_id)),
+      )
+    ).flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
+    const byId = new Map(history.map((t) => [t.id, t]));
+    for (const t of extras) {
+      const prev = byId.get(t.id);
+      if (!prev) {
+        byId.set(t.id, t);
+        continue;
+      }
+      byId.set(t.id, {
+        ...prev,
+        title: prev.title || t.title,
+        updatedAt: t.updatedAt ?? prev.updatedAt,
+        project_id: t.project_id ?? prev.project_id,
+      });
+    }
+    return [...byId.values()];
+  } catch {
+    return history;
+  }
+}
+
 interface AppLayoutProps {
   children: React.ReactNode;
 }
@@ -71,6 +101,14 @@ export function AppLayout({ children }: AppLayoutProps) {
   const dispatch = useAppDispatch();
   const chats = useAppSelector(selectAllChats);
   const branding = useAppSelector((state: RootState) => state.config.branding);
+  const {
+    sidebarProjects,
+    createProject,
+    updateProject,
+    deleteProject,
+    assignThreadToProject,
+    unassignAllThreads,
+  } = useProjects();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
@@ -117,7 +155,9 @@ export function AppLayout({ children }: AppLayoutProps) {
     async function loadUserHistory() {
       try {
         dispatch(setLoadingThreads(true));
-        const history = await getAllThreadsByUserId(window.USER_DATA.preferred_username || window.USER_DATA.sub);
+        const history = await withProjectThreads(
+          await getAllThreadsByUserId(window.USER_DATA.preferred_username || window.USER_DATA.sub),
+        );
 
         const backendIds = new Set(history.map((t) => t.id));
         const local = chatsRef.current;
@@ -136,6 +176,10 @@ export function AppLayout({ children }: AppLayoutProps) {
           }, []),
         );
 
+        const backendProjectMap = new Map(
+          history.map((t) => [t.id, t.project_id ?? null] as const),
+        );
+
         const survivingWithTitles = surviving.map((c) => {
           const backendTitle = backendTitleMap.get(c.id);
           const ts = backendTimestampMap.get(c.id);
@@ -146,6 +190,13 @@ export function AppLayout({ children }: AppLayoutProps) {
           }
           if (ts) {
             updated.timestamp = ts;
+          }
+          if (
+            backendIds.has(c.id) &&
+            backendProjectMap.has(c.id) &&
+            c._prevProjectId === undefined
+          ) {
+            updated.project_id = backendProjectMap.get(c.id);
           }
           return updated;
         });
@@ -161,6 +212,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             timestamp: t.updatedAt || new Date().toISOString(),
             historicalActivities: {},
             feedback: {},
+            project_id: t.project_id ?? null,
           }));
 
         const reconciled = [...survivingWithTitles, ...added].sort(
@@ -231,13 +283,16 @@ export function AppLayout({ children }: AppLayoutProps) {
           chat.messages.length > 0
             ? (chat.messages[0].content as string).substring(0, 60) + '...'
             : chat.preview,
+        project_id: chat.project_id,
       })),
     [chats]
   );
 
   const handleSelectChat = (chatId: string) => navigate(`/chat/${chatId}`);
 
-  const handleNewChat = useCallback(() => {
+  const handleNewChat = useCallback((projectId?: string) => {
+    // Only the per-project "+" control passes projectId. The sidebar
+    // "New Chat" button always starts an unassigned conversation.
     const newChatId = uuidv4();
     markChatAsClientCreated(newChatId);
     const newChat: ChatItem = {
@@ -248,13 +303,21 @@ export function AppLayout({ children }: AppLayoutProps) {
       messages: [],
       historicalActivities: {},
       feedback: {},
+      project_id: projectId ?? null,
     };
     dispatch(addChat(newChat));
+    if (projectId) {
+      dispatch(updateProjectThreadCount({ projectId, delta: 1 }));
+    }
     navigate(`/chat/${newChatId}`, { state: { newChat: true } });
   }, [dispatch, navigate]);
 
   const handleDeleteChat = useCallback(
     async (chatId: string) => {
+      const chat = chats.find((c) => c.id === chatId);
+      if (chat?.project_id) {
+        dispatch(updateProjectThreadCount({ projectId: chat.project_id, delta: -1 }));
+      }
       releaseStreamingManager(chatId);
       dispatch(deleteChat(chatId));
       chatStorage.clearChats();
@@ -263,6 +326,9 @@ export function AppLayout({ children }: AppLayoutProps) {
       if (ok) {
         dispatch(addToast({ title: 'Chat deleted', variant: 'success' }));
       } else {
+        if (chat?.project_id) {
+          dispatch(updateProjectThreadCount({ projectId: chat.project_id, delta: 1 }));
+        }
         dispatch(addToast({ title: 'Chat cleared locally but server delete failed', variant: 'warning' }));
       }
       if (location.pathname === `/chat/${chatId}`) {
@@ -272,28 +338,81 @@ export function AppLayout({ children }: AppLayoutProps) {
     [dispatch, chats, navigate, location.pathname]
   );
 
-  const handleDeleteAllChats = useCallback(async () => {
-    const ids = chats.map((c) => c.id);
-    ids.forEach((id) => releaseStreamingManager(id));
-    dispatch(clearAllChats());
-    chatStorage.clearChats();
-    const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
-    const failures = results.filter((r) => !r).length;
-    if (failures > 0 && failures < ids.length) {
-      dispatch(addToast({ title: `${ids.length - failures} chats deleted, ${failures} failed on server`, variant: 'warning' }));
-    } else if (failures === ids.length) {
-      dispatch(addToast({ title: 'Chats cleared locally but server deletion failed', variant: 'warning' }));
-    } else {
-      dispatch(addToast({ title: 'All chats deleted', variant: 'success' }));
-    }
-    navigate('/');
-  }, [dispatch, chats, navigate]);
-
   const handleRenameChat = useCallback(
     (chatId: string, newTitle: string) => {
       dispatch(updateChat({ id: chatId, updates: { title: newTitle.trim() || 'Untitled Chat' } }));
     },
     [dispatch]
+  );
+
+  const handleDeleteProject = useCallback(
+    async (projectId: string, options?: { keepThreads?: boolean }) => {
+      const keepThreads = options?.keepThreads === true;
+      const { ok, deletedThreadIds, missing } = await deleteProject(projectId, { keepThreads });
+      if (!ok) {
+        dispatch(addToast({ title: 'Failed to delete project', variant: 'danger' }));
+        return false;
+      }
+
+      if (keepThreads) {
+        dispatch(addToast({
+          title: 'Project deleted. Conversations moved to Chats.',
+          variant: 'success',
+        }));
+        if (location.pathname.startsWith(`/project/${projectId}`)) {
+          navigate('/');
+        }
+        return true;
+      }
+
+      dispatch(addToast({ title: 'Project deleted', variant: 'success' }));
+      if (missing) {
+        for (const chat of chats) {
+          if (chat.project_id === projectId) {
+            dispatch(updateChat({ id: chat.id, updates: { project_id: null } }));
+          }
+        }
+        if (location.pathname.startsWith(`/project/${projectId}`)) {
+          navigate('/');
+        }
+        return true;
+      }
+      const localChatIds = chats
+        .filter((c) => c.project_id === projectId)
+        .map((c) => c.id);
+      const allIds = new Set([...deletedThreadIds, ...localChatIds]);
+      if (
+        location.pathname.startsWith(`/project/${projectId}`) ||
+        (currentChatId && allIds.has(currentChatId))
+      ) {
+        navigate('/');
+      }
+      for (const id of allIds) {
+        releaseStreamingManager(id);
+        dispatch(deleteChat(id));
+      }
+      const remaining = chats.filter((c) => !allIds.has(c.id));
+      if (remaining.length === 0) {
+        chatStorage.clearChats();
+      } else {
+        chatStorage.saveChats(remaining as any);
+      }
+      return true;
+    },
+    [deleteProject, dispatch, chats, navigate, location.pathname, currentChatId],
+  );
+
+  const handleUnassignAll = useCallback(
+    async (projectId: string) => {
+      const ok = await unassignAllThreads(projectId);
+      if (ok) {
+        dispatch(addToast({ title: 'Conversations moved to Chats', variant: 'success' }));
+      } else {
+        dispatch(addToast({ title: 'Failed to unassign conversations', variant: 'danger' }));
+      }
+      return ok;
+    },
+    [unassignAllThreads, dispatch],
   );
 
   useKeyboardShortcuts({
@@ -365,8 +484,13 @@ export function AppLayout({ children }: AppLayoutProps) {
             onNewChat={handleNewChat}
             onSelectChat={handleSelectChat}
             onDeleteChat={handleDeleteChat}
-            onDeleteAllChats={handleDeleteAllChats}
             onRenameChat={handleRenameChat}
+            projects={sidebarProjects}
+            onCreateProject={createProject}
+            onUpdateProject={updateProject}
+            onDeleteProject={handleDeleteProject}
+            onAssignThread={assignThreadToProject}
+            onUnassignAll={handleUnassignAll}
           />
         </ErrorBoundary>
       </PageSidebarBody>

--- a/src/frontend/components/settings/ProfileSection.test.tsx
+++ b/src/frontend/components/settings/ProfileSection.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createTestStore } from '../../test-utils/createTestStore';
+import { addChat } from '../../redux/slices/chats';
+import { setProjects } from '../../redux/slices/projects';
+import { ProfileSection } from './ProfileSection';
+import * as projectsApi from '../../services/projects-api';
+
+vi.mock('../../services/chatStorage', () => ({
+  chatStorage: {
+    clearChats: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/agent-rest', () => ({
+  deleteThread: vi.fn(async () => true),
+}));
+
+vi.mock('../../lib/streaming/streamingManagerRegistry', () => ({
+  releaseStreamingManager: vi.fn(),
+}));
+
+vi.mock('../../services/projects-api', () => ({
+  getProjects: vi.fn(async () => []),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  assignThreadToProject: vi.fn(),
+  unassignAllThreadsFromProject: vi.fn(),
+  getThreadsByProject: vi.fn(async () => []),
+}));
+
+function seedStore() {
+  const store = createTestStore();
+  store.dispatch(
+    setProjects([
+      {
+        project_id: 'p1',
+        project_name: 'Alpha',
+        project_description: null,
+        username: 'u1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-01',
+        thread_count: 2,
+      },
+    ]),
+  );
+  store.dispatch(
+    addChat({
+      id: 'c1',
+      title: 'Chat',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      preview: '',
+      messages: [],
+      historicalActivities: {},
+      feedback: {},
+      project_id: 'p1',
+    }),
+  );
+  return store;
+}
+
+describe('ProfileSection — delete all', () => {
+  beforeEach(() => {
+    Object.assign(window, {
+      USER_DATA: { displayName: 'Dev', preferred_username: 'dev' },
+    });
+    vi.mocked(projectsApi.getProjects).mockReset();
+  });
+
+  it('reloads project conversation counts from the server after delete all', async () => {
+    vi.mocked(projectsApi.getProjects).mockResolvedValue([
+      {
+        project_id: 'p1',
+        project_name: 'Alpha',
+        project_description: null,
+        username: 'u1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-01',
+        thread_count: 3,
+      },
+    ]);
+    const user = userEvent.setup();
+    const store = seedStore();
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <ProfileSection />
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Delete all' }));
+    await user.click(screen.getByRole('button', { name: 'Delete all' }));
+
+    await waitFor(() => {
+      expect(projectsApi.getProjects).toHaveBeenCalled();
+      expect(store.getState().projects.projects[0].thread_count).toBe(3);
+    });
+  });
+});

--- a/src/frontend/components/settings/ProfileSection.tsx
+++ b/src/frontend/components/settings/ProfileSection.tsx
@@ -4,6 +4,7 @@ import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from
 import { User, Mail, Shield, Trash2 } from 'lucide-react';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { clearAllChats, selectAllChats } from '../../redux/slices/chats';
+import { loadProjectsThunk } from '../../redux/slices/projects';
 import { addToast } from '../../redux/slices/toasts';
 import { deleteThread } from '../../services/agent-rest';
 import { chatStorage } from '../../services/chatStorage';
@@ -28,6 +29,7 @@ export function ProfileSection() {
     setConfirmDelete(false);
 
     const results = await Promise.all(ids.map((id) => deleteThread(id).catch(() => false)));
+    void dispatch(loadProjectsThunk());
     const failures = results.filter((r) => !r).length;
 
     if (failures > 0 && failures < ids.length) {

--- a/src/frontend/hooks/useProjects.test.ts
+++ b/src/frontend/hooks/useProjects.test.ts
@@ -1,0 +1,247 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createTestStore } from '../test-utils/createTestStore';
+import { addChat } from '../redux/slices/chats';
+import { selectToasts } from '../redux/slices/toasts';
+import * as projectsApi from '../services/projects-api';
+import { markChatAsClientCreated, unmarkChatAsClientCreated } from '../services/newChatTracker';
+import { useProjects } from './useProjects';
+
+vi.mock('../services/projects-api', () => ({
+  getProjects: vi.fn(async () => []),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  assignThreadToProject: vi.fn(),
+  unassignAllThreadsFromProject: vi.fn(),
+}));
+
+function wrapperFor(store: ReturnType<typeof createTestStore>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store }, children);
+  };
+}
+
+describe('useProjects', () => {
+  beforeEach(() => {
+    vi.mocked(projectsApi.getProjects).mockReset();
+    vi.mocked(projectsApi.getProjects).mockResolvedValue([]);
+    vi.mocked(projectsApi.createProject).mockReset();
+    vi.mocked(projectsApi.assignThreadToProject).mockReset();
+    vi.mocked(projectsApi.deleteProject).mockReset();
+  });
+
+  it('toasts when loading projects fails', async () => {
+    vi.mocked(projectsApi.getProjects).mockRejectedValue(new Error('network'));
+    const store = createTestStore();
+    renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await waitFor(() => {
+      expect(
+        selectToasts(store.getState()).some((t) => t.title === 'Failed to load projects'),
+      ).toBe(true);
+    });
+  });
+
+  it('toasts when assigning a conversation fails', async () => {
+    vi.mocked(projectsApi.assignThreadToProject).mockRejectedValue(new Error('fail'));
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'c1',
+        title: 'Chat',
+        timestamp: new Date().toISOString(),
+        preview: '',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: null,
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      const ok = await result.current.assignThreadToProject('c1', 'p1');
+      expect(ok).toBe(false);
+    });
+
+    expect(
+      selectToasts(store.getState()).some((t) => t.title === 'Failed to move conversation'),
+    ).toBe(true);
+  });
+
+  it('assigns a never-streamed new chat locally without calling the API', async () => {
+    markChatAsClientCreated('new-1');
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'new-1',
+        title: 'New Chat',
+        timestamp: new Date().toISOString(),
+        preview: '',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: null,
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      const ok = await result.current.assignThreadToProject('new-1', 'p1');
+      expect(ok).toBe(true);
+    });
+
+    expect(projectsApi.assignThreadToProject).not.toHaveBeenCalled();
+    expect(store.getState().chats.chats[0].project_id).toBe('p1');
+    expect(
+      selectToasts(store.getState()).some((t) => t.title === 'Failed to move conversation'),
+    ).toBe(false);
+  });
+
+  it('unassigns a never-streamed new chat locally without calling the API', async () => {
+    markChatAsClientCreated('new-2');
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'new-2',
+        title: 'New Chat',
+        timestamp: new Date().toISOString(),
+        preview: '',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: 'p1',
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      const ok = await result.current.assignThreadToProject('new-2', null);
+      expect(ok).toBe(true);
+    });
+
+    expect(projectsApi.assignThreadToProject).not.toHaveBeenCalled();
+    expect(store.getState().chats.chats[0].project_id).toBeNull();
+  });
+
+  it('assigns a client-created chat locally even after it has a message', async () => {
+    markChatAsClientCreated('new-3');
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'new-3',
+        title: 'Chat',
+        timestamp: new Date().toISOString(),
+        preview: 'hello',
+        messages: [{ type: 'human', content: 'hello', id: 'm1' }],
+        historicalActivities: {},
+        feedback: {},
+        project_id: null,
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      const ok = await result.current.assignThreadToProject('new-3', 'p1');
+      expect(ok).toBe(true);
+    });
+
+    expect(projectsApi.assignThreadToProject).not.toHaveBeenCalled();
+    expect(store.getState().chats.chats[0].project_id).toBe('p1');
+  });
+
+  it('calls the API after the chat is unmarked as client-created', async () => {
+    markChatAsClientCreated('new-4');
+    unmarkChatAsClientCreated('new-4');
+    vi.mocked(projectsApi.assignThreadToProject).mockResolvedValue();
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'new-4',
+        title: 'Chat',
+        timestamp: new Date().toISOString(),
+        preview: 'hello',
+        messages: [{ type: 'human', content: 'hello', id: 'm1' }],
+        historicalActivities: {},
+        feedback: {},
+        project_id: null,
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      const ok = await result.current.assignThreadToProject('new-4', 'p1');
+      expect(ok).toBe(true);
+    });
+
+    expect(projectsApi.assignThreadToProject).toHaveBeenCalledWith('new-4', 'p1');
+  });
+
+  it('reports missing when delete returns 404', async () => {
+    vi.mocked(projectsApi.deleteProject).mockResolvedValue({
+      deleted_thread_ids: [],
+      missing: true,
+    });
+    const store = createTestStore();
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    let deleted: Awaited<ReturnType<typeof result.current.deleteProject>> | undefined;
+    await act(async () => {
+      deleted = await result.current.deleteProject('p1');
+    });
+
+    expect(deleted).toEqual({
+      ok: true,
+      deletedThreadIds: [],
+      keepThreads: false,
+      missing: true,
+    });
+  });
+
+  it('counts never-streamed local chats in the sidebar badge', async () => {
+    vi.mocked(projectsApi.getProjects).mockResolvedValue([
+      {
+        project_id: 'p1',
+        project_name: 'Alpha',
+        project_description: null,
+        username: 'u1',
+        created_at: '2026-01-01',
+        updated_at: '2026-01-01',
+        thread_count: 0,
+      },
+    ]);
+    const store = createTestStore();
+    store.dispatch(
+      addChat({
+        id: 'c1',
+        title: 'Chat',
+        timestamp: new Date().toISOString(),
+        preview: '',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: 'p1',
+      }),
+    );
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await waitFor(() => {
+      expect(result.current.sidebarProjects[0]?.threadCount).toBe(1);
+    });
+  });
+
+  it('rethrows create errors that are not duplicate-name conflicts', async () => {
+    vi.mocked(projectsApi.createProject).mockRejectedValue(
+      new Error('Failed to create project: 500'),
+    );
+    const store = createTestStore();
+    const { result } = renderHook(() => useProjects(), { wrapper: wrapperFor(store) });
+
+    await act(async () => {
+      await expect(result.current.createProject('Alpha')).rejects.toThrow(/Failed to create/);
+    });
+  });
+});

--- a/src/frontend/hooks/useProjects.ts
+++ b/src/frontend/hooks/useProjects.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { selectAllChats, updateChat } from '../redux/slices/chats';
+import {
+  loadProjectsThunk,
+  createProjectThunk,
+  updateProjectThunk,
+  deleteProjectThunk,
+  assignThreadToProjectThunk,
+  unassignAllThreadsThunk,
+  selectAllProjects,
+  updateProjectThreadCount,
+} from '../redux/slices/projects';
+import { addToast } from '../redux/slices/toasts';
+import { isClientCreatedChat } from '../services/newChatTracker';
+import type { SidebarProject } from '../types/chat';
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    return String((err as { message: unknown }).message);
+  }
+  return String(err);
+}
+
+export function useProjects() {
+  const dispatch = useAppDispatch();
+  const projects = useAppSelector(selectAllProjects);
+  const chats = useAppSelector(selectAllChats);
+
+  useEffect(() => {
+    void dispatch(loadProjectsThunk())
+      .unwrap()
+      .catch(() => {
+        dispatch(addToast({ title: 'Failed to load projects', variant: 'danger' }));
+      });
+  }, [dispatch]);
+
+  const sidebarProjects: SidebarProject[] = useMemo(
+    () =>
+      projects.map((p) => ({
+        id: p.project_id,
+        name: p.project_name,
+        description: p.project_description,
+        threadCount: Math.max(
+          p.thread_count,
+          chats.filter((c) => c.project_id === p.project_id).length,
+        ),
+      })),
+    [projects, chats],
+  );
+
+  const handleCreateProject = useCallback(
+    async (name: string, description?: string): Promise<string | null> => {
+      try {
+        const result = await dispatch(createProjectThunk({ name, description })).unwrap();
+        return result.project_id;
+      } catch (err) {
+        if (errorMessage(err).includes('already exists')) return null;
+        throw err;
+      }
+    },
+    [dispatch],
+  );
+
+  const handleUpdateProject = useCallback(
+    async (projectId: string, name?: string, description?: string): Promise<boolean> => {
+      try {
+        await dispatch(updateProjectThunk({ projectId, name, description })).unwrap();
+        return true;
+      } catch (err) {
+        if (errorMessage(err).includes('already exists')) return false;
+        throw err;
+      }
+    },
+    [dispatch],
+  );
+
+  const handleDeleteProject = useCallback(
+    async (
+      projectId: string,
+      options?: { keepThreads?: boolean },
+    ): Promise<{
+      ok: boolean;
+      deletedThreadIds: string[];
+      keepThreads: boolean;
+      missing: boolean;
+    }> => {
+      const keepThreads = options?.keepThreads === true;
+      try {
+        const result = await dispatch(
+          deleteProjectThunk({ projectId, keepThreads }),
+        ).unwrap();
+        return {
+          ok: true,
+          deletedThreadIds: result.deletedThreadIds,
+          keepThreads: result.keepThreads,
+          missing: result.missing === true,
+        };
+      } catch {
+        return { ok: false, deletedThreadIds: [], keepThreads, missing: false };
+      }
+    },
+    [dispatch],
+  );
+
+  const handleUnassignAllThreads = useCallback(
+    async (projectId: string): Promise<boolean> => {
+      try {
+        await dispatch(unassignAllThreadsThunk(projectId)).unwrap();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [dispatch],
+  );
+
+  const handleAssignThread = useCallback(
+    async (threadId: string, projectId: string | null): Promise<boolean> => {
+      const chat = chats.find((c) => c.id === threadId);
+      const prev = chat?.project_id ?? null;
+      if (prev === projectId) return true;
+
+      const bumpCounts = () => {
+        if (prev) {
+          dispatch(updateProjectThreadCount({ projectId: prev, delta: -1 }));
+        }
+        if (projectId) {
+          dispatch(updateProjectThreadCount({ projectId, delta: 1 }));
+        }
+      };
+
+      if (chat && isClientCreatedChat(threadId)) {
+        dispatch(updateChat({ id: threadId, updates: { project_id: projectId } }));
+        bumpCounts();
+        return true;
+      }
+
+      try {
+        await dispatch(assignThreadToProjectThunk({ threadId, projectId })).unwrap();
+        bumpCounts();
+        return true;
+      } catch {
+        dispatch(addToast({ title: 'Failed to move conversation', variant: 'danger' }));
+        return false;
+      }
+    },
+    [dispatch, chats],
+  );
+
+  return {
+    sidebarProjects,
+    createProject: handleCreateProject,
+    updateProject: handleUpdateProject,
+    deleteProject: handleDeleteProject,
+    unassignAllThreads: handleUnassignAllThreads,
+    assignThreadToProject: handleAssignThread,
+  };
+}

--- a/src/frontend/hooks/useSidebarDragDrop.test.ts
+++ b/src/frontend/hooks/useSidebarDragDrop.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { DragEvent } from 'react';
+import { useSidebarDragDrop } from './useSidebarDragDrop';
+
+function dragOverEvent(): DragEvent<HTMLElement> {
+  return {
+    preventDefault() {},
+    dataTransfer: { dropEffect: '' },
+  } as unknown as DragEvent<HTMLElement>;
+}
+
+function dropEvent(threadId: string): DragEvent<HTMLElement> {
+  return {
+    preventDefault() {},
+    dataTransfer: { getData: () => threadId },
+  } as unknown as DragEvent<HTMLElement>;
+}
+
+describe('useSidebarDragDrop', () => {
+  it('keeps the drop target when leaving into a child', () => {
+    const { result } = renderHook(() => useSidebarDragDrop(vi.fn(async () => true)));
+    const parent = document.createElement('div');
+    const child = document.createElement('span');
+    parent.appendChild(child);
+
+    act(() => {
+      result.current.handleDragOver(dragOverEvent(), 'p1');
+    });
+    expect(result.current.dragOverTarget).toBe('p1');
+
+    act(() => {
+      result.current.handleDragLeave({
+        currentTarget: parent,
+        relatedTarget: child,
+      } as unknown as DragEvent<HTMLElement>);
+    });
+    expect(result.current.dragOverTarget).toBe('p1');
+  });
+
+  it('clears the drop target when leaving the folder', () => {
+    const { result } = renderHook(() => useSidebarDragDrop(vi.fn(async () => true)));
+    const parent = document.createElement('div');
+
+    act(() => {
+      result.current.handleDragOver(dragOverEvent(), 'p1');
+    });
+
+    act(() => {
+      result.current.handleDragLeave({
+        currentTarget: parent,
+        relatedTarget: document.createElement('div'),
+      } as unknown as DragEvent<HTMLElement>);
+    });
+    expect(result.current.dragOverTarget).toBeNull();
+  });
+
+  it('ignores a second drop while the first assign is still running', async () => {
+    let release!: (ok: boolean) => void;
+    const onAssign = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useSidebarDragDrop(onAssign));
+
+    let first: Promise<void>;
+    act(() => {
+      first = result.current.handleDrop(dropEvent('t1'), 'p1');
+    });
+    expect(onAssign).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.handleDrop(dropEvent('t1'), 'p2');
+    });
+    expect(onAssign).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      release(true);
+      await first!;
+    });
+  });
+});

--- a/src/frontend/hooks/useSidebarDragDrop.ts
+++ b/src/frontend/hooks/useSidebarDragDrop.ts
@@ -1,0 +1,67 @@
+import { useState, useCallback, useRef, type DragEvent } from 'react';
+
+export function useSidebarDragDrop(
+  onAssign: (threadId: string, projectId: string | null) => Promise<boolean>,
+) {
+  const [draggedThreadId, setDraggedThreadId] = useState<string | null>(null);
+  const [dragOverTarget, setDragOverTarget] = useState<string | null>(null);
+  const processingRef = useRef(false);
+
+  const handleDragStart = useCallback(
+    (e: DragEvent<HTMLElement>, threadId: string) => {
+      e.dataTransfer.setData('text/plain', threadId);
+      e.dataTransfer.effectAllowed = 'move';
+      setDraggedThreadId(threadId);
+    },
+    [],
+  );
+
+  const handleDragOver = useCallback(
+    (e: DragEvent<HTMLElement>, targetId: string) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDragOverTarget(targetId);
+    },
+    [],
+  );
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLElement>) => {
+    const next = e.relatedTarget as Node | null;
+    if (next && e.currentTarget.contains(next)) return;
+    setDragOverTarget(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: DragEvent<HTMLElement>, targetProjectId: string | null) => {
+      e.preventDefault();
+      const threadId = e.dataTransfer.getData('text/plain');
+      setDragOverTarget(null);
+      setDraggedThreadId(null);
+      if (processingRef.current) return;
+      processingRef.current = true;
+      try {
+        if (threadId) {
+          await onAssign(threadId, targetProjectId);
+        }
+      } finally {
+        processingRef.current = false;
+      }
+    },
+    [onAssign],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedThreadId(null);
+    setDragOverTarget(null);
+  }, []);
+
+  return {
+    draggedThreadId,
+    dragOverTarget,
+    handleDragStart,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleDragEnd,
+  };
+}

--- a/src/frontend/hooks/useStreamingAPI.test.ts
+++ b/src/frontend/hooks/useStreamingAPI.test.ts
@@ -5,12 +5,25 @@ import { renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import React from 'react';
 import { configureStore } from '@reduxjs/toolkit';
-import chatsReducer, { addChat, selectStreamingState } from '../redux/slices/chats';
+import chatsReducer, { addChat, selectStreamingState, updateChat } from '../redux/slices/chats';
 import configReducer from '../redux/slices/config';
 import personalizationReducer from '../redux/slices/personalization';
 import toastsReducer from '../redux/slices/toasts';
 import userSettingsReducer, { addAlwaysAllowedTool } from '../redux/slices/userSettings';
+import projectsReducer from '../redux/slices/projects';
 import { useStreamingAPI, RECOVERY_POLL_TIMEOUT_MS, _startRecoveryPolling } from './useStreamingAPI';
+import * as projectsApi from '../services/projects-api';
+import { markChatAsClientCreated, unmarkChatAsClientCreated } from '../services/newChatTracker';
+
+vi.mock('../services/projects-api', () => ({
+  getProjects: vi.fn(async () => []),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  assignThreadToProject: vi.fn(async () => undefined),
+  unassignAllThreadsFromProject: vi.fn(),
+  getThreadsByProject: vi.fn(async () => []),
+}));
 
 // ── Store factory ─────────────────────────────────────────────────────────────
 
@@ -22,6 +35,7 @@ function makeStore(preloadedState?: Record<string, unknown>) {
       personalization: personalizationReducer,
       toasts: toastsReducer,
       userSettings: userSettingsReducer,
+      projects: projectsReducer,
     },
     preloadedState,
   });
@@ -228,6 +242,116 @@ describe('useStreamingAPI — initial state and stop()', () => {
 
     // Clean up the in-flight request
     act(() => result.current.stop());
+  });
+
+  it('stamps the current project_id even if submit was created before assign', async () => {
+    const fetchMock = vi.fn(
+      () => new Promise(() => { /* never resolves */ }),
+    );
+    vi.mocked(fetch).mockImplementation(fetchMock);
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+    const submitBeforeAssign = result.current.submit;
+
+    act(() => {
+      store.dispatch(updateChat({ id: THREAD_ID, updates: { project_id: 'p-new' } }));
+    });
+
+    const userMessage = {
+      type: 'human',
+      content: 'hello world',
+      id: 'user-msg-1',
+    } as unknown as Message;
+
+    act(() => void submitBeforeAssign({ messages: [userMessage] }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, init] = fetchMock.mock.calls[0] as [string, { body: string }];
+    expect(JSON.parse(init.body).project_id).toBe('p-new');
+
+    act(() => result.current.stop());
+  });
+
+  it('persists folder membership after the first successful stream of a client-created chat', async () => {
+    markChatAsClientCreated(THREAD_ID);
+    store.dispatch(updateChat({ id: THREAD_ID, updates: { project_id: 'p1' } }));
+    vi.mocked(projectsApi.assignThreadToProject).mockResolvedValue();
+
+    const encoder = new TextEncoder();
+    const sseBody =
+      `data: ${JSON.stringify({ type: 'token', content: 'Hi', chunk_id: 0 })}\n\n` +
+      'data: [DONE]\n\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseBody));
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+    const userMessage = {
+      type: 'human',
+      content: 'hello world',
+      id: 'user-msg-1',
+    } as unknown as Message;
+
+    await act(async () => {
+      await result.current.submit({ messages: [userMessage] });
+    });
+
+    await waitFor(() => {
+      expect(projectsApi.assignThreadToProject).toHaveBeenCalledWith(THREAD_ID, 'p1');
+    });
+    unmarkChatAsClientCreated(THREAD_ID);
+  });
+
+  it('does not persist folder membership for a chat that already exists on the server', async () => {
+    unmarkChatAsClientCreated(THREAD_ID);
+    store.dispatch(updateChat({ id: THREAD_ID, updates: { project_id: 'p1' } }));
+    vi.mocked(projectsApi.assignThreadToProject).mockClear();
+
+    const encoder = new TextEncoder();
+    const sseBody =
+      `data: ${JSON.stringify({ type: 'token', content: 'Hi', chunk_id: 0 })}\n\n` +
+      'data: [DONE]\n\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseBody));
+        controller.close();
+      },
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    const { result } = renderHook(() => useStreamingAPI(THREAD_ID), {
+      wrapper: makeWrapper(store),
+    });
+    const userMessage = {
+      type: 'human',
+      content: 'hello world',
+      id: 'user-msg-2',
+    } as unknown as Message;
+
+    await act(async () => {
+      await result.current.submit({ messages: [userMessage] });
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(projectsApi.assignThreadToProject).not.toHaveBeenCalled();
   });
 });
 

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -26,6 +26,9 @@ import {
 import { chatStorage } from '@/services/chatStorage';
 import { getThreadState, getThreadStateAndInterrupt } from '@/services/agent-rest';
 import { buildAppPath } from '@/lib/app-paths';
+import { addToast } from '@/redux/slices/toasts';
+import { assignThreadToProjectThunk } from '@/redux/slices/projects';
+import { isClientCreatedChat } from '@/services/newChatTracker';
 import { selectActiveRules, selectMemories } from '@/redux/slices/personalization';
 import { selectAlwaysAllowedTools } from '@/redux/slices/userSettings';
 import { isSubAgentToolCall, extractSubAgentName } from '@/types/deep-agent';
@@ -455,7 +458,9 @@ export function useStreamingAPI(threadId: string) {
         token,
         memories: memories.map((m) => m.content),
         rules: activeRules.map((r) => r.content),
+        projectId: chatRef.current?.project_id,
       };
+      const wasClientCreated = isClientCreatedChat(threadId);
 
       let _lastOutcome: 'success' | 'cancelled' | 'failed' = 'failed';
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
@@ -881,7 +886,10 @@ export function useStreamingAPI(threadId: string) {
             },
           };
 
-          manager.stream(streamRequest, callbacks).then(() => {
+          manager.stream(
+            { ...streamRequest, projectId: chatRef.current?.project_id },
+            callbacks,
+          ).then(() => {
             if (!settled) {
               if (!streamEndedWithInterruptRef.current) {
                 dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
@@ -926,6 +934,17 @@ export function useStreamingAPI(threadId: string) {
 
         setRetryCount(attempt + 1);
         await new Promise<void>((r) => setTimeout(r, computeRetryDelayMs(attempt + 1)));
+      }
+
+      if (_lastOutcome === 'success' && wasClientCreated) {
+        const pid = chatRef.current?.project_id;
+        if (pid) {
+          void dispatch(assignThreadToProjectThunk({ threadId, projectId: pid }))
+            .unwrap()
+            .catch(() => {
+              dispatch(addToast({ title: 'Failed to move conversation', variant: 'danger' }));
+            });
+        }
       }
 
       // After all retries: start a fallback recovery poller ONLY if

--- a/src/frontend/lib/streaming/StreamingManager.test.ts
+++ b/src/frontend/lib/streaming/StreamingManager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StreamingManager } from './StreamingManager';
 import type { StreamCallback } from './StreamingManager';
+import { markChatAsClientCreated, isClientCreatedChat } from '@/services/newChatTracker';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -241,5 +242,28 @@ describe('StreamingManager', () => {
 
     // chunk_id 0 was used in first stream; after cancel+reset it should work again
     expect(cb2.onToken).toHaveBeenCalledWith('Re-used');
+  });
+
+  it('includes project_id in the stream request body when provided', async () => {
+    const sseBody = makeTokenSSE('Hi', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const manager = new StreamingManager();
+    await manager.stream({ ...BASE_REQUEST, projectId: 'proj-1' }, makeCallbacks());
+
+    const [, init] = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.project_id).toBe('proj-1');
+  });
+
+  it('unmarks a client-created chat after the stream HTTP response succeeds', async () => {
+    markChatAsClientCreated('thread-1');
+    const sseBody = makeTokenSSE('Hi', 0) + 'data: [DONE]\n\n';
+    vi.mocked(fetch).mockResolvedValueOnce(makeStreamResponse(sseBody));
+
+    const manager = new StreamingManager();
+    await manager.stream(BASE_REQUEST, makeCallbacks());
+
+    expect(isClientCreatedChat('thread-1')).toBe(false);
   });
 });

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -1,6 +1,7 @@
 import type { Message } from '@langchain/langgraph-sdk';
 
 import { parseRetryAfterSeconds, triggerRateLimit } from '@/services/authenticated-fetch';
+import { unmarkChatAsClientCreated } from '@/services/newChatTracker';
 import { buildAgentApiUrl } from '../app-paths';
 import type { HITLInterruptValue } from '@/types/deep-agent';
 
@@ -15,6 +16,7 @@ export interface StreamRequest {
   token?: string;
   memories?: string[];
   rules?: string[];
+  projectId?: string | null;
   resume?: boolean;
   resumeDecisions?: Array<{ type: 'approve' | 'reject' | 'edit'; message?: string }>;
 }
@@ -146,6 +148,7 @@ export class StreamingManager {
       if (request.resume) body.resume = true;
       if (request.memories?.length) body.memories = request.memories;
       if (request.rules?.length) body.rules = request.rules;
+      if (request.projectId) body.project_id = request.projectId;
 
       const response = await fetch(streamUrl, {
         method: 'POST',
@@ -162,6 +165,8 @@ export class StreamingManager {
         }
         throw new Error(`HTTP error! status: ${response.status}`);
       }
+
+      unmarkChatAsClientCreated(request.threadId);
 
       reader = response.body?.getReader();
       if (!reader) {

--- a/src/frontend/pages/ProjectChatPage.test.tsx
+++ b/src/frontend/pages/ProjectChatPage.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import { createTestStore } from '../test-utils/createTestStore';
+import { addChat } from '../redux/slices/chats';
+import { setProjects } from '../redux/slices/projects';
+import { ProjectChatPage } from './ProjectChatPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const project = {
+  project_id: 'p1',
+  project_name: 'Alpha',
+  project_description: 'Research',
+  username: 'dev',
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  thread_count: 0,
+};
+
+function renderPage() {
+  const store = createTestStore();
+  store.dispatch(setProjects([project]));
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/project/p1']}>
+        <Routes>
+          <Route path="/project/:projectId" element={<ProjectChatPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+  return store;
+}
+
+describe('ProjectChatPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('renders a new-chat-in-project button without a prompt textbox', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /new chat in project/i })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('New Chat in Project opens an empty project chat', async () => {
+    const user = userEvent.setup();
+    const store = renderPage();
+    await user.click(screen.getByRole('button', { name: /new chat in project/i }));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/chat\/[^/?]+$/),
+      expect.objectContaining({ state: { newChat: true } }),
+    );
+    expect(store.getState().chats.chats[0].project_id).toBe('p1');
+  });
+
+  it('shows Unassign all when the project has conversations', () => {
+    const store = createTestStore();
+    store.dispatch(setProjects([{ ...project, thread_count: 2 }]));
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/project/p1']}>
+          <Routes>
+            <Route path="/project/:projectId" element={<ProjectChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByRole('button', { name: /unassign all/i })).toBeInTheDocument();
+  });
+
+  it('hides Unassign all when there are no conversations', () => {
+    renderPage();
+    expect(screen.queryByRole('button', { name: /unassign all/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Unassign all when local chats exist even if the server count is 0', () => {
+    const store = createTestStore();
+    store.dispatch(setProjects([project]));
+    store.dispatch(
+      addChat({
+        id: 'c1',
+        title: 'Local chat',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        preview: 'hello',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: 'p1',
+      }),
+    );
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/project/p1']}>
+          <Routes>
+            <Route path="/project/:projectId" element={<ProjectChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByText(/1 conversation/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /unassign all/i })).toBeInTheDocument();
+  });
+
+  it('asks before unassigning all conversations', async () => {
+    const user = userEvent.setup();
+    const store = createTestStore();
+    store.dispatch(setProjects([{ ...project, thread_count: 2 }]));
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/project/p1']}>
+          <Routes>
+            <Route path="/project/:projectId" element={<ProjectChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    await user.click(screen.getByRole('button', { name: /unassign all/i }));
+    expect(
+      screen.getByRole('dialog', { name: /unassign all conversations/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('scrolls the conversation list inside the page', () => {
+    const store = createTestStore();
+    store.dispatch(setProjects([{ ...project, thread_count: 1 }]));
+    store.dispatch(
+      addChat({
+        id: 'c1',
+        title: 'Old chat',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        preview: 'hello',
+        messages: [],
+        historicalActivities: {},
+        feedback: {},
+        project_id: 'p1',
+      }),
+    );
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/project/p1']}>
+          <Routes>
+            <Route path="/project/:projectId" element={<ProjectChatPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    const list = screen.getByRole('region', { name: /project conversations/i });
+    expect(list.className).toMatch(/overflow-y-auto/);
+    expect(list.className).toMatch(/min-h-0/);
+    expect(screen.getByRole('button', { name: /old chat/i })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/pages/ProjectChatPage.tsx
+++ b/src/frontend/pages/ProjectChatPage.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant, Spinner } from '@patternfly/react-core';
+import { Plus, MessageSquare, FolderMinus } from 'lucide-react';
+import { useAppDispatch, useAppSelector } from '../redux/hooks';
+import { addChat, selectChatsByProject, type ChatItem } from '../redux/slices/chats';
+import {
+  selectProjectById,
+  selectProjectsLoading,
+  unassignAllThreadsThunk,
+  updateProjectThreadCount,
+} from '../redux/slices/projects';
+import { addToast } from '../redux/slices/toasts';
+import { markChatAsClientCreated } from '../services/newChatTracker';
+
+export function ProjectChatPage() {
+  const { projectId } = useParams<{ projectId: string }>();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const project = useAppSelector((state) =>
+    projectId ? selectProjectById(state, projectId) : undefined,
+  );
+  const projectChats = useAppSelector((state) =>
+    projectId ? selectChatsByProject(state, projectId) : [],
+  );
+  const isLoading = useAppSelector(selectProjectsLoading);
+  const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false);
+  const [unassignBusy, setUnassignBusy] = useState(false);
+
+  const startChat = useCallback(() => {
+    if (!projectId) return;
+    const newId = uuidv4();
+    markChatAsClientCreated(newId);
+    const newChat: ChatItem = {
+      id: newId,
+      title: 'New Chat',
+      timestamp: new Date().toISOString(),
+      preview: 'Start a new conversation',
+      messages: [],
+      historicalActivities: {},
+      feedback: {},
+      project_id: projectId,
+    };
+    dispatch(addChat(newChat));
+    dispatch(updateProjectThreadCount({ projectId, delta: 1 }));
+    navigate(`/chat/${newId}`, { state: { newChat: true } });
+  }, [dispatch, navigate, projectId]);
+
+  const unassignAll = useCallback(async () => {
+    if (!projectId) return;
+    setUnassignBusy(true);
+    try {
+      await dispatch(unassignAllThreadsThunk(projectId)).unwrap();
+      dispatch(addToast({ title: 'Conversations moved to Chats', variant: 'success' }));
+      setUnassignConfirmOpen(false);
+    } catch {
+      dispatch(addToast({ title: 'Failed to unassign conversations', variant: 'danger' }));
+    } finally {
+      setUnassignBusy(false);
+    }
+  }, [dispatch, projectId]);
+
+  if (isLoading && !project) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-4">
+        <Spinner size="lg" aria-label="Loading project" />
+        <p className="text-muted-foreground">Loading project...</p>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-muted-foreground">Project not found</p>
+      </div>
+    );
+  }
+
+  const visibleCount = Math.max(project.thread_count, projectChats.length);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 p-6 max-w-3xl mx-auto">
+      <div className="shrink-0 mb-6">
+        <h1 className="text-2xl font-bold">{project.project_name}</h1>
+        {project.project_description && (
+          <p className="text-muted-foreground mt-1">{project.project_description}</p>
+        )}
+        <p className="text-sm text-muted-foreground mt-2">
+          {visibleCount} conversation(s)
+        </p>
+      </div>
+
+      <div className="shrink-0 flex flex-wrap gap-2">
+        <Button variant="primary" onClick={startChat} icon={<Plus className="w-4 h-4" />}>
+          New Chat in Project
+        </Button>
+        {visibleCount > 0 && (
+          <Button
+            variant="secondary"
+            onClick={() => setUnassignConfirmOpen(true)}
+            icon={<FolderMinus className="w-4 h-4" />}
+          >
+            Unassign all
+          </Button>
+        )}
+      </div>
+
+      <div
+        className="mt-6 flex-1 min-h-0 overflow-y-auto space-y-2"
+        role="region"
+        aria-label="Project conversations"
+      >
+        {projectChats.length === 0 ? (
+          <div className="text-center py-10 text-muted-foreground">
+            <MessageSquare className="w-8 h-8 mx-auto mb-2 opacity-40" />
+            <p>No conversations yet. Start one above.</p>
+          </div>
+        ) : (
+          projectChats.map((chat) => (
+            <div
+              key={chat.id}
+              className="p-3 rounded-lg border border-border hover:bg-secondary/50 cursor-pointer transition-colors"
+              onClick={() => navigate(`/chat/${chat.id}`)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  navigate(`/chat/${chat.id}`);
+                }
+              }}
+              role="button"
+              tabIndex={0}
+            >
+              <p className="font-medium">{chat.title}</p>
+              <p className="text-sm text-muted-foreground truncate">{chat.preview}</p>
+            </div>
+          ))
+        )}
+      </div>
+
+      <Modal
+        variant={ModalVariant.small}
+        isOpen={unassignConfirmOpen}
+        onClose={() => {
+          if (!unassignBusy) setUnassignConfirmOpen(false);
+        }}
+        aria-label="Unassign all conversations confirmation"
+      >
+        <ModalHeader title="Unassign all conversations" />
+        <ModalBody>Move every conversation in this project back to Chats?</ModalBody>
+        <ModalFooter>
+          <Button
+            variant="danger"
+            isDisabled={unassignBusy}
+            onClick={() => void unassignAll()}
+          >
+            Unassign
+          </Button>
+          <Button
+            variant="link"
+            isDisabled={unassignBusy}
+            onClick={() => setUnassignConfirmOpen(false)}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+}

--- a/src/frontend/redux/slices/chats.test.ts
+++ b/src/frontend/redux/slices/chats.test.ts
@@ -318,6 +318,7 @@ describe('chats slice — project assignment', () => {
     s = chatsReducer(s, addChat(makeChat('c2', { project_id: 'p1' })));
     const state = { chats: s };
     expect(selectChatsByProject(state, 'p1').map((c) => c.id)).toEqual(['c2']);
+    expect(selectChatsByProject(state, 'p1')).toBe(selectChatsByProject(state, 'p1'));
   });
 
   it('optimistically sets project_id while assign is pending', () => {

--- a/src/frontend/redux/slices/chats.test.ts
+++ b/src/frontend/redux/slices/chats.test.ts
@@ -7,6 +7,8 @@ import chatsReducer, {
   deleteChat,
   mergeToolResult,
   resolveAllPendingToolCalls,
+  selectChatsByProject,
+  setChats,
   setMessageFeedback,
   updateChat,
   updateLastMessageInChat,
@@ -14,6 +16,7 @@ import chatsReducer, {
   type ChatsState,
   type ChatItem,
 } from './chats';
+import { assignThreadToProjectThunk, deleteProjectThunk, unassignAllThreadsThunk } from './projects';
 
 /** Minimal fixture shape that matches the runtime duck-type expected by chats slice reducers. */
 type TestToolCall = { id: string; name: string; args: Record<string, unknown>; content?: string };
@@ -306,5 +309,132 @@ describe('chats slice — updateStreamingState', () => {
     expect(s.streamingStates['new-chat'].isLoading).toBe(true);
     // defaults are preserved
     expect(s.streamingStates['new-chat'].pendingInterrupt).toBeNull();
+  });
+});
+
+describe('chats slice — project assignment', () => {
+  it('selectChatsByProject returns chats in that project', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    s = chatsReducer(s, addChat(makeChat('c2', { project_id: 'p1' })));
+    const state = { chats: s };
+    expect(selectChatsByProject(state, 'p1').map((c) => c.id)).toEqual(['c2']);
+  });
+
+  it('optimistically sets project_id while assign is pending', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: null })));
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.pending('', { threadId: 'c1', projectId: 'p1' }),
+    );
+    expect(s.chats[0].project_id).toBe('p1');
+    expect(s.chats[0]._prevProjectId).toBeNull();
+  });
+
+  it('rolls back project_id when assign is rejected', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: 'p0' })));
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.pending('', { threadId: 'c1', projectId: 'p1' }),
+    );
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.rejected(new Error('fail'), '', { threadId: 'c1', projectId: 'p1' }),
+    );
+    expect(s.chats[0].project_id).toBe('p0');
+  });
+
+  it('rolls back to null when the chat had no project_id field', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1')));
+    expect(s.chats[0].project_id).toBeUndefined();
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.pending('', { threadId: 'c1', projectId: 'p1' }),
+    );
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.rejected(new Error('fail'), '', { threadId: 'c1', projectId: 'p1' }),
+    );
+    expect(s.chats[0].project_id).toBeNull();
+  });
+
+  it('restores project_id on assign fulfilled after the chat list is replaced', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: null })));
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.pending('', { threadId: 'c1', projectId: 'p1' }),
+    );
+    s = chatsReducer(
+      s,
+      setChats([{ ...s.chats[0], project_id: null, _prevProjectId: null }]),
+    );
+    s = chatsReducer(
+      s,
+      assignThreadToProjectThunk.fulfilled(
+        { threadId: 'c1', projectId: 'p1' },
+        '',
+        { threadId: 'c1', projectId: 'p1' },
+      ),
+    );
+    expect(s.chats[0].project_id).toBe('p1');
+    expect(s.chats[0]._prevProjectId).toBeUndefined();
+  });
+
+  it('clears project_id for all project chats after unassign-all', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: 'p1' })));
+    s = chatsReducer(s, addChat(makeChat('c2', { project_id: 'p1' })));
+    s = chatsReducer(s, addChat(makeChat('c3', { project_id: 'p2' })));
+    s = chatsReducer(
+      s,
+      unassignAllThreadsThunk.fulfilled(
+        { projectId: 'p1' },
+        '',
+        'p1',
+      ),
+    );
+    expect(s.chats.find((c) => c.id === 'c1')?.project_id).toBeNull();
+    expect(s.chats.find((c) => c.id === 'c2')?.project_id).toBeNull();
+    expect(s.chats.find((c) => c.id === 'c3')?.project_id).toBe('p2');
+  });
+
+  it('clears project_id when a project is deleted with keepThreads', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: 'p1' })));
+    s = chatsReducer(
+      s,
+      deleteProjectThunk.fulfilled(
+        { projectId: 'p1', deletedThreadIds: [], keepThreads: true },
+        '',
+        { projectId: 'p1', keepThreads: true },
+      ),
+    );
+    expect(s.chats[0].project_id).toBeNull();
+    expect(s.chats).toHaveLength(1);
+  });
+
+  it('leaves chats in place when a project is hard-deleted', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: 'p1' })));
+    s = chatsReducer(
+      s,
+      deleteProjectThunk.fulfilled(
+        { projectId: 'p1', deletedThreadIds: ['c1'], keepThreads: false },
+        '',
+        { projectId: 'p1', keepThreads: false },
+      ),
+    );
+    expect(s.chats).toHaveLength(1);
+    expect(s.chats[0].project_id).toBe('p1');
+  });
+
+  it('clears project_id when delete reports the project missing', () => {
+    let s = chatsReducer(initialState(), addChat(makeChat('c1', { project_id: 'p1' })));
+    s = chatsReducer(
+      s,
+      deleteProjectThunk.fulfilled(
+        { projectId: 'p1', deletedThreadIds: [], keepThreads: false, missing: true },
+        '',
+        { projectId: 'p1', keepThreads: false },
+      ),
+    );
+    expect(s.chats).toHaveLength(1);
+    expect(s.chats[0].project_id).toBeNull();
   });
 });

--- a/src/frontend/redux/slices/chats.ts
+++ b/src/frontend/redux/slices/chats.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { Message } from '@langchain/langgraph-sdk';
 import type { SubAgentInfo, InterruptInfo, TaskStep } from '../../types/deep-agent';
 import { withMcpAppArguments } from '../../types/mcp-apps';
+import { assignThreadToProjectThunk, deleteProjectThunk, unassignAllThreadsThunk } from './projects';
 
 export interface StreamingState {
   isLoading: boolean;
@@ -25,6 +26,8 @@ export interface ChatItem {
   messages: Message[];
   historicalActivities: Record<string, any[]>;
   feedback: Record<string, 'up' | 'down'>;
+  project_id?: string | null;
+  _prevProjectId?: string | null;
 }
 
 export interface ChatsState {
@@ -226,6 +229,50 @@ const chatsSlice = createSlice({
       return initialState;
     },
   },
+  extraReducers: (builder) => {
+    builder
+      .addCase(assignThreadToProjectThunk.pending, (state, action) => {
+        const { threadId, projectId } = action.meta.arg;
+        const chat = state.chats.find((c) => c.id === threadId);
+        if (chat) {
+          chat._prevProjectId = chat.project_id ?? null;
+          chat.project_id = projectId;
+        }
+      })
+      .addCase(assignThreadToProjectThunk.rejected, (state, action) => {
+        const { threadId } = action.meta.arg;
+        const chat = state.chats.find((c) => c.id === threadId);
+        if (chat && chat._prevProjectId !== undefined) {
+          chat.project_id = chat._prevProjectId;
+          delete chat._prevProjectId;
+        }
+      })
+      .addCase(assignThreadToProjectThunk.fulfilled, (state, action) => {
+        const { threadId, projectId } = action.meta.arg;
+        const chat = state.chats.find((c) => c.id === threadId);
+        if (chat) {
+          chat.project_id = projectId;
+          delete chat._prevProjectId;
+        }
+      })
+      .addCase(unassignAllThreadsThunk.fulfilled, (state, action) => {
+        const { projectId } = action.payload;
+        for (const chat of state.chats) {
+          if (chat.project_id === projectId) {
+            chat.project_id = null;
+          }
+        }
+      })
+      .addCase(deleteProjectThunk.fulfilled, (state, action) => {
+        if (!action.payload.keepThreads && !action.payload.missing) return;
+        const { projectId } = action.payload;
+        for (const chat of state.chats) {
+          if (chat.project_id === projectId) {
+            chat.project_id = null;
+          }
+        }
+      });
+  },
 });
 
 export const {
@@ -269,6 +316,10 @@ export function selectThreadsListHydrated(state: { chats: ChatsState }) {
 
 export function selectChatsError(state: { chats: ChatsState }) {
   return state.chats.error;
+}
+
+export function selectChatsByProject(state: { chats: ChatsState }, projectId: string) {
+  return state.chats.chats.filter((c) => c.project_id === projectId);
 }
 
 export default chatsSlice.reducer;

--- a/src/frontend/redux/slices/chats.ts
+++ b/src/frontend/redux/slices/chats.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { Message } from '@langchain/langgraph-sdk';
 import type { SubAgentInfo, InterruptInfo, TaskStep } from '../../types/deep-agent';
 import { withMcpAppArguments } from '../../types/mcp-apps';
@@ -318,8 +318,9 @@ export function selectChatsError(state: { chats: ChatsState }) {
   return state.chats.error;
 }
 
-export function selectChatsByProject(state: { chats: ChatsState }, projectId: string) {
-  return state.chats.chats.filter((c) => c.project_id === projectId);
-}
+export const selectChatsByProject = createSelector(
+  [(state: { chats: ChatsState }) => state.chats.chats, (_state, projectId: string) => projectId],
+  (chats, projectId) => chats.filter((c) => c.project_id === projectId),
+);
 
 export default chatsSlice.reducer;

--- a/src/frontend/redux/slices/projects.test.ts
+++ b/src/frontend/redux/slices/projects.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import projectsReducer, {
+  createProjectThunk,
+  deleteProjectThunk,
+  loadProjectsThunk,
+  selectProjectById,
+  setProjects,
+  updateProjectThreadCount,
+  type ProjectsState,
+} from './projects';
+import type { Project } from '../../types/chat';
+
+vi.mock('../../services/projects-api', () => ({
+  getProjects: vi.fn(async () => []),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  assignThreadToProject: vi.fn(),
+  unassignAllThreadsFromProject: vi.fn(),
+}));
+
+function makeProject(id: string, overrides: Partial<Project> = {}): Project {
+  return {
+    project_id: id,
+    project_name: `Project ${id}`,
+    project_description: null,
+    username: 'u1',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+    thread_count: 0,
+    ...overrides,
+  };
+}
+
+function initialState(): ProjectsState {
+  return projectsReducer(undefined, { type: '@@INIT' });
+}
+
+describe('projects slice', () => {
+  it('setProjects replaces the list', () => {
+    const s = projectsReducer(initialState(), setProjects([makeProject('p1')]));
+    expect(s.projects).toHaveLength(1);
+  });
+
+  it('updateProjectThreadCount clamps at zero', () => {
+    let s = projectsReducer(initialState(), setProjects([makeProject('p1', { thread_count: 1 })]));
+    s = projectsReducer(s, updateProjectThreadCount({ projectId: 'p1', delta: -5 }));
+    expect(s.projects[0].thread_count).toBe(0);
+  });
+
+  it('selectProjectById finds a project', () => {
+    const state = { projects: projectsReducer(initialState(), setProjects([makeProject('p1')])) };
+    expect(selectProjectById(state, 'p1')?.project_name).toBe('Project p1');
+    expect(selectProjectById(state, 'missing')).toBeUndefined();
+  });
+
+  it('loadProjectsThunk.fulfilled stores projects', () => {
+    const s = projectsReducer(
+      { ...initialState(), isLoadingProjects: true },
+      { type: loadProjectsThunk.fulfilled.type, payload: [makeProject('p1')] },
+    );
+    expect(s.projects[0].project_id).toBe('p1');
+    expect(s.isLoadingProjects).toBe(false);
+  });
+
+  it('createProjectThunk.fulfilled prepends the project', () => {
+    const existing = makeProject('p0');
+    const created = makeProject('p1');
+    const s = projectsReducer(
+      { ...initialState(), projects: [existing] },
+      { type: createProjectThunk.fulfilled.type, payload: created },
+    );
+    expect(s.projects[0].project_id).toBe('p1');
+  });
+
+  it('deleteProjectThunk.fulfilled removes the project', () => {
+    const s = projectsReducer(
+      { ...initialState(), projects: [makeProject('p1')] },
+      { type: deleteProjectThunk.fulfilled.type, payload: { projectId: 'p1', deletedThreadIds: [] } },
+    );
+    expect(s.projects).toHaveLength(0);
+  });
+
+  it('unassignAllThreadsThunk.fulfilled zeros the thread count', () => {
+    const s = projectsReducer(
+      { ...initialState(), projects: [makeProject('p1', { thread_count: 3 })] },
+      {
+        type: 'projects/unassignAll/fulfilled',
+        payload: { projectId: 'p1' },
+      },
+    );
+    expect(s.projects[0].thread_count).toBe(0);
+  });
+});

--- a/src/frontend/redux/slices/projects.ts
+++ b/src/frontend/redux/slices/projects.ts
@@ -1,0 +1,143 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { Project } from '../../types/chat';
+import {
+  getProjects,
+  createProject,
+  updateProject as updateProjectApi,
+  deleteProject as deleteProjectApi,
+  assignThreadToProject as assignApi,
+  unassignAllThreadsFromProject as unassignAllApi,
+} from '../../services/projects-api';
+
+export interface ProjectsState {
+  projects: Project[];
+  isLoadingProjects: boolean;
+}
+
+const initialState: ProjectsState = {
+  projects: [],
+  isLoadingProjects: false,
+};
+
+export const loadProjectsThunk = createAsyncThunk(
+  'projects/load',
+  async () => getProjects(),
+);
+
+export const createProjectThunk = createAsyncThunk(
+  'projects/create',
+  async ({ name, description }: { name: string; description?: string }) =>
+    createProject(name, description),
+);
+
+export const updateProjectThunk = createAsyncThunk(
+  'projects/update',
+  async ({ projectId, name, description }: { projectId: string; name?: string; description?: string }) =>
+    updateProjectApi(projectId, name, description),
+);
+
+export const deleteProjectThunk = createAsyncThunk(
+  'projects/delete',
+  async ({ projectId, keepThreads = false }: { projectId: string; keepThreads?: boolean }) => {
+    const result = await deleteProjectApi(projectId, { keepThreads });
+    return {
+      projectId,
+      deletedThreadIds: result.deleted_thread_ids,
+      keepThreads,
+      missing: result.missing === true,
+    };
+  },
+);
+
+export const unassignAllThreadsThunk = createAsyncThunk(
+  'projects/unassignAll',
+  async (projectId: string) => {
+    await unassignAllApi(projectId);
+    return { projectId };
+  },
+);
+
+export const assignThreadToProjectThunk = createAsyncThunk(
+  'projects/assignThread',
+  async ({ threadId, projectId }: { threadId: string; projectId: string | null }) => {
+    await assignApi(threadId, projectId);
+    return { threadId, projectId };
+  },
+);
+
+const projectsSlice = createSlice({
+  name: 'projects',
+  initialState,
+  reducers: {
+    setProjects(state, action: PayloadAction<Project[]>) {
+      state.projects = action.payload;
+    },
+    updateProjectThreadCount(
+      state,
+      action: PayloadAction<{ projectId: string; delta: number }>,
+    ) {
+      const p = state.projects.find((pr) => pr.project_id === action.payload.projectId);
+      if (p) {
+        p.thread_count = Math.max(0, p.thread_count + action.payload.delta);
+      }
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(loadProjectsThunk.pending, (state) => {
+        state.isLoadingProjects = true;
+      })
+      .addCase(loadProjectsThunk.fulfilled, (state, action) => {
+        state.projects = action.payload;
+        state.isLoadingProjects = false;
+      })
+      .addCase(loadProjectsThunk.rejected, (state) => {
+        state.isLoadingProjects = false;
+      })
+
+      .addCase(createProjectThunk.fulfilled, (state, action) => {
+        state.projects.unshift(action.payload);
+      })
+
+      .addCase(updateProjectThunk.fulfilled, (state, action) => {
+        const idx = state.projects.findIndex(
+          (p) => p.project_id === action.payload.project_id,
+        );
+        if (idx !== -1) {
+          state.projects[idx] = action.payload;
+        }
+      })
+
+      .addCase(deleteProjectThunk.fulfilled, (state, action) => {
+        state.projects = state.projects.filter(
+          (p) => p.project_id !== action.payload.projectId,
+        );
+      })
+
+      .addCase(unassignAllThreadsThunk.fulfilled, (state, action) => {
+        const p = state.projects.find((pr) => pr.project_id === action.payload.projectId);
+        if (p) {
+          p.thread_count = 0;
+        }
+      });
+  },
+});
+
+export const { setProjects, updateProjectThreadCount } = projectsSlice.actions;
+
+export function selectAllProjects(state: { projects: ProjectsState }) {
+  return state.projects.projects;
+}
+
+export function selectProjectById(
+  state: { projects: ProjectsState },
+  projectId: string,
+) {
+  return state.projects.projects.find((p) => p.project_id === projectId);
+}
+
+export function selectProjectsLoading(state: { projects: ProjectsState }) {
+  return state.projects.isLoadingProjects;
+}
+
+export default projectsSlice.reducer;

--- a/src/frontend/redux/store.ts
+++ b/src/frontend/redux/store.ts
@@ -4,6 +4,7 @@ import configReducer from './slices/config';
 import personalizationReducer from './slices/personalization';
 import toastsReducer from './slices/toasts';
 import userSettingsReducer from './slices/userSettings';
+import projectsReducer from './slices/projects';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     personalization: personalizationReducer,
     toasts: toastsReducer,
     userSettings: userSettingsReducer,
+    projects: projectsReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/src/frontend/services/agent-rest.ts
+++ b/src/frontend/services/agent-rest.ts
@@ -8,6 +8,7 @@ export interface Thread {
   title?: string;
   messages: Message[];
   updatedAt?: string;
+  project_id?: string | null;
 }
 
 /**
@@ -182,6 +183,7 @@ export async function getAllThreadsByUserId(userId: string): Promise<Thread[]> {
       title: t.metadata?.thread_name,
       messages: [],
       updatedAt: t.updated_at || t.created_at,
+      project_id: t.metadata?.project_id ?? null,
     }));
 }
 

--- a/src/frontend/services/chatStorage.test.ts
+++ b/src/frontend/services/chatStorage.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { chatStorage } from './chatStorage';
+
+describe('chatStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not persist in-flight assign rollback state', () => {
+    chatStorage.saveChats([
+      {
+        id: 'c1',
+        title: 'Chat',
+        preview: '',
+        messages: [],
+        project_id: 'p1',
+        ...({ _prevProjectId: null } as { _prevProjectId: null }),
+      },
+    ]);
+
+    const raw = JSON.parse(localStorage.getItem('dataverse-ai-chats') ?? '[]');
+    expect(raw[0]._prevProjectId).toBeUndefined();
+    expect(chatStorage.loadChats()[0]).not.toHaveProperty('_prevProjectId');
+  });
+
+  it('strips _prevProjectId from chats already in localStorage', () => {
+    localStorage.setItem(
+      'dataverse-ai-chats',
+      JSON.stringify([
+        {
+          id: 'c1',
+          title: 'Chat',
+          preview: '',
+          messages: [],
+          project_id: 'p1',
+          _prevProjectId: null,
+        },
+      ]),
+    );
+    expect(chatStorage.loadChats()[0]).not.toHaveProperty('_prevProjectId');
+  });
+});

--- a/src/frontend/services/chatStorage.ts
+++ b/src/frontend/services/chatStorage.ts
@@ -1,6 +1,14 @@
 import { ChatItem } from '../types/chat';
 import { scopedStorageKey } from '../lib/app-paths';
 
+function omitPrevProjectId(chats: ChatItem[]): ChatItem[] {
+  return chats.map((chat) => {
+    const copy = { ...chat } as ChatItem & { _prevProjectId?: unknown };
+    delete copy._prevProjectId;
+    return copy;
+  });
+}
+
 class ChatStorageService {
   private readonly CHATS_STORAGE_KEY = scopedStorageKey('dataverse-ai-chats');
   private readonly MAX_CHATS = 50; // Limit to prevent localStorage bloat
@@ -10,7 +18,7 @@ class ChatStorageService {
    */
   saveChats(chats: ChatItem[]): boolean {
     try {
-      const limitedChats = chats.slice(0, this.MAX_CHATS);
+      const limitedChats = omitPrevProjectId(chats.slice(0, this.MAX_CHATS));
       localStorage.setItem(this.CHATS_STORAGE_KEY, JSON.stringify(limitedChats));
       return true;
     } catch (error) {
@@ -18,7 +26,9 @@ class ChatStorageService {
       
       // If storage is full, try to reduce and save again
       try {
-        const reducedChats = chats.slice(0, Math.floor(this.MAX_CHATS / 2));
+        const reducedChats = omitPrevProjectId(
+          chats.slice(0, Math.floor(this.MAX_CHATS / 2)),
+        );
         localStorage.setItem(this.CHATS_STORAGE_KEY, JSON.stringify(reducedChats));
         console.warn('localStorage was full, reduced chat history');
         return true;
@@ -60,7 +70,7 @@ class ChatStorageService {
       const parsedChats: ChatItem[] = JSON.parse(storedChats);
       
       // Validate and transform data
-      return parsedChats
+      return omitPrevProjectId(parsedChats)
         .filter(chat => chat.id && chat.title) // Filter invalid entries
         .map(chat => ({
           ...chat,

--- a/src/frontend/services/newChatTracker.ts
+++ b/src/frontend/services/newChatTracker.ts
@@ -12,3 +12,7 @@ export function markChatAsClientCreated(chatId: string): void {
 export function isClientCreatedChat(chatId: string): boolean {
   return clientCreatedIds.has(chatId);
 }
+
+export function unmarkChatAsClientCreated(chatId: string): void {
+  clientCreatedIds.delete(chatId);
+}

--- a/src/frontend/services/projects-api.test.ts
+++ b/src/frontend/services/projects-api.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./authenticated-fetch', () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../lib/app-paths', () => ({
+  buildAgentApiUrl: (path: string) => `/api/proxy/agent${path}`,
+}));
+
+import { authenticatedFetch } from './authenticated-fetch';
+import {
+  assignThreadToProject,
+  createProject,
+  deleteProject,
+  getProjects,
+  getThreadsByProject,
+  unassignAllThreadsFromProject,
+  updateProject,
+} from './projects-api';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('projects-api', () => {
+  beforeEach(() => {
+    vi.mocked(authenticatedFetch).mockReset();
+  });
+
+  it('getThreadsByProject maps project thread rows', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse([
+        {
+          thread_id: 'th1',
+          thread_title: 'Old chat',
+          project_id: 'p1',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      ]),
+    );
+    const threads = await getThreadsByProject('p1');
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects/p1/threads',
+    );
+    expect(threads).toEqual([
+      {
+        id: 'th1',
+        title: 'Old chat',
+        messages: [],
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        project_id: 'p1',
+      },
+    ]);
+  });
+
+  it('getProjects returns the projects array', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ projects: [{ project_id: 'p1', project_name: 'Alpha' }] }),
+    );
+    const projects = await getProjects();
+    expect(authenticatedFetch).toHaveBeenCalledWith('/api/proxy/agent/projects');
+    expect(projects[0].project_id).toBe('p1');
+  });
+
+  it('createProject posts name and description', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ project_id: 'p1', project_name: 'Alpha' }, 201),
+    );
+    await createProject('Alpha', 'desc');
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          project_name: 'Alpha',
+          project_description: 'desc',
+        }),
+      }),
+    );
+  });
+
+  it('createProject throws on 409', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(jsonResponse({}, 409));
+    await expect(createProject('Alpha')).rejects.toThrow(/already exists/);
+  });
+
+  it('updateProject sends a patch body', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ project_id: 'p1', project_name: 'Beta' }),
+    );
+    await updateProject('p1', 'Beta');
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects/p1',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  it('deleteProject treats 404 as empty deleted ids', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(new Response(null, { status: 404 }));
+    const result = await deleteProject('p1');
+    expect(result.deleted_thread_ids).toEqual([]);
+    expect(result.missing).toBe(true);
+  });
+
+  it('assignThreadToProject posts thread and project ids', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(jsonResponse({ status: 'success' }));
+    await assignThreadToProject('th1', 'p1');
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects/assign',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ thread_id: 'th1', project_id: 'p1' }),
+      }),
+    );
+  });
+
+  it('assignThreadToProject includes status on failure', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ detail: 'Thread not found' }, 404),
+    );
+    await expect(assignThreadToProject('th1', 'p1')).rejects.toThrow(
+      'Failed to assign thread: 404',
+    );
+  });
+
+  it('unassignAllThreadsFromProject posts to unassign-all', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({
+        status: 'success',
+        project_id: 'p1',
+        threads_unassigned: 2,
+        unassigned_thread_ids: ['t1', 't2'],
+      }),
+    );
+    const result = await unassignAllThreadsFromProject('p1');
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects/p1/unassign-all',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(result.threads_unassigned).toBe(2);
+    expect(result.unassigned_thread_ids).toEqual(['t1', 't2']);
+  });
+
+  it('deleteProject passes keep_threads when requested', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ deleted_thread_ids: [] }),
+    );
+    const result = await deleteProject('p1', { keepThreads: true });
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/projects/p1?keep_threads=true',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+    expect(result.deleted_thread_ids).toEqual([]);
+  });
+
+  it('deleteProject marks a successful delete as not missing', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      jsonResponse({ deleted_thread_ids: ['t1'] }),
+    );
+    const result = await deleteProject('p1');
+    expect(result.deleted_thread_ids).toEqual(['t1']);
+    expect(result.missing).toBe(false);
+  });
+});

--- a/src/frontend/services/projects-api.ts
+++ b/src/frontend/services/projects-api.ts
@@ -1,0 +1,156 @@
+import { authenticatedFetch } from './authenticated-fetch';
+import { buildAgentApiUrl } from '../lib/app-paths';
+import type { Project } from '../types/chat';
+import type { Thread } from './agent-rest';
+
+export interface ProjectListResponse {
+  projects: Project[];
+}
+
+export interface DeleteProjectResponse {
+  deleted_thread_ids: string[];
+  missing?: boolean;
+}
+
+export async function getProjects(): Promise<Project[]> {
+  const resp = await authenticatedFetch(buildAgentApiUrl('/projects'));
+  if (!resp.ok) {
+    throw new Error(`Failed to load projects: ${resp.status}`);
+  }
+  const data: ProjectListResponse = await resp.json();
+  return data.projects;
+}
+
+export async function createProject(
+  name: string,
+  description?: string,
+): Promise<Project> {
+  const resp = await authenticatedFetch(buildAgentApiUrl('/projects'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      project_name: name,
+      project_description: description ?? null,
+    }),
+  });
+  if (resp.status === 409) {
+    throw new Error('A project with that name already exists');
+  }
+  if (!resp.ok) {
+    throw new Error(`Failed to create project: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export async function updateProject(
+  projectId: string,
+  name?: string,
+  description?: string,
+): Promise<Project> {
+  const body: Record<string, unknown> = {};
+  if (name !== undefined) body.project_name = name;
+  if (description !== undefined) body.project_description = description;
+
+  const resp = await authenticatedFetch(
+    buildAgentApiUrl(`/projects/${projectId}`),
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+  if (resp.status === 409) {
+    throw new Error('A project with that name already exists');
+  }
+  if (!resp.ok) {
+    throw new Error(`Failed to update project: ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export interface UnassignAllResponse {
+  status: string;
+  message: string;
+  project_id: string;
+  threads_unassigned: number;
+  unassigned_thread_ids: string[];
+}
+
+export async function deleteProject(
+  projectId: string,
+  options?: { keepThreads?: boolean },
+): Promise<DeleteProjectResponse> {
+  const path = options?.keepThreads
+    ? `/projects/${projectId}?keep_threads=true`
+    : `/projects/${projectId}`;
+  const resp = await authenticatedFetch(
+    buildAgentApiUrl(path),
+    { method: 'DELETE' },
+  );
+  if (!resp.ok && resp.status !== 404) {
+    throw new Error(`Failed to delete project: ${resp.status}`);
+  }
+  if (resp.status === 404) {
+    return { deleted_thread_ids: [], missing: true };
+  }
+  const data = await resp.json();
+  return { deleted_thread_ids: data.deleted_thread_ids ?? [], missing: false };
+}
+
+export async function assignThreadToProject(
+  threadId: string,
+  projectId: string | null,
+): Promise<void> {
+  const resp = await authenticatedFetch(
+    buildAgentApiUrl('/projects/assign'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        thread_id: threadId,
+        project_id: projectId,
+      }),
+    },
+  );
+  if (!resp.ok) {
+    throw new Error(`Failed to assign thread: ${resp.status}`);
+  }
+}
+
+export async function getThreadsByProject(projectId: string): Promise<Thread[]> {
+  const resp = await authenticatedFetch(
+    buildAgentApiUrl(`/projects/${projectId}/threads`),
+  );
+  if (!resp.ok) {
+    throw new Error(`Failed to load project threads: ${resp.status}`);
+  }
+  const rows: unknown = await resp.json();
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .filter((t: { thread_id?: string }) => t.thread_id)
+    .map((t: {
+      thread_id: string;
+      thread_title?: string | null;
+      project_id?: string | null;
+      updated_at?: string;
+    }) => ({
+      id: t.thread_id,
+      title: t.thread_title ?? undefined,
+      messages: [],
+      updatedAt: t.updated_at,
+      project_id: t.project_id ?? projectId,
+    }));
+}
+
+export async function unassignAllThreadsFromProject(
+  projectId: string,
+): Promise<UnassignAllResponse> {
+  const resp = await authenticatedFetch(
+    buildAgentApiUrl(`/projects/${projectId}/unassign-all`),
+    { method: 'POST' },
+  );
+  if (!resp.ok) {
+    throw new Error(`Failed to unassign threads: ${resp.status}`);
+  }
+  return resp.json();
+}

--- a/src/frontend/test-utils/createTestStore.ts
+++ b/src/frontend/test-utils/createTestStore.ts
@@ -4,6 +4,7 @@ import configReducer from '../redux/slices/config';
 import personalizationReducer from '../redux/slices/personalization';
 import toastsReducer from '../redux/slices/toasts';
 import userSettingsReducer from '../redux/slices/userSettings';
+import projectsReducer from '../redux/slices/projects';
 
 export function createTestStore() {
   return configureStore({
@@ -13,6 +14,7 @@ export function createTestStore() {
       personalization: personalizationReducer,
       toasts: toastsReducer,
       userSettings: userSettingsReducer,
+      projects: projectsReducer,
     },
   });
 }

--- a/src/frontend/types/chat.ts
+++ b/src/frontend/types/chat.ts
@@ -9,6 +9,7 @@ export interface ChatItem {
   messages: Message[];
   historicalActivities?: Record<string, ProcessedEvent[]>;
   feedback?: Record<string, 'up' | 'down'>;
+  project_id?: string | null;
 }
 
 export interface ChatState {
@@ -35,4 +36,22 @@ export interface SidebarChatItem {
   title: string;
   timestamp: Date;
   preview: string;
+  project_id?: string | null;
+}
+
+export interface Project {
+  project_id: string;
+  project_name: string;
+  project_description: string | null;
+  username: string;
+  created_at: string;
+  updated_at: string;
+  thread_count: number;
+}
+
+export interface SidebarProject {
+  id: string;
+  name: string;
+  description: string | null;
+  threadCount: number;
 }

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -588,4 +588,32 @@ describe('POST /api/proxy/agent/v1/stream', () => {
     // The proxy must propagate the upstream 503 — not silently return 200
     expect(res.statusCode).toBe(503);
   });
+
+  it('forwards project_id into thread metadata without run configurable', async () => {
+    const agentSSE =
+      `event: messages/partial\ndata: [{"type":"ai","content":"Hello"}]\n\n`;
+    const mock = stubFetch(
+      okJson({ thread_id: 'th-proj' }),
+      makeSSEResponse(agentSSE),
+      okJson({ messages: [], tasks: [] }),
+    );
+
+    const server = await buildTestServer();
+    await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: {
+        message: 'hello',
+        thread_id: 'th-proj',
+        user_id: 'u1',
+        project_id: 'proj-1',
+      },
+    });
+
+    const threadBody = JSON.parse(mock.mock.calls[0][1].body as string);
+    expect(threadBody.metadata.project_id).toBe('proj-1');
+    expect(threadBody.ifExists).toBe('do_nothing');
+    const runBody = JSON.parse(mock.mock.calls[1][1].body as string);
+    expect(runBody.config.configurable?.project_id).toBeUndefined();
+  });
 });

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -616,4 +616,24 @@ describe('POST /api/proxy/agent/v1/stream', () => {
     const runBody = JSON.parse(mock.mock.calls[1][1].body as string);
     expect(runBody.config.configurable?.project_id).toBeUndefined();
   });
+
+  it('rejects non-string project_id without calling the agent', async () => {
+    const mock = stubFetch(okJson({}));
+
+    const server = await buildTestServer();
+    const res = await server.inject({
+      method: 'POST',
+      url: '/api/proxy/agent/v1/stream',
+      payload: {
+        message: 'hello',
+        thread_id: 'th-proj',
+        user_id: 'u1',
+        project_id: { foo: 1 },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('project_id must be a string when provided');
+    expect(mock).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -380,6 +380,10 @@ async function proxyRoutes(fastify: FastifyInstance) {
 
       const { message, thread_id, user_id, resume: isResume, memories, rules, project_id } = request.body;
 
+      if (project_id != null && typeof project_id !== 'string') {
+        return reply.status(400).send({ error: 'project_id must be a string when provided' });
+      }
+
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
         'X-Trace-ID': traceId,

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -45,6 +45,7 @@ interface StreamRequestBody {
   resume?: boolean;
   memories?: string[];
   rules?: string[];
+  project_id?: string | null;
 }
 
 /**
@@ -377,7 +378,7 @@ async function proxyRoutes(fastify: FastifyInstance) {
         return reply.status(401).send({ error: 'Not authenticated' });
       }
 
-      const { message, thread_id, user_id, resume: isResume, memories, rules } = request.body;
+      const { message, thread_id, user_id, resume: isResume, memories, rules, project_id } = request.body;
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -398,7 +399,10 @@ async function proxyRoutes(fastify: FastifyInstance) {
           headers,
           body: JSON.stringify({
             threadId: thread_id,
-            metadata: { user_identity: user_id ?? 'anonymous' },
+            metadata: {
+              user_identity: user_id ?? 'anonymous',
+              ...(project_id ? { project_id } : {}),
+            },
             ifExists: 'do_nothing',
           }),
           signal: AbortSignal.timeout(cfg.agent.timeout_ms),


### PR DESCRIPTION
## What

Add project folders in the sidebar and chat list so users can group conversations.

Fixes #160 

## How

- Sidebar folders: create/edit/delete (keep chats or delete them), DnD, add-to-project, unassign, unassign-all, project page at `/project/:projectId`.
- BFF `POST /threads` stamps `metadata.project_id` when present (`ifExists: do_nothing`). Run `configurable` is not given `project_id`. Resume streams do not send `project_id`.
- Never-sent (client-created) chats update Redux only; after the first successful stream, `POST /projects/assign` persists membership. Existing threads are fail-closed on assign errors.

Companion agent PR: https://github.com/redhat-data-and-ai/template-agent/pull/280

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

Vitest coverage for projects API, Redux, Sidebar, `useProjects`, `useStreamingAPI`, AppLayout hydration, BFF stamp. Manual: new folder, DnD, first message in a folder chat, delete keep vs purge, unassign-all, reload.

## Rollback

Revert the commit. No DB migration on the UI side.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)