### PR TITLE
feat: add AI output warning and AI generated labels

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -118,7 +118,7 @@ function getCopyableAiMessageText(content: unknown): string {
   const body = thinkingText
     ? [thinkingText, main].filter((s) => s.length > 0).join('\n\n')
     : main;
-  if (!body) return body;
+  if (!body?.trim()) return '';
   return `${body}\n\n[AI-generated]`;
 }
 

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -115,8 +115,11 @@ function getCopyableAiMessageText(content: unknown): string {
   const { thinkingText, markdownForDisplay } = partitionMessageContent(content);
   const main =
     markdownForDisplay.length > 0 ? markdownForDisplay : extractMessageText(content);
-  if (!thinkingText) return main;
-  return [thinkingText, main].filter((s) => s.length > 0).join('\n\n');
+  const body = thinkingText
+    ? [thinkingText, main].filter((s) => s.length > 0).join('\n\n')
+    : main;
+  if (!body) return body;
+  return `${body}\n\n[AI-generated]`;
 }
 
 type MdComponentProps = {
@@ -1060,18 +1063,24 @@ export function ChatMessagesView({
                     allDecisionsMade={globalAllDecisionsMade}
                     onSingleDecision={handleGlobalSingleDecision}
                   />
-                  {isLastAiInTurn && (
-                    <div className="pl-11 flex items-center gap-0.5 mt-1">
-                      <MessageCopyButton text={copyText} />
-                      <FeedbackButtons
-                        messageId={message.id ?? `msg-${messageIndex}`}
-                        chatId={chatId}
-                        traceId={traceId}
-                        userId={userId}
-                        existingFeedback={messageFeedback[message.id ?? `msg-${messageIndex}`] ?? null}
-                      />
-                    </div>
-                  )}
+                  <div className="pl-11 flex items-center gap-0.5 mt-1">
+                    {isLastAiInTurn && (
+                      <>
+                        <MessageCopyButton text={copyText} />
+                        <FeedbackButtons
+                          messageId={message.id ?? `msg-${messageIndex}`}
+                          chatId={chatId}
+                          traceId={traceId}
+                          userId={userId}
+                          existingFeedback={messageFeedback[message.id ?? `msg-${messageIndex}`] ?? null}
+                        />
+                      </>
+                    )}
+                    <span className="inline-flex items-center gap-1 ml-2 text-[11px] text-muted-foreground" aria-label="AI-generated content">
+                      <Bot className="w-2.5 h-2.5" aria-hidden="true" />
+                      AI-generated
+                    </span>
+                  </div>
                   {showResponseTiming && (
                     <div aria-hidden="true" className="pl-11 mt-1 space-y-0.5 text-muted-foreground">
                       <div className="text-[11px] text-muted-foreground">

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -932,8 +932,9 @@ export function ChatMessagesView({
     if (!wasLoading || isLoading) return;
     const lastAiMessage = [...messages].reverse().find((m) => m.type === 'ai');
     if (!lastAiMessage) return;
-    const text = getCopyableAiMessageText(lastAiMessage.content);
-    if (!text) return;
+    const { markdownForDisplay } = partitionMessageContent(lastAiMessage.content);
+    const text = markdownForDisplay || extractMessageText(lastAiMessage.content);
+    if (!text?.trim()) return;
     setSrAnnouncement('');
     const id = setTimeout(() => setSrAnnouncement(text), 50);
     return () => clearTimeout(id);

--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -113,8 +113,7 @@ function partitionMessageContent(content: unknown): { thinkingText: string; mark
 
 function getCopyableAiMessageText(content: unknown): string {
   const { thinkingText, markdownForDisplay } = partitionMessageContent(content);
-  const main =
-    markdownForDisplay.length > 0 ? markdownForDisplay : extractMessageText(content);
+  const main = markdownForDisplay || (thinkingText ? '' : extractMessageText(content));
   const body = thinkingText
     ? [thinkingText, main].filter((s) => s.length > 0).join('\n\n')
     : main;

--- a/src/frontend/components/InputForm.tsx
+++ b/src/frontend/components/InputForm.tsx
@@ -124,6 +124,9 @@ export const InputForm = forwardRef<HTMLTextAreaElement, InputFormProps>(functio
           </button>
         </div>
       )}
+      <p className="text-sm text-muted-foreground text-center mt-2">
+        You are interacting with an AI tool. Always review AI-generated content prior to use.
+      </p>
     </form>
   );
 });

--- a/src/frontend/pages/HomePage.tsx
+++ b/src/frontend/pages/HomePage.tsx
@@ -126,8 +126,8 @@ export function HomePage() {
               </button>
             </div>
           </form>
-          <p className="text-xs text-muted-foreground text-center mt-2">
-            AI can make mistakes. Please review AI-generated content prior to use.
+          <p className="text-sm text-muted-foreground text-center mt-2">
+            You are interacting with an AI tool. Always review AI-generated content prior to use.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## What

Adds "AI-generated" label at end of every AI output and also to the copy to clipboard function. Adds a persistent AI disclaimer in the input form

Fixes #194 

## How

Adds the AI generated label next to the action items below the AI output bubble. Also adds it to copy clipboard function. Adds persistent AI disclaimer at bottom of input form below text input area

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

## Rollback

revert the commit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)
