### PR TITLE
fix: propagate mcp error logs

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -658,8 +658,9 @@ export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume
                               (toolCall as Record<string, unknown>).status === 'error' ? 'text-red-500 dark:text-red-400' : 'text-muted-foreground',
                             )}>
                               {(toolCall as Record<string, unknown>).status === 'error'
-                                ? (typeof (toolCall as Record<string, unknown>).content === 'string' && (toolCall as Record<string, unknown>).content
-                                  ? String((toolCall as Record<string, unknown>).content).replace(/^\[TOOL_ERROR]\s*/i, '').slice(0, 150)
+                                ? (typeof (toolCall as Record<string, unknown>).content === 'string'
+                                  && String((toolCall as Record<string, unknown>).content).replace(/^\[TOOL_ERROR]\s*/i, '').trim()
+                                  ? String((toolCall as Record<string, unknown>).content).replace(/^\[TOOL_ERROR]\s*/i, '').trim().slice(0, 150)
                                   : 'Tool execution failed')
                                 : 'Tool execution'}
                             </div>

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -657,7 +657,11 @@ export function AIMessageRenderer({ message, pendingInterrupt, onInterruptResume
                               "text-xs mt-0.5",
                               (toolCall as Record<string, unknown>).status === 'error' ? 'text-red-500 dark:text-red-400' : 'text-muted-foreground',
                             )}>
-                              {(toolCall as Record<string, unknown>).status === 'error' ? 'Tool execution failed' : 'Tool execution'}
+                              {(toolCall as Record<string, unknown>).status === 'error'
+                                ? (typeof (toolCall as Record<string, unknown>).content === 'string' && (toolCall as Record<string, unknown>).content
+                                  ? String((toolCall as Record<string, unknown>).content).replace(/^\[TOOL_ERROR]\s*/i, '').slice(0, 150)
+                                  : 'Tool execution failed')
+                                : 'Tool execution'}
                             </div>
                           </div>
                         </div>

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -721,7 +721,7 @@ export function useStreamingAPI(threadId: string) {
                 }
                 setWasInterrupted(true);
               } else {
-                dispatch(resolveAllPendingToolCalls({ chatId: threadId, status: 'error' }));
+                dispatch(resolveAllPendingToolCalls({ chatId: threadId, status: 'error', errorMessage: error.message }));
                 dispatch(
                   updateStreamingState({
                     chatId: threadId,
@@ -1087,7 +1087,7 @@ export function useStreamingAPI(threadId: string) {
           dispatch(updateStreamingState({ chatId: threadId, state: { pendingInterrupt: enrichInterrupt(interrupt) } }));
         },
         onError(error) {
-          dispatch(resolveAllPendingToolCalls({ chatId: threadId, status: 'error' }));
+          dispatch(resolveAllPendingToolCalls({ chatId: threadId, status: 'error', errorMessage: error.message }));
           resumeStreamHadError = true;
           // Queue decision to localStorage for replay when agent recovers
           let decisionQueued = false;

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -1222,7 +1222,7 @@ export function useStreamingAPI(threadId: string) {
             );
           },
           onError(error) {
-            dispatch(resolveAllPendingToolCalls({ chatId: threadId }));
+            dispatch(resolveAllPendingToolCalls({ chatId: threadId, status: 'error', errorMessage: error.message }));
             dispatch(
               updateStreamingState({
                 chatId: threadId,

--- a/src/frontend/redux/slices/chats.ts
+++ b/src/frontend/redux/slices/chats.ts
@@ -171,16 +171,17 @@ const chatsSlice = createSlice({
         }
       }
     },
-    resolveAllPendingToolCalls(state, action: PayloadAction<{ chatId: string; status?: string }>) {
+    resolveAllPendingToolCalls(state, action: PayloadAction<{ chatId: string; status?: string; errorMessage?: string }>) {
       const chat = state.chats.find((c) => c.id === action.payload.chatId);
       if (!chat) return;
       const terminalStatus = action.payload.status || 'error';
+      const fallbackContent = action.payload.errorMessage || '';
       for (const message of chat.messages) {
         const msg = message as Message & { tool_calls?: ToolCallRecord[] };
         if (!Array.isArray(msg.tool_calls)) continue;
         for (const tc of msg.tool_calls) {
           if (tc && tc.content == null) {
-            tc.content = '';
+            tc.content = fallbackContent;
             tc.status = terminalStatus;
           }
         }


### PR DESCRIPTION
## What

Display MCP error messages in the case of tool call failure, rather than crashing chat.

Fixes #163 

## How

Check for tool call error, then display error message in tool result

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)
