### PR TITLE
feat: add MCP OAuth settings tab for connect, re-auth, and disconnect

### DIFF
--- a/e2e/accessibility/wcag.spec.ts
+++ b/e2e/accessibility/wcag.spec.ts
@@ -7,7 +7,7 @@
  * Covers:
  *  - Home page (light + dark)
  *  - Chat page after a streamed response
- *  - Settings page — all 5 tab panels
+ *  - Settings page — all 6 tab panels
  */
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
@@ -115,7 +115,7 @@ test.describe('Chat page — WCAG 2.1 AA', () => {
 // active panel is in the visible DOM at a time.
 // ---------------------------------------------------------------------------
 
-const SETTINGS_TABS = ['Profile', 'Memories', 'Custom Rules', 'Appearance', 'Tool Approvals'] as const;
+const SETTINGS_TABS = ['Profile', 'Memories', 'Custom Rules', 'Appearance', 'Tool Approvals', 'MCP OAuth'] as const;
 
 test.describe('Settings page — WCAG 2.1 AA', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/helpers/config-mount.ts
+++ b/e2e/helpers/config-mount.ts
@@ -106,6 +106,14 @@ export async function mountConfig(
       body: '[]',
     }),
   );
+
+  await page.route('**/api/proxy/agent/mcp/oauth/connections', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ connections: [] }),
+    }),
+  );
 }
 
 /** Minimal config: only required fields populated, no logo, default colors. */

--- a/e2e/page-objects/SettingsPage.ts
+++ b/e2e/page-objects/SettingsPage.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
-type SettingsTab = 'Profile' | 'Memories' | 'Custom Rules' | 'Appearance' | 'Tool Approvals';
+type SettingsTab = 'Profile' | 'Memories' | 'Custom Rules' | 'Appearance' | 'Tool Approvals' | 'MCP OAuth';
 
 /** Page object for the settings view (`/settings`). */
 export class SettingsPage {

--- a/e2e/settings/settings-page.spec.ts
+++ b/e2e/settings/settings-page.spec.ts
@@ -63,6 +63,14 @@ test.describe('Settings page', () => {
     await settings.expectTabContentVisible('Memories');
   });
 
+  test('clicking MCP OAuth tab shows the OAuth connections section', async ({ page }) => {
+    const settings = new SettingsPage(page);
+    await settings.goto();
+    await settings.clickTab('MCP OAuth');
+    await settings.expectTabContentVisible('MCP OAuth');
+    await expect(page.getByText(/no oauth-connected services are configured/i)).toBeVisible();
+  });
+
   // ── Theme toggle + localStorage persistence ────────────────────────────────
 
   test('toggling the theme persists the selection to localStorage', async ({ page }) => {

--- a/src/frontend/components/InterruptBanner.tsx
+++ b/src/frontend/components/InterruptBanner.tsx
@@ -6,7 +6,11 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { Bot, CheckCircle, Link2, XCircle } from 'lucide-react';
-import { buildAgentApiUrl } from '../lib/app-paths';
+import {
+  openMcpOAuthPopup,
+  startMcpOAuthConnect,
+  verifyMcpOAuthConnected,
+} from '../services/mcp-oauth-api';
 import type { InterruptInfo } from '../types/deep-agent';
 
 interface InterruptBannerProps {
@@ -50,30 +54,6 @@ function parseMcpAuthPayload(interrupt: InterruptInfo): InterruptInfo['payload']
   return null;
 }
 
-const STATUS_RETRY_MS = 400;
-const STATUS_MAX_RETRIES = 6;
-
-async function verifyMcpConnected(mcpName: string): Promise<boolean> {
-  for (let attempt = 0; attempt < STATUS_MAX_RETRIES; attempt++) {
-    try {
-      const resp = await fetch(
-        buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpName)}/status`),
-        { credentials: 'include' },
-      );
-      if (resp.ok) {
-        const body = (await resp.json()) as { connected?: boolean };
-        if (body.connected) return true;
-      }
-    } catch {
-      // retry
-    }
-    if (attempt < STATUS_MAX_RETRIES - 1) {
-      await new Promise((resolve) => setTimeout(resolve, STATUS_RETRY_MS));
-    }
-  }
-  return false;
-}
-
 export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBannerProps) {
   const [response, setResponse] = useState('');
   const [oauthReady, setOauthReady] = useState(false);
@@ -84,7 +64,7 @@ export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBan
   const mcpAuth = parseMcpAuthPayload(interrupt);
 
   const verifyAndSetReady = useCallback(async (mcpName: string) => {
-    const connected = await verifyMcpConnected(mcpName);
+    const connected = await verifyMcpOAuthConnected(mcpName);
     if (connected) {
       setOauthReady(true);
       setConnectError(null);
@@ -123,25 +103,9 @@ export function InterruptBanner({ interrupt, onResume, onDismiss }: InterruptBan
     setConnecting(true);
     setConnectError(null);
     try {
-      const connectUrl = buildAgentApiUrl(`/mcp/${encodeURIComponent(mcpAuth.mcp_name)}/connect`);
-      const resp = await fetch(connectUrl, {
-        method: 'POST',
-        credentials: 'include',
-      });
-      if (!resp.ok) {
-        const text = await resp.text();
-        throw new Error(text || `Connect failed (${resp.status})`);
-      }
-      const body = (await resp.json()) as { authorize_url?: string };
-      if (!body.authorize_url) {
-        throw new Error('No authorize_url returned');
-      }
-      const authorizeUrl = new URL(body.authorize_url, window.location.origin);
-      setOauthOrigin(authorizeUrl.origin);
-      const popup = window.open(authorizeUrl.href, 'mcp-oauth', 'width=600,height=700');
-      if (!popup) {
-        throw new Error('Popup blocked by browser');
-      }
+      const { authorize_url } = await startMcpOAuthConnect(mcpAuth.mcp_name);
+      const { origin } = openMcpOAuthPopup(authorize_url);
+      setOauthOrigin(origin);
     } catch (err) {
       setConnectError(err instanceof Error ? err.message : 'Connect failed');
     } finally {

--- a/src/frontend/components/__tests__/accessibility.test.tsx
+++ b/src/frontend/components/__tests__/accessibility.test.tsx
@@ -89,7 +89,7 @@ describe('SettingsPage — accessibility', () => {
   it('tabs have role="tab" and aria-selected', () => {
     renderWithProviders(<SettingsPage />);
     const tabs = screen.getAllByRole('tab');
-    expect(tabs.length).toBe(5);
+    expect(tabs.length).toBe(6);
     const selectedTabs = tabs.filter((t) => t.getAttribute('aria-selected') === 'true');
     expect(selectedTabs.length).toBe(1);
   });
@@ -119,7 +119,7 @@ describe('SettingsPage — accessibility', () => {
     renderWithProviders(<SettingsPage />);
     const hiddenPanels = document
       .querySelectorAll('[role="tabpanel"][hidden]');
-    expect(hiddenPanels.length).toBe(4);
+    expect(hiddenPanels.length).toBe(5);
   });
 
   it('arrow-key navigation moves focus between tabs', async () => {

--- a/src/frontend/components/settings/OAuthConnections.test.tsx
+++ b/src/frontend/components/settings/OAuthConnections.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test-utils/render';
+import { OAuthConnections } from './OAuthConnections';
+import type { McpOAuthConnection } from '../../services/mcp-oauth-api';
+
+vi.mock('../../services/mcp-oauth-api', () => ({
+  fetchMcpOAuthConnections: vi.fn(),
+  disconnectMcpOAuth: vi.fn(),
+  startMcpOAuthConnect: vi.fn(),
+  verifyMcpOAuthConnected: vi.fn(),
+  openMcpOAuthPopup: vi.fn(),
+}));
+
+import {
+  disconnectMcpOAuth,
+  fetchMcpOAuthConnections,
+  openMcpOAuthPopup,
+  startMcpOAuthConnect,
+  verifyMcpOAuthConnected,
+} from '../../services/mcp-oauth-api';
+
+const connected: McpOAuthConnection = {
+  mcp_name: 'smartsheet-mcp',
+  auth_mode: 'oauth',
+  description: 'Smartsheet',
+  connected: true,
+};
+
+const disconnected: McpOAuthConnection = {
+  mcp_name: 'jira-mcp',
+  auth_mode: 'dcr',
+  description: 'Jira',
+  connected: false,
+};
+
+describe('OAuthConnections', () => {
+  beforeEach(() => {
+    vi.mocked(fetchMcpOAuthConnections).mockReset();
+    vi.mocked(disconnectMcpOAuth).mockReset();
+    vi.mocked(startMcpOAuthConnect).mockReset();
+    vi.mocked(openMcpOAuthPopup).mockReset();
+    vi.mocked(verifyMcpOAuthConnected).mockReset();
+  });
+
+  it('shows an empty state when no OAuth MCPs are configured', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockResolvedValue([]);
+    renderWithProviders(<OAuthConnections />);
+    expect(
+      await screen.findByText(/no oauth-connected services are configured/i),
+    ).toBeInTheDocument();
+  });
+
+  it('lists connected and disconnected MCPs with matching actions', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockResolvedValue([connected, disconnected]);
+    renderWithProviders(<OAuthConnections />);
+
+    expect(await screen.findByText('Smartsheet')).toBeInTheDocument();
+    expect(screen.getByText('Jira')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /disconnect smartsheet/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /re-authenticate smartsheet/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /authenticate jira/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /disconnect jira/i })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the MCP name when description is empty', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockResolvedValue([
+      { ...connected, description: '', mcp_name: 'plain-mcp' },
+    ]);
+    renderWithProviders(<OAuthConnections />);
+    expect(await screen.findByText('plain-mcp')).toBeInTheDocument();
+  });
+
+  it('disconnects an MCP and refreshes status', async () => {
+    vi.mocked(fetchMcpOAuthConnections)
+      .mockResolvedValueOnce([connected])
+      .mockResolvedValueOnce([{ ...connected, connected: false }]);
+    vi.mocked(disconnectMcpOAuth).mockResolvedValue({
+      mcp_name: 'smartsheet-mcp',
+      connected: false,
+    });
+
+    renderWithProviders(<OAuthConnections />);
+    await userEvent.click(await screen.findByRole('button', { name: /disconnect smartsheet/i }));
+
+    await waitFor(() => {
+      expect(disconnectMcpOAuth).toHaveBeenCalledWith('smartsheet-mcp');
+    });
+    expect(await screen.findByRole('button', { name: /authenticate smartsheet/i })).toBeInTheDocument();
+  });
+
+  it('starts OAuth popup when Authenticate is clicked', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockResolvedValue([disconnected]);
+    vi.mocked(startMcpOAuthConnect).mockResolvedValue({
+      authorize_url: 'https://oauth.example.com/auth',
+    });
+    vi.mocked(openMcpOAuthPopup).mockReturnValue({ origin: 'https://oauth.example.com' });
+
+    renderWithProviders(<OAuthConnections />);
+    await userEvent.click(await screen.findByRole('button', { name: /authenticate jira/i }));
+
+    await waitFor(() => {
+      expect(startMcpOAuthConnect).toHaveBeenCalledWith('jira-mcp');
+      expect(openMcpOAuthPopup).toHaveBeenCalledWith('https://oauth.example.com/auth');
+    });
+  });
+
+  it('refreshes status after mcp_oauth_done from the agent callback origin', async () => {
+    vi.mocked(fetchMcpOAuthConnections)
+      .mockResolvedValueOnce([disconnected])
+      .mockResolvedValue([{ ...disconnected, connected: true }]);
+    vi.mocked(startMcpOAuthConnect).mockResolvedValue({
+      authorize_url: 'https://oauth.example.com/auth',
+    });
+    vi.mocked(openMcpOAuthPopup).mockReturnValue({ origin: 'https://oauth.example.com' });
+    vi.mocked(verifyMcpOAuthConnected).mockResolvedValue(true);
+
+    renderWithProviders(<OAuthConnections />);
+    await userEvent.click(await screen.findByRole('button', { name: /authenticate jira/i }));
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: 'mcp_oauth_done', mcp_name: 'jira-mcp' },
+        origin: 'http://localhost:5002',
+      }),
+    );
+
+    expect(await screen.findByRole('button', { name: /disconnect jira/i })).toBeInTheDocument();
+  });
+
+  it('refreshes status when the window regains focus after starting auth', async () => {
+    vi.mocked(fetchMcpOAuthConnections)
+      .mockResolvedValueOnce([disconnected])
+      .mockResolvedValue([{ ...disconnected, connected: true }]);
+    vi.mocked(startMcpOAuthConnect).mockResolvedValue({
+      authorize_url: 'https://oauth.example.com/auth',
+    });
+    vi.mocked(openMcpOAuthPopup).mockReturnValue({ origin: 'https://oauth.example.com' });
+    vi.mocked(verifyMcpOAuthConnected).mockResolvedValue(true);
+
+    renderWithProviders(<OAuthConnections />);
+    await userEvent.click(await screen.findByRole('button', { name: /authenticate jira/i }));
+
+    fireEvent(window, new Event('focus'));
+
+    expect(await screen.findByRole('button', { name: /disconnect jira/i })).toBeInTheDocument();
+  });
+
+  it('shows an error when loading connections fails', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockRejectedValue(new Error('agent down'));
+    renderWithProviders(<OAuthConnections />);
+    expect(await screen.findByText(/agent down/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/settings/OAuthConnections.test.tsx
+++ b/src/frontend/components/settings/OAuthConnections.test.tsx
@@ -107,7 +107,7 @@ describe('OAuthConnections', () => {
     });
   });
 
-  it('refreshes status after mcp_oauth_done from the agent callback origin', async () => {
+  it('refreshes status after mcp_oauth_done from an allowed origin', async () => {
     vi.mocked(fetchMcpOAuthConnections)
       .mockResolvedValueOnce([disconnected])
       .mockResolvedValue([{ ...disconnected, connected: true }]);
@@ -124,11 +124,38 @@ describe('OAuthConnections', () => {
       window,
       new MessageEvent('message', {
         data: { type: 'mcp_oauth_done', mcp_name: 'jira-mcp' },
-        origin: 'http://localhost:5002',
+        origin: 'https://oauth.example.com',
       }),
     );
 
     expect(await screen.findByRole('button', { name: /disconnect jira/i })).toBeInTheDocument();
+  });
+
+  it('ignores mcp_oauth_done from an untrusted origin', async () => {
+    vi.mocked(fetchMcpOAuthConnections).mockResolvedValue([disconnected]);
+    vi.mocked(startMcpOAuthConnect).mockResolvedValue({
+      authorize_url: 'https://oauth.example.com/auth',
+    });
+    vi.mocked(openMcpOAuthPopup).mockReturnValue({ origin: 'https://oauth.example.com' });
+
+    renderWithProviders(<OAuthConnections />);
+    await userEvent.click(await screen.findByRole('button', { name: /authenticate jira/i }));
+    await waitFor(() => {
+      expect(openMcpOAuthPopup).toHaveBeenCalled();
+    });
+    vi.mocked(fetchMcpOAuthConnections).mockClear();
+
+    fireEvent(
+      window,
+      new MessageEvent('message', {
+        data: { type: 'mcp_oauth_done', mcp_name: 'jira-mcp' },
+        origin: 'https://evil.example.com',
+      }),
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchMcpOAuthConnections).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /disconnect jira/i })).not.toBeInTheDocument();
   });
 
   it('refreshes status when the window regains focus after starting auth', async () => {

--- a/src/frontend/components/settings/OAuthConnections.tsx
+++ b/src/frontend/components/settings/OAuthConnections.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, Spinner } from '@patternfly/react-core';
+import { KeyRound, Link2, Unplug } from 'lucide-react';
+import { useAppDispatch } from '../../redux/hooks';
+import { addToast } from '../../redux/slices/toasts';
+import {
+  disconnectMcpOAuth,
+  fetchMcpOAuthConnections,
+  openMcpOAuthPopup,
+  startMcpOAuthConnect,
+  type McpOAuthConnection,
+} from '../../services/mcp-oauth-api';
+
+function displayName(connection: McpOAuthConnection): string {
+  const description = (connection.description ?? '').trim();
+  return description || connection.mcp_name;
+}
+
+export function OAuthConnections() {
+  const dispatch = useAppDispatch();
+  const [connections, setConnections] = useState<McpOAuthConnection[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyMcp, setBusyMcp] = useState<string | null>(null);
+  const [oauthOrigin, setOauthOrigin] = useState<string | null>(null);
+  const pendingMcpRef = useRef<string | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const refreshingRef = useRef(false);
+
+  const clearPoll = useCallback(() => {
+    if (pollRef.current != null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      setError(null);
+      const rows = await fetchMcpOAuthConnections();
+      setConnections(rows);
+      return rows;
+    } catch (err) {
+      setConnections(null);
+      setError(err instanceof Error ? err.message : 'Failed to load OAuth connections');
+      return [];
+    }
+  }, []);
+
+  const refreshAfterAuth = useCallback(
+    async (mcpName: string) => {
+      if (refreshingRef.current || pendingMcpRef.current !== mcpName) return;
+      refreshingRef.current = true;
+      try {
+        const rows = await load();
+        const nowConnected = rows.some((row) => row.mcp_name === mcpName && row.connected);
+        if (nowConnected) {
+          pendingMcpRef.current = null;
+          clearPoll();
+          dispatch(addToast({ title: `${mcpName} connected`, variant: 'success' }));
+        }
+      } finally {
+        refreshingRef.current = false;
+      }
+    },
+    [clearPoll, dispatch, load],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const data = event.data as { type?: string; mcp_name?: string } | null;
+      if (data?.type !== 'mcp_oauth_done' || !data.mcp_name) return;
+      const pending = pendingMcpRef.current;
+      const allowedOrigins = [window.location.origin, oauthOrigin].filter(Boolean);
+      const originOk =
+        allowedOrigins.includes(event.origin) || pending === data.mcp_name;
+      if (!originOk) return;
+      void refreshAfterAuth(data.mcp_name);
+    };
+
+    const onFocus = () => {
+      if (pendingMcpRef.current) {
+        void refreshAfterAuth(pendingMcpRef.current);
+      }
+    };
+
+    window.addEventListener('message', handler);
+    window.addEventListener('focus', onFocus);
+    return () => {
+      window.removeEventListener('message', handler);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, [oauthOrigin, refreshAfterAuth]);
+
+  useEffect(() => () => clearPoll(), [clearPoll]);
+
+  const handleAuthenticate = async (mcpName: string) => {
+    setBusyMcp(mcpName);
+    setOauthOrigin(null);
+    try {
+      const { authorize_url } = await startMcpOAuthConnect(mcpName);
+      const { origin, popup } = openMcpOAuthPopup(authorize_url);
+      pendingMcpRef.current = mcpName;
+      setOauthOrigin(origin);
+      clearPoll();
+      if (popup) {
+        pollRef.current = window.setInterval(() => {
+          if (!popup.closed) return;
+          clearPoll();
+          if (pendingMcpRef.current) {
+            void refreshAfterAuth(pendingMcpRef.current);
+          }
+        }, 500);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Connect failed';
+      setError(message);
+      dispatch(addToast({ title: message, variant: 'danger' }));
+    } finally {
+      setBusyMcp(null);
+    }
+  };
+
+  const handleDisconnect = async (connection: McpOAuthConnection) => {
+    setBusyMcp(connection.mcp_name);
+    try {
+      await disconnectMcpOAuth(connection.mcp_name);
+      dispatch(
+        addToast({
+          title: `Disconnected ${displayName(connection)}`,
+          variant: 'success',
+        }),
+      );
+      await load();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Disconnect failed';
+      setError(message);
+      dispatch(addToast({ title: message, variant: 'danger' }));
+    } finally {
+      setBusyMcp(null);
+    }
+  };
+
+  if (connections === null && !error) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+        <Spinner size="sm" aria-label="Loading OAuth connections" />
+        Loading OAuth connections…
+      </div>
+    );
+  }
+
+  if (error && connections === null) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-destructive">{error}</p>
+        <Button variant="secondary" size="sm" onClick={() => void load()}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (!connections || connections.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 gap-3 text-center">
+        <KeyRound className="w-8 h-8 text-muted-foreground/40" aria-hidden="true" />
+        <p className="text-sm text-muted-foreground">
+          No OAuth-connected services are configured.
+        </p>
+        <p className="text-xs text-muted-foreground max-w-xs">
+          MCP servers that use OAuth or DCR will appear here so you can connect, re-authenticate,
+          or disconnect them.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Manage OAuth connections for MCP servers. Disconnecting clears tokens stored for this
+        agent; you can authenticate again at any time.
+      </p>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <ul className="space-y-3">
+        {connections.map((connection) => {
+          const name = displayName(connection);
+          const busy = busyMcp === connection.mcp_name;
+          return (
+            <li
+              key={connection.mcp_name}
+              className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border border-border bg-muted/30 px-3 py-3"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-foreground break-words">{name}</p>
+                <div className="flex items-center gap-2 flex-wrap mt-1.5">
+                  <span className="inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {connection.auth_mode}
+                  </span>
+                  <span
+                    className={
+                      connection.connected
+                        ? 'inline-flex items-center rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success'
+                        : 'inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
+                    }
+                  >
+                    {connection.connected ? 'Connected' : 'Not connected'}
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 sm:justify-end">
+                {connection.connected ? (
+                  <>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      icon={<Link2 className="w-3.5 h-3.5" />}
+                      isLoading={busy}
+                      aria-label={`Re-authenticate ${name}`}
+                      onClick={() => void handleAuthenticate(connection.mcp_name)}
+                    >
+                      Re-authenticate
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      icon={<Unplug className="w-3.5 h-3.5" />}
+                      isLoading={busy}
+                      aria-label={`Disconnect ${name}`}
+                      onClick={() => void handleDisconnect(connection)}
+                    >
+                      Disconnect
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    icon={<Link2 className="w-3.5 h-3.5" />}
+                    isLoading={busy}
+                    aria-label={`Authenticate ${name}`}
+                    onClick={() => void handleAuthenticate(connection.mcp_name)}
+                  >
+                    Authenticate
+                  </Button>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/frontend/components/settings/OAuthConnections.tsx
+++ b/src/frontend/components/settings/OAuthConnections.tsx
@@ -73,11 +73,8 @@ export function OAuthConnections() {
     const handler = (event: MessageEvent) => {
       const data = event.data as { type?: string; mcp_name?: string } | null;
       if (data?.type !== 'mcp_oauth_done' || !data.mcp_name) return;
-      const pending = pendingMcpRef.current;
       const allowedOrigins = [window.location.origin, oauthOrigin].filter(Boolean);
-      const originOk =
-        allowedOrigins.includes(event.origin) || pending === data.mcp_name;
-      if (!originOk) return;
+      if (!allowedOrigins.includes(event.origin)) return;
       void refreshAfterAuth(data.mcp_name);
     };
 

--- a/src/frontend/pages/SettingsPage.tsx
+++ b/src/frontend/pages/SettingsPage.tsx
@@ -1,15 +1,16 @@
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
-import { ArrowLeft, User, Brain, ScrollText, Palette, ShieldCheck } from 'lucide-react';
+import { ArrowLeft, User, Brain, ScrollText, Palette, ShieldCheck, KeyRound } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProfileSection } from '../components/settings/ProfileSection';
 import { MemoryList } from '../components/settings/MemoryList';
 import { RulesEditor } from '../components/settings/RulesEditor';
 import { AppearanceSettings } from '../components/settings/AppearanceSettings';
 import { AlwaysAllowedTools } from '../components/settings/AlwaysAllowedTools';
+import { OAuthConnections } from '../components/settings/OAuthConnections';
 
-type TabId = 'profile' | 'memories' | 'rules' | 'appearance' | 'tool-approvals';
+type TabId = 'profile' | 'memories' | 'rules' | 'appearance' | 'tool-approvals' | 'oauth';
 
 const TABS: { id: TabId; label: string; icon: typeof User }[] = [
   { id: 'profile', label: 'Profile', icon: User },
@@ -17,6 +18,7 @@ const TABS: { id: TabId; label: string; icon: typeof User }[] = [
   { id: 'rules', label: 'Custom Rules', icon: ScrollText },
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'tool-approvals', label: 'Tool Approvals', icon: ShieldCheck },
+  { id: 'oauth', label: 'MCP OAuth', icon: KeyRound },
 ];
 
 const TAB_CONTENT: Record<TabId, React.FC> = {
@@ -25,6 +27,7 @@ const TAB_CONTENT: Record<TabId, React.FC> = {
   rules: RulesEditor,
   appearance: AppearanceSettings,
   'tool-approvals': AlwaysAllowedTools,
+  oauth: OAuthConnections,
 };
 
 export function SettingsPage() {

--- a/src/frontend/services/mcp-oauth-api.test.ts
+++ b/src/frontend/services/mcp-oauth-api.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./authenticated-fetch', () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../lib/app-paths', () => ({
+  buildAgentApiUrl: (path: string) => `/api/proxy/agent${path}`,
+}));
+
+import { authenticatedFetch } from './authenticated-fetch';
+import {
+  disconnectMcpOAuth,
+  fetchMcpOAuthConnections,
+  startMcpOAuthConnect,
+  verifyMcpOAuthConnected,
+} from './mcp-oauth-api';
+
+describe('mcp-oauth-api', () => {
+  beforeEach(() => {
+    vi.mocked(authenticatedFetch).mockReset();
+  });
+
+  it('fetchMcpOAuthConnections GETs the connections list', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          connections: [
+            {
+              mcp_name: 'smartsheet-mcp',
+              auth_mode: 'oauth',
+              description: 'Smartsheet',
+              connected: true,
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const result = await fetchMcpOAuthConnections();
+
+    expect(authenticatedFetch).toHaveBeenCalledWith('/api/proxy/agent/mcp/oauth/connections', {
+      method: 'GET',
+    });
+    expect(result).toEqual([
+      {
+        mcp_name: 'smartsheet-mcp',
+        auth_mode: 'oauth',
+        description: 'Smartsheet',
+        connected: true,
+      },
+    ]);
+  });
+
+  it('fetchMcpOAuthConnections rejects non-OK responses', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response('boom', { status: 502 }),
+    );
+
+    await expect(fetchMcpOAuthConnections()).rejects.toThrow(/boom/);
+  });
+
+  it('disconnectMcpOAuth DELETEs the per-MCP disconnect route', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ mcp_name: 'smartsheet-mcp', connected: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await disconnectMcpOAuth('smartsheet-mcp');
+
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/mcp/smartsheet-mcp/disconnect',
+      { method: 'DELETE' },
+    );
+    expect(result).toEqual({ mcp_name: 'smartsheet-mcp', connected: false });
+  });
+
+  it('startMcpOAuthConnect POSTs connect and returns authorize_url', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ authorize_url: 'https://oauth.example.com/auth' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await startMcpOAuthConnect('smartsheet-mcp');
+
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/mcp/smartsheet-mcp/connect',
+      { method: 'POST' },
+    );
+    expect(result.authorize_url).toBe('https://oauth.example.com/auth');
+  });
+
+  it('startMcpOAuthConnect rejects a response without authorize_url', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(startMcpOAuthConnect('smartsheet-mcp')).rejects.toThrow(/authorize_url/);
+  });
+
+  it('verifyMcpOAuthConnected returns true when status is connected', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ connected: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(verifyMcpOAuthConnected('smartsheet-mcp')).resolves.toBe(true);
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/mcp/smartsheet-mcp/status',
+      { method: 'GET' },
+    );
+  });
+
+  it('verifyMcpOAuthConnected does not retry after a rate-limit error', async () => {
+    vi.mocked(authenticatedFetch).mockRejectedValue(
+      new Error('Rate limited. Retry after 5000ms'),
+    );
+
+    await expect(verifyMcpOAuthConnected('smartsheet-mcp')).resolves.toBe(false);
+    expect(authenticatedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('encodes MCP names in path segments', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ connected: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await disconnectMcpOAuth('sheet mcp');
+
+    expect(authenticatedFetch).toHaveBeenCalledWith(
+      '/api/proxy/agent/mcp/sheet%20mcp/disconnect',
+      { method: 'DELETE' },
+    );
+  });
+});

--- a/src/frontend/services/mcp-oauth-api.test.ts
+++ b/src/frontend/services/mcp-oauth-api.test.ts
@@ -12,6 +12,7 @@ import { authenticatedFetch } from './authenticated-fetch';
 import {
   disconnectMcpOAuth,
   fetchMcpOAuthConnections,
+  openMcpOAuthPopup,
   startMcpOAuthConnect,
   verifyMcpOAuthConnected,
 } from './mcp-oauth-api';
@@ -121,6 +122,18 @@ describe('mcp-oauth-api', () => {
     );
   });
 
+  it('verifyMcpOAuthConnected returns false after a single disconnected status', async () => {
+    vi.mocked(authenticatedFetch).mockResolvedValue(
+      new Response(JSON.stringify({ connected: false }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(verifyMcpOAuthConnected('smartsheet-mcp')).resolves.toBe(false);
+    expect(authenticatedFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('verifyMcpOAuthConnected does not retry after a rate-limit error', async () => {
     vi.mocked(authenticatedFetch).mockRejectedValue(
       new Error('Rate limited. Retry after 5000ms'),
@@ -144,5 +157,51 @@ describe('mcp-oauth-api', () => {
       '/api/proxy/agent/mcp/sheet%20mcp/disconnect',
       { method: 'DELETE' },
     );
+  });
+});
+
+describe('openMcpOAuthPopup', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(window);
+    openSpy.mockClear();
+  });
+
+  it('opens https authorization URLs', () => {
+    const result = openMcpOAuthPopup('https://oauth.example.com/auth');
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://oauth.example.com/auth',
+      'mcp-oauth',
+      'width=600,height=700',
+    );
+    expect(result.origin).toBe('https://oauth.example.com');
+  });
+
+  it('opens http URLs on localhost', () => {
+    openMcpOAuthPopup('http://localhost:8080/auth');
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens http URLs on 127.0.0.1', () => {
+    openMcpOAuthPopup('http://127.0.0.1:9000/auth');
+    expect(openSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects javascript URLs without opening a popup', () => {
+    expect(() => openMcpOAuthPopup('javascript:alert(1)')).toThrow(/invalid authorization url/i);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects data URLs without opening a popup', () => {
+    expect(() => openMcpOAuthPopup('data:text/html,hi')).toThrow(/invalid authorization url/i);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-local http URLs without opening a popup', () => {
+    expect(() => openMcpOAuthPopup('http://evil.example.com/auth')).toThrow(
+      /invalid authorization url/i,
+    );
+    expect(openSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/services/mcp-oauth-api.ts
+++ b/src/frontend/services/mcp-oauth-api.ts
@@ -1,0 +1,103 @@
+/**
+ * Browser client for per-user MCP OAuth/DCR connect, status, and disconnect.
+ *
+ * Calls go UI BFF → template-agent. Tokens stay server-side.
+ */
+
+import { authenticatedFetch } from './authenticated-fetch';
+import { buildAgentApiUrl } from '../lib/app-paths';
+
+export interface McpOAuthConnection {
+  mcp_name: string;
+  auth_mode: string;
+  description: string;
+  connected: boolean;
+}
+
+export interface McpOAuthDisconnectResult {
+  mcp_name: string;
+  connected: boolean;
+}
+
+const STATUS_RETRY_MS = 400;
+const STATUS_MAX_RETRIES = 6;
+
+function mcpOAuthPath(mcpName: string, suffix: string): string {
+  return `/mcp/${encodeURIComponent(mcpName)}${suffix}`;
+}
+
+async function mcpOAuthJson<T>(
+  path: string,
+  init: RequestInit,
+  errorLabel: string,
+): Promise<T> {
+  const response = await authenticatedFetch(buildAgentApiUrl(path), init);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `${errorLabel} failed (${response.status})`);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchMcpOAuthConnections(): Promise<McpOAuthConnection[]> {
+  const body = await mcpOAuthJson<{ connections?: McpOAuthConnection[] }>(
+    '/mcp/oauth/connections',
+    { method: 'GET' },
+    'List MCP OAuth connections',
+  );
+  return Array.isArray(body.connections) ? body.connections : [];
+}
+
+export async function disconnectMcpOAuth(
+  mcpName: string,
+): Promise<McpOAuthDisconnectResult> {
+  return mcpOAuthJson<McpOAuthDisconnectResult>(
+    mcpOAuthPath(mcpName, '/disconnect'),
+    { method: 'DELETE' },
+    'Disconnect MCP OAuth',
+  );
+}
+
+export async function startMcpOAuthConnect(
+  mcpName: string,
+): Promise<{ authorize_url: string }> {
+  const body = await mcpOAuthJson<{ authorize_url?: string }>(
+    mcpOAuthPath(mcpName, '/connect'),
+    { method: 'POST' },
+    'Connect',
+  );
+  if (!body.authorize_url) {
+    throw new Error('No authorize_url returned');
+  }
+  return { authorize_url: body.authorize_url };
+}
+
+export async function verifyMcpOAuthConnected(mcpName: string): Promise<boolean> {
+  for (let attempt = 0; attempt < STATUS_MAX_RETRIES; attempt++) {
+    try {
+      const body = await mcpOAuthJson<{ connected?: boolean }>(
+        mcpOAuthPath(mcpName, '/status'),
+        { method: 'GET' },
+        'MCP OAuth status',
+      );
+      if (body.connected) return true;
+    } catch (err) {
+      if (err instanceof Error && /rate limited/i.test(err.message)) {
+        return false;
+      }
+    }
+    if (attempt < STATUS_MAX_RETRIES - 1) {
+      await new Promise((resolve) => setTimeout(resolve, STATUS_RETRY_MS));
+    }
+  }
+  return false;
+}
+
+export function openMcpOAuthPopup(authorizeUrl: string): { origin: string; popup: Window } {
+  const url = new URL(authorizeUrl, window.location.origin);
+  const popup = window.open(url.href, 'mcp-oauth', 'width=600,height=700');
+  if (!popup) {
+    throw new Error('Popup blocked by browser');
+  }
+  return { origin: url.origin, popup };
+}

--- a/src/frontend/services/mcp-oauth-api.ts
+++ b/src/frontend/services/mcp-oauth-api.ts
@@ -19,9 +19,6 @@ export interface McpOAuthDisconnectResult {
   connected: boolean;
 }
 
-const STATUS_RETRY_MS = 400;
-const STATUS_MAX_RETRIES = 6;
-
 function mcpOAuthPath(mcpName: string, suffix: string): string {
   return `/mcp/${encodeURIComponent(mcpName)}${suffix}`;
 }
@@ -73,28 +70,34 @@ export async function startMcpOAuthConnect(
 }
 
 export async function verifyMcpOAuthConnected(mcpName: string): Promise<boolean> {
-  for (let attempt = 0; attempt < STATUS_MAX_RETRIES; attempt++) {
-    try {
-      const body = await mcpOAuthJson<{ connected?: boolean }>(
-        mcpOAuthPath(mcpName, '/status'),
-        { method: 'GET' },
-        'MCP OAuth status',
-      );
-      if (body.connected) return true;
-    } catch (err) {
-      if (err instanceof Error && /rate limited/i.test(err.message)) {
-        return false;
-      }
-    }
-    if (attempt < STATUS_MAX_RETRIES - 1) {
-      await new Promise((resolve) => setTimeout(resolve, STATUS_RETRY_MS));
-    }
+  try {
+    const body = await mcpOAuthJson<{ connected?: boolean }>(
+      mcpOAuthPath(mcpName, '/status'),
+      { method: 'GET' },
+      'MCP OAuth status',
+    );
+    return Boolean(body.connected);
+  } catch {
+    return false;
   }
-  return false;
+}
+
+function isAllowedAuthorizeUrl(url: URL): boolean {
+  if (url.protocol === 'https:') {
+    return true;
+  }
+  if (url.protocol !== 'http:') {
+    return false;
+  }
+  const host = url.hostname.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1';
 }
 
 export function openMcpOAuthPopup(authorizeUrl: string): { origin: string; popup: Window } {
   const url = new URL(authorizeUrl, window.location.origin);
+  if (!isAllowedAuthorizeUrl(url)) {
+    throw new Error('Invalid authorization URL');
+  }
   const popup = window.open(url.href, 'mcp-oauth', 'width=600,height=700');
   if (!popup) {
     throw new Error('Popup blocked by browser');


### PR DESCRIPTION
## What

Add a Settings **MCP OAuth** tab so users can see connection status and authenticate, re-authenticate, or disconnect without starting a chat.

Fixes redhat-data-and-ai/template-agent#286

## How

- New Settings tab lists interactive OAuth/DCR MCPs from `GET /mcp/oauth/connections`.
- Each row: description on top (wraps; falls back to MCP name), type + status badges below, actions on the right.
- Disconnected: **Authenticate**. Connected: **Re-authenticate** + **Disconnect**.
- Reuse the existing connect popup (`POST /mcp/{name}/connect`). After auth, refresh once via `postMessage`, window focus, or popup close. Do not poll `/status` in a loop (that hits the BFF 100 req/min limit).
- Empty state when no OAuth/DCR MCPs are configured.

Companion agent PR: `redhat-data-and-ai/template-agent` branch `feat/settings-mcp-oauth-connections`.

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)
  - Settings lists OAuth/DCR MCPs with current-user status
  - Authenticate / Re-authenticate completes the popup and shows Connected
  - Disconnect clears the token and the row shows Not connected
  - Long descriptions wrap
  - Auth refresh does not 429 the BFF

## Rollback

Revert the commit.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)