### PR TITLE
fix: set Node.js heap limit to prevent container OOM kills

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -39,5 +39,6 @@ RUN npm ci && npm run build
 # Config will be mounted here at runtime from PVC
 # Override UI_CONFIG_PATH in deployment.yaml if using a custom mount location
 ENV UI_CONFIG_PATH=/app/config/ui/settings.yaml
+ENV NODE_OPTIONS="--max-old-space-size=384"
 
 CMD ["node", "dist/server/index.js"]


### PR DESCRIPTION
## What

Fix Node.js OOM kills by capping V8 heap size via `NODE_OPTIONS`. Without this, V8 sizes its heap based on the OpenShift node's total memory (32-64GB), not the container's memory limit (512Mi-1Gi), causing OOM kills under load.

Observed in production: `podeshpa/variance-agent` UI crashed with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` at ~509MB.

## How

Added `ENV NODE_OPTIONS="--max-old-space-size=384"` to the Containerfile. This caps V8's heap at 384MB, which is ~75% of the typical 512Mi container memory limit, leaving room for non-heap memory (buffers, native allocations, child processes).

Alternative considered: setting this in the deployment manifest as an env var — rejected because the Containerfile is the right place for a universal default that applies to all deployments.

## Testing

- [ ] Unit tests added/updated
- [x] Manual verification: confirmed V8 respects `--max-old-space-size` and `process.memoryUsage().heapTotal` stays below the configured limit
- [ ] Deploy to OpenShift and verify UI starts correctly with the heap cap
- [ ] Load test to confirm heap stays within bounds and no degradation

## Rollback

Revert the commit. No data migration needed.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [ ] Lint and tests pass (`npm run lint && npm run test`)

Closes #200