### PR TITLE
fix(ci): restore deployment.zip artifact name

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -76,7 +76,7 @@ jobs:
             VERSION="${GITHUB_REF#refs/heads/}-${GITHUB_SHA::7}"
           fi
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "package_name=ui-deployment.zip" >> $GITHUB_OUTPUT
+          echo "package_name=deployment.zip" >> $GITHUB_OUTPUT
 
       - name: Build image locally for scanning
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
@@ -321,7 +321,7 @@ jobs:
 
             | File | Description |
             |------|-------------|
-            | `ui-deployment.zip` | Deployment manifests with release metadata |
+            | `deployment.zip` | Deployment manifests with release metadata |
             | `sbom.cdx.json` | CycloneDX software bill of materials |
             | `trivy-report.json` | Vulnerability scan results |
             | `SHA256SUMS.txt` | SHA-256 checksums for all release artifacts |


### PR DESCRIPTION
## Summary
- Restores the release artifact name from `ui-deployment.zip` back to `deployment.zip`
- The rename was introduced in PR #76 (deep-agent merge) via commit `0e4b8bf`, causing regressions from `dev-1.0.3` onward
- Updates both the package_name output variable and the release notes table in `build-base-image.yml`

## Test plan
- [ ] Verify next release produces `deployment.zip` instead of `ui-deployment.zip`
- [ ] Confirm release notes table shows `deployment.zip`
- [ ] Validate downstream consumers work with restored artifact name

🤖 Generated with [Claude Code](https://claude.com/claude-code)