### PR TITLE
feat: add consent page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "fastify-plugin": "^5.0.1",
         "ioredis": "^5.10.1",
         "js-yaml": "^4.3.1",
-        "ldapts": "^9.0.0",
+        "ldapts": "9.0.0",
         "lucide-react": "^0.508.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -5,6 +5,7 @@ import { AnnouncementBanner } from '../components/AnnouncementBanner';
 import { AppLayout } from './components/layout/AppLayout';
 import { HomePage } from './pages/HomePage';
 import { ChatRoutePage } from './pages/ChatPage';
+import { ConsentPage } from './pages/ConsentPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { ProjectChatPage } from './pages/ProjectChatPage';
 import { EvalDatasetPage } from './pages/EvalDatasetPage';
@@ -100,19 +101,24 @@ export default function App() {
       }}
     >
       <AnnouncementBanner />
-      <AppLayout>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/chat" element={<Navigate to="/" replace />} />
-          <Route path="/chat/:threadId" element={<ChatRoutePage />} />
-          <Route path="/project/:projectId" element={<ProjectChatPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route
-            path="/eval/dataset"
-            element={isPrivilegedUser() ? <EvalDatasetPage /> : <Navigate to="/" replace />}
-          />
-        </Routes>
-      </AppLayout>
+      <Routes>
+        <Route path="/consent" element={<ConsentPage />} />
+        <Route path="/*" element={
+          <AppLayout>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/chat" element={<Navigate to="/" replace />} />
+              <Route path="/chat/:threadId" element={<ChatRoutePage />} />
+              <Route path="/project/:projectId" element={<ProjectChatPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route
+                path="/eval/dataset"
+                element={isPrivilegedUser() ? <EvalDatasetPage /> : <Navigate to="/" replace />}
+              />
+            </Routes>
+          </AppLayout>
+        } />
+      </Routes>
       <ToastNotifications />
     </ErrorBoundary>
   );

--- a/src/frontend/components/settings/AuthorizationSettings.tsx
+++ b/src/frontend/components/settings/AuthorizationSettings.tsx
@@ -1,0 +1,177 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Shield, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
+
+interface ConsentStatus {
+  hasConsent: boolean;
+  grantedAt: string | null;
+}
+
+export function AuthorizationSettings() {
+  const navigate = useNavigate();
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchConsentStatus = useCallback(async () => {
+    try {
+      const response = await fetch('/auth/consent/status', {
+        credentials: 'include',
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setConsentStatus(data);
+      }
+    } catch {
+      setError('Failed to load authorization status');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConsentStatus();
+  }, [fetchConsentStatus]);
+
+  const handleRevoke = async () => {
+    setIsRevoking(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/auth/consent/revoke', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to revoke authorization');
+      }
+
+      navigate('/consent', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8" role="status" aria-label="Loading authorization status">
+        <div className="animate-spin rounded-full h-6 w-6 border-2 border-primary/30 border-t-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Status indicator */}
+      <div className="flex items-center gap-3 p-4 rounded-lg bg-secondary border border-border">
+        {consentStatus?.hasConsent ? (
+          <CheckCircle className="w-6 h-6 text-green-500 dark:text-green-400 shrink-0" />
+        ) : (
+          <XCircle className="w-6 h-6 text-destructive shrink-0" />
+        )}
+        <div>
+          <p className="font-medium text-foreground">
+            {consentStatus?.hasConsent ? 'Authorization Granted' : 'Not Authorized'}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {consentStatus?.hasConsent
+              ? 'You have authorized this agent to act on your behalf'
+              : 'This agent does not have your authorization'}
+          </p>
+        </div>
+      </div>
+
+      {consentStatus?.hasConsent && (
+        <>
+          {/* Consent details */}
+          {consentStatus.grantedAt && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">Authorized on: </span>
+              <span className="text-foreground font-medium">
+                {new Date(consentStatus.grantedAt).toLocaleString()}
+              </span>
+            </div>
+          )}
+
+          {/* What was granted */}
+          <div>
+            <h3 className="text-sm font-medium text-foreground mb-2 flex items-center gap-2">
+              <Shield className="w-4 h-4 text-primary" />
+              Granted Permissions
+            </h3>
+            <ul className="space-y-1.5 text-sm text-muted-foreground">
+              <li className="flex items-center gap-2">
+                <CheckCircle className="w-3.5 h-3.5 text-green-500 dark:text-green-400 shrink-0" />
+                Authenticate with connected platforms using your SSO session
+              </li>
+              <li className="flex items-center gap-2">
+                <CheckCircle className="w-3.5 h-3.5 text-green-500 dark:text-green-400 shrink-0" />
+                Execute actions on your behalf through MCP tools and skills
+              </li>
+              <li className="flex items-center gap-2">
+                <CheckCircle className="w-3.5 h-3.5 text-green-500 dark:text-green-400 shrink-0" />
+                Read and process data from connected platforms
+              </li>
+            </ul>
+          </div>
+
+          {/* Revoke section */}
+          <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+            <div className="flex items-start gap-2 mb-3">
+              <AlertTriangle className="w-5 h-5 text-amber-500 dark:text-amber-400 mt-0.5 shrink-0" />
+              <div>
+                <h4 className="font-medium text-foreground mb-1">Revoke Authorization</h4>
+                <p className="text-sm text-muted-foreground">
+                  Revoking will remove the agent's ability to act on your behalf.
+                  You will need to re-authorize to continue using the application.
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleRevoke}
+              disabled={isRevoking}
+              className="px-4 py-2 rounded-lg bg-destructive text-white hover:bg-destructive/90 transition-colors disabled:opacity-70 disabled:cursor-not-allowed text-sm font-medium flex items-center gap-2"
+            >
+              {isRevoking ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/30 border-t-white" />
+                  Revoking…
+                </>
+              ) : (
+                'Revoke Authorization'
+              )}
+            </button>
+          </div>
+        </>
+      )}
+
+      {!consentStatus?.hasConsent && (
+        <div className="text-center py-4">
+          <p className="text-muted-foreground mb-4 text-sm">
+            To use this agent, you need to grant authorization.
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate('/consent', { replace: true })}
+            className="px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-sm font-medium"
+          >
+            Grant Authorization
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-destructive/10 border border-destructive/30 rounded-lg p-3" role="alert">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/components/settings/AuthorizationSettings.tsx
+++ b/src/frontend/components/settings/AuthorizationSettings.tsx
@@ -19,10 +19,11 @@ export function AuthorizationSettings() {
       const response = await fetch('/auth/consent/status', {
         credentials: 'include',
       });
-      if (response.ok) {
-        const data = await response.json();
-        setConsentStatus(data);
+      if (!response.ok) {
+        throw new Error(`Server returned ${response.status}`);
       }
+      const data = await response.json();
+      setConsentStatus(data);
     } catch {
       setError('Failed to load authorization status');
     } finally {

--- a/src/frontend/pages/ConsentPage.tsx
+++ b/src/frontend/pages/ConsentPage.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Shield, AlertTriangle, CheckCircle, Lock } from 'lucide-react';
+
+export function ConsentPage() {
+  const navigate = useNavigate();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleApprove = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/auth/consent/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({}),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to approve consent');
+      }
+
+      const data = await response.json();
+      navigate(data.redirectUrl ?? '/', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeny = () => {
+    setError(
+      'You must approve the authorization to continue using this application.',
+    );
+  };
+
+  return (
+    <div className="w-full min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="max-w-3xl w-full bg-card rounded-xl shadow-elevated border border-border animate-fadeInUp">
+        <div className="p-6 sm:p-8">
+          {/* Header */}
+          <div className="text-center mb-6">
+            <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mx-auto mb-4">
+              <Shield className="w-8 h-8 text-primary-foreground" />
+            </div>
+            <h1 className="text-2xl font-bold text-foreground mb-2">
+              Authorization Required
+            </h1>
+            <p className="text-muted-foreground">
+              This application needs your permission before you continue
+            </p>
+          </div>
+
+          {/* AI Technology Usage Notice */}
+          <div className="bg-primary/10 border border-primary/30 rounded-lg p-4 mb-6">
+            <h3 className="font-semibold text-foreground mb-3">
+              AI Technology Usage Notice
+            </h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              You are about to use a Red Hat tool that utilizes AI technology to
+              provide you with relevant information. By proceeding to use the
+              tool, you acknowledge that the tool and any output provided are
+              only intended for internal use and that information should only be
+              shared with those with a legitimate business purpose. Responses
+              provided by tools utilizing AI technology should be reviewed and
+              verified prior to use.
+            </p>
+          </div>
+
+          {/* Permissions */}
+          <div className="space-y-4 mb-6">
+            <div className="bg-secondary rounded-lg p-4 border border-border">
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                <li className="flex items-start gap-2">
+                  <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400 mt-0.5 shrink-0" />
+                  Your SSO token will be used to authenticate with connected
+                  platforms (e.g. Snowflake, Jira, GitLab, or other integrated
+                  services)
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400 mt-0.5 shrink-0" />
+                  Execute actions on your behalf through configured MCP tools
+                  and skills
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle className="w-4 h-4 text-green-500 dark:text-green-400 mt-0.5 shrink-0" />
+                  Read and process data returned by those platforms to generate
+                  insights
+                </li>
+              </ul>
+            </div>
+
+            <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="w-5 h-5 text-amber-500 dark:text-amber-400 mt-0.5 shrink-0" />
+                <div>
+                  <h4 className="font-medium text-foreground mb-1">
+                    Important:
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    Actions performed by this agent are executed under your
+                    identity. You will be able to review and approve individual
+                    tool calls during your session, and you can revoke consent at
+                    any time from your settings.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div
+              className="bg-destructive/10 border border-destructive/30 rounded-lg p-3 mb-4"
+              role="alert"
+            >
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={handleDeny}
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2.5 rounded-lg border border-border text-foreground bg-secondary hover:bg-secondary/70 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium text-sm"
+            >
+              Deny
+            </button>
+            <button
+              type="button"
+              onClick={handleApprove}
+              disabled={isSubmitting}
+              className="flex-1 px-4 py-2.5 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-70 disabled:cursor-not-allowed font-medium text-sm flex items-center justify-center gap-2"
+            >
+              {isSubmitting ? (
+                <>
+                  <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary-foreground/30 border-t-primary-foreground" />
+                  Approving…
+                </>
+              ) : (
+                'Approve & Continue'
+              )}
+            </button>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-6 pt-4 border-t border-border">
+            <p className="text-xs text-muted-foreground text-center leading-relaxed">
+              By approving, you allow this agent to use your authenticated
+              session to interact with connected platforms on your behalf. Your
+              queries and results may be logged for governance and product
+              improvement purposes.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/pages/ConsentPage.tsx
+++ b/src/frontend/pages/ConsentPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Shield, AlertTriangle, CheckCircle, Lock } from 'lucide-react';
+import { Shield, AlertTriangle, CheckCircle } from 'lucide-react';
 
 export function ConsentPage() {
   const navigate = useNavigate();

--- a/src/frontend/pages/SettingsPage.tsx
+++ b/src/frontend/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
-import { ArrowLeft, User, Brain, ScrollText, Palette, ShieldCheck, Code2, KeyRound } from 'lucide-react';
+import { ArrowLeft, User, Brain, ScrollText, Palette, ShieldCheck, Shield, Code2, KeyRound } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProfileSection } from '../components/settings/ProfileSection';
 import { MemoryList } from '../components/settings/MemoryList';
@@ -9,13 +9,14 @@ import { RulesEditor } from '../components/settings/RulesEditor';
 import { AppearanceSettings } from '../components/settings/AppearanceSettings';
 import { AlwaysAllowedTools } from '../components/settings/AlwaysAllowedTools';
 import { DeveloperSettings } from '../components/settings/DeveloperSettings';
+import { AuthorizationSettings } from '../components/settings/AuthorizationSettings';
 import { useAppSelector } from '../redux/hooks';
 import { selectDeveloperMode } from '../redux/slices/userSettings';
 import { OAuthConnections } from '../components/settings/OAuthConnections';
 import { isPrivilegedUser } from '../lib/role-utils';
 import type { RootState } from '../redux/store';
 
-type TabId = 'profile' | 'memories' | 'rules' | 'appearance' | 'tool-approvals' | 'oauth' | 'developer';
+type TabId = 'profile' | 'memories' | 'rules' | 'appearance' | 'tool-approvals' | 'authorization' | 'oauth' | 'developer';
 
 const TABS: { id: TabId; label: string; panelTitle?: string; icon: typeof User }[] = [
   { id: 'profile', label: 'Profile', icon: User },
@@ -23,6 +24,7 @@ const TABS: { id: TabId; label: string; panelTitle?: string; icon: typeof User }
   { id: 'rules', label: 'Custom Rules', icon: ScrollText },
   { id: 'appearance', label: 'Appearance', icon: Palette },
   { id: 'tool-approvals', label: 'Tool Approvals', icon: ShieldCheck },
+  { id: 'authorization', label: 'Authorization', icon: Shield },
   { id: 'oauth', label: 'MCP OAuth', icon: KeyRound },
   { id: 'developer', label: 'Developer', icon: Code2 },
 ];
@@ -33,6 +35,7 @@ const TAB_CONTENT: Record<TabId, React.FC> = {
   rules: RulesEditor,
   appearance: AppearanceSettings,
   'tool-approvals': AlwaysAllowedTools,
+  authorization: AuthorizationSettings,
   oauth: OAuthConnections,
   developer: DeveloperSettings,
 };

--- a/src/server/plugins/auth-check.plugin.ts
+++ b/src/server/plugins/auth-check.plugin.ts
@@ -2,6 +2,7 @@ import fastifyPlugin from "fastify-plugin";
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { getSettings } from "../utils/settings.js";
 import { resolveRole, type UserRole } from "../utils/role-resolver.js";
+import { safePostLoginRedirect } from "../utils/session-identity.js";
 
 declare module "fastify" {
   interface Session {
@@ -178,7 +179,7 @@ async function authCheck(
         if (path.startsWith("/api/") || path.startsWith("/v1/")) {
           return reply.code(403).send({ error: "consent_required", message: "User consent is required" });
         }
-        request.session.postConsentRedirect = request.url;
+        request.session.postConsentRedirect = safePostLoginRedirect(request.url);
         return reply.redirect("/consent");
       }
     }

--- a/src/server/plugins/auth-check.plugin.ts
+++ b/src/server/plugins/auth-check.plugin.ts
@@ -4,6 +4,11 @@ import { getSettings } from "../utils/settings.js";
 import { resolveRole, type UserRole } from "../utils/role-resolver.js";
 import { safePostLoginRedirect } from "../utils/session-identity.js";
 
+function getAgentHost(): string {
+  const cfg = getSettings();
+  return cfg.agent.endpoint || process.env.AGENT_HOST || "http://localhost:5002";
+}
+
 declare module "fastify" {
   interface Session {
     user?: {
@@ -170,6 +175,25 @@ async function authCheck(
           error: "forbidden",
           message: "Insufficient permissions for this resource.",
         });
+      }
+    }
+
+    if (!request.session.consentApproved) {
+      const token = request.session.token?.access_token;
+      if (token) {
+        try {
+          const resp = await fetch(`${getAgentHost()}/personalization/consent`, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(3000),
+          });
+          if (resp.ok) {
+            const data = (await resp.json()) as { has_consent?: boolean; granted_at?: string };
+            if (data.has_consent) {
+              request.session.consentApproved = true;
+              request.session.consentGrantedAt = data.granted_at;
+            }
+          }
+        } catch { /* agent unreachable — stay with session state */ }
       }
     }
 

--- a/src/server/plugins/auth-check.plugin.ts
+++ b/src/server/plugins/auth-check.plugin.ts
@@ -24,6 +24,9 @@ declare module "fastify" {
     redirectUri?: string;
     role?: UserRole;
     roleResolvedAt?: number;
+    consentApproved?: boolean;
+    consentGrantedAt?: string;
+    postConsentRedirect?: string;
   }
 }
 function headerValue(request: FastifyRequest, name: string): string | undefined {
@@ -45,6 +48,7 @@ function shouldSkipAuth(request: FastifyRequest): boolean {
     path.startsWith("/dist/") ||
     path === "/favicon.ico" ||
     path === "/login" ||
+    path === "/consent" ||
     path === "/api/health/agent" ||
     path === "/sandbox_proxy.html" ||
     path === "/sandbox_proxy.js"
@@ -116,6 +120,11 @@ async function authCheck(
       }
 
       request.session.role = "owners";
+
+      if (!request.session.consentApproved) {
+        request.session.consentApproved = true;
+        request.session.consentGrantedAt = new Date().toISOString();
+      }
     }
 
     if (!request.session?.user) {
@@ -160,6 +169,17 @@ async function authCheck(
           error: "forbidden",
           message: "Insufficient permissions for this resource.",
         });
+      }
+    }
+
+    if (!request.session.consentApproved) {
+      const path = request.url.split("?")[0];
+      if (path !== "/consent") {
+        if (path.startsWith("/api/") || path.startsWith("/v1/")) {
+          return reply.code(403).send({ error: "consent_required", message: "User consent is required" });
+        }
+        request.session.postConsentRedirect = request.url;
+        return reply.redirect("/consent");
       }
     }
   });

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -1,5 +1,5 @@
 import oauthPlugin from "@fastify/oauth2";
-import { FastifyInstance } from "fastify";
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import fp from "fastify-plugin";
 import { getSettings } from "../utils/settings.js";
 import { resolveSessionIdentity, safePostLoginRedirect } from "../utils/session-identity.js";
@@ -20,6 +20,26 @@ declare module "fastify" {
   interface FastifyInstance {
     redhatSSO: OAuth2Namespace;
   }
+}
+
+/**
+ * Reject cross-origin POST requests that lack a same-origin Origin header.
+ * Defends cookie-authenticated mutations against CSRF.
+ */
+function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean {
+  const origin = request.headers.origin;
+  if (!origin) return true;
+  try {
+    const allowed = new URL(`${request.protocol}://${request.hostname}`).origin;
+    if (new URL(origin).origin !== allowed) {
+      reply.code(403).send({ error: "cross_origin_denied", message: "Cross-origin request rejected" });
+      return false;
+    }
+  } catch {
+    reply.code(403).send({ error: "invalid_origin", message: "Invalid Origin header" });
+    return false;
+  }
+  return true;
 }
 
 /** Auth-only limiter: this plugin is wrapped with fp(), so global:true would apply app-wide. */
@@ -139,8 +159,15 @@ async function routes(fastify: FastifyInstance) {
         user: userInfo,
         token: tokenSet.token,
       });
+
+      const previousSub = (request as any).session.user?.sub;
       (request as any).session.user = identity.user;
       (request as any).session.token = tokenSet.token;
+
+      if (previousSub && previousSub !== identity.user.sub) {
+        (request as any).session.consentApproved = false;
+        delete (request as any).session.consentGrantedAt;
+      }
 
       if ((request as any).session.consentApproved) {
         return reply.redirect(defaultRedirect);
@@ -155,6 +182,7 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.post("/auth/consent/approve", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    if (!verifyCsrfOrigin(request, reply)) return;
     const session = (request as any).session;
     if (!session?.user) {
       return reply.code(401).send({ error: "Not authenticated" });
@@ -178,6 +206,7 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.post("/auth/consent/revoke", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    if (!verifyCsrfOrigin(request, reply)) return;
     const session = (request as any).session;
     if (!session?.user) {
       return reply.code(401).send({ error: "Not authenticated" });

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -27,7 +27,10 @@ declare module "fastify" {
  */
 function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean {
   const origin = request.headers.origin;
-  if (!origin) return true;
+  if (!origin) {
+    reply.code(403).send({ error: "missing_origin", message: "Origin header is required" });
+    return false;
+  }
   try {
     const allowed = new URL(`${request.protocol}://${request.host}`).origin;
     if (new URL(origin).origin !== allowed) {

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -268,7 +268,7 @@ async function routes(fastify: FastifyInstance) {
 
     const token = session.token?.access_token;
     try {
-      await fetch(`${getAgentHost()}/personalization/consent`, {
+      const resp = await fetch(`${getAgentHost()}/personalization/consent`, {
         method: "DELETE",
         headers: {
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -276,8 +276,13 @@ async function routes(fastify: FastifyInstance) {
         },
         signal: AbortSignal.timeout(5000),
       });
+      if (!resp.ok) {
+        fastify.log.error({ status: resp.status }, "Agent consent revoke returned non-2xx");
+        return reply.code(502).send({ error: "revoke_failed", message: "Failed to revoke consent on the agent" });
+      }
     } catch (err) {
-      fastify.log.warn({ err }, "Agent consent revoke failed");
+      fastify.log.error({ err }, "Agent consent revoke failed");
+      return reply.code(502).send({ error: "revoke_failed", message: "Agent unreachable during consent revocation" });
     }
 
     session.consentApproved = false;

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -237,6 +237,7 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.get("/auth/consent/status", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    reply.header("Cache-Control", "no-store");
     const session = (request as any).session;
 
     if (session?.consentApproved) {

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -29,7 +29,7 @@ function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean
   const origin = request.headers.origin;
   if (!origin) return true;
   try {
-    const allowed = new URL(`${request.protocol}://${request.hostname}`).origin;
+    const allowed = new URL(`${request.protocol}://${request.host}`).origin;
     if (new URL(origin).origin !== allowed) {
       reply.code(403).send({ error: "cross_origin_denied", message: "Cross-origin request rejected" });
       return false;

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -4,6 +4,26 @@ import fp from "fastify-plugin";
 import { getSettings } from "../utils/settings.js";
 import { resolveSessionIdentity, safePostLoginRedirect } from "../utils/session-identity.js";
 
+function getAgentHost(): string {
+  const cfg = getSettings();
+  return cfg.agent.endpoint || process.env.AGENT_HOST || "http://localhost:5002";
+}
+
+/**
+ * Check consent status from the agent's Postgres-backed API.
+ * Returns { has_consent, granted_at } or null on failure.
+ */
+async function fetchAgentConsent(accessToken: string): Promise<{ has_consent: boolean; granted_at: string | null } | null> {
+  try {
+    const resp = await fetch(`${getAgentHost()}/personalization/consent`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (resp.ok) return (await resp.json()) as { has_consent: boolean; granted_at: string | null };
+  } catch { /* agent unreachable — fall through */ }
+  return null;
+}
+
 import { OAuth2Namespace } from "@fastify/oauth2";
 
 type UserInfo = {
@@ -162,19 +182,18 @@ async function routes(fastify: FastifyInstance) {
         token: tokenSet.token,
       });
 
-      const previousSub = (request as any).session.user?.sub;
       (request as any).session.user = identity.user;
       (request as any).session.token = tokenSet.token;
 
-      if (previousSub && previousSub !== identity.user.sub) {
-        (request as any).session.consentApproved = false;
-        delete (request as any).session.consentGrantedAt;
-      }
-
-      if ((request as any).session.consentApproved) {
+      const agentConsent = await fetchAgentConsent(tokenSet.token.access_token);
+      if (agentConsent?.has_consent) {
+        (request as any).session.consentApproved = true;
+        (request as any).session.consentGrantedAt = agentConsent.granted_at;
         return reply.redirect(defaultRedirect);
       }
 
+      (request as any).session.consentApproved = false;
+      delete (request as any).session.consentGrantedAt;
       (request as any).session.postConsentRedirect = defaultRedirect;
       return reply.redirect("/consent");
     } catch (error) {
@@ -190,8 +209,26 @@ async function routes(fastify: FastifyInstance) {
       return reply.code(401).send({ error: "Not authenticated" });
     }
 
-    session.consentApproved = true;
-    session.consentGrantedAt = new Date().toISOString();
+    const token = session.token?.access_token;
+    try {
+      const resp = await fetch(`${getAgentHost()}/personalization/consent`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          "X-User-ID": session.user.preferred_username || session.user.sub || "",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!resp.ok) throw new Error(`Agent returned ${resp.status}`);
+      const data = (await resp.json()) as { granted_at?: string };
+      session.consentApproved = true;
+      session.consentGrantedAt = data.granted_at;
+    } catch (err) {
+      session.consentApproved = true;
+      session.consentGrantedAt = new Date().toISOString();
+      fastify.log.warn({ err }, "Agent consent store failed, session-only fallback");
+    }
 
     const redirectUrl = session.postConsentRedirect ?? "/";
     delete session.postConsentRedirect;
@@ -201,10 +238,25 @@ async function routes(fastify: FastifyInstance) {
 
   fastify.get("/auth/consent/status", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
     const session = (request as any).session;
-    return reply.send({
-      hasConsent: !!session?.consentApproved,
-      grantedAt: session?.consentGrantedAt ?? null,
-    });
+
+    if (session?.consentApproved) {
+      return reply.send({
+        hasConsent: true,
+        grantedAt: session.consentGrantedAt ?? null,
+      });
+    }
+
+    const token = session?.token?.access_token;
+    if (token) {
+      const agentConsent = await fetchAgentConsent(token);
+      if (agentConsent?.has_consent) {
+        session.consentApproved = true;
+        session.consentGrantedAt = agentConsent.granted_at;
+        return reply.send({ hasConsent: true, grantedAt: agentConsent.granted_at });
+      }
+    }
+
+    return reply.send({ hasConsent: false, grantedAt: null });
   });
 
   fastify.post("/auth/consent/revoke", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
@@ -212,6 +264,20 @@ async function routes(fastify: FastifyInstance) {
     const session = (request as any).session;
     if (!session?.user) {
       return reply.code(401).send({ error: "Not authenticated" });
+    }
+
+    const token = session.token?.access_token;
+    try {
+      await fetch(`${getAgentHost()}/personalization/consent`, {
+        method: "DELETE",
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          "X-User-ID": session.user.preferred_username || session.user.sub || "",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (err) {
+      fastify.log.warn({ err }, "Agent consent revoke failed");
     }
 
     session.consentApproved = false;

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -142,11 +142,51 @@ async function routes(fastify: FastifyInstance) {
       (request as any).session.user = identity.user;
       (request as any).session.token = tokenSet.token;
 
-      return reply.redirect(defaultRedirect);
+      if ((request as any).session.consentApproved) {
+        return reply.redirect(defaultRedirect);
+      }
+
+      (request as any).session.postConsentRedirect = defaultRedirect;
+      return reply.redirect("/consent");
     } catch (error) {
       console.error(error);
       return reply.send({ message: "Some error occured!" });
     }
+  });
+
+  fastify.post("/auth/consent/approve", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    const session = (request as any).session;
+    if (!session?.user) {
+      return reply.code(401).send({ error: "Not authenticated" });
+    }
+
+    session.consentApproved = true;
+    session.consentGrantedAt = new Date().toISOString();
+
+    const redirectUrl = session.postConsentRedirect ?? "/";
+    delete session.postConsentRedirect;
+
+    return reply.send({ message: "Consent approved", redirectUrl });
+  });
+
+  fastify.get("/auth/consent/status", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    const session = (request as any).session;
+    return reply.send({
+      hasConsent: !!session?.consentApproved,
+      grantedAt: session?.consentGrantedAt ?? null,
+    });
+  });
+
+  fastify.post("/auth/consent/revoke", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
+    const session = (request as any).session;
+    if (!session?.user) {
+      return reply.code(401).send({ error: "Not authenticated" });
+    }
+
+    session.consentApproved = false;
+    delete session.consentGrantedAt;
+
+    return reply.send({ message: "Consent revoked" });
   });
 }
 

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -24,7 +24,6 @@ declare module "fastify" {
 
 /**
  * Reject cross-origin POST requests that lack a same-origin Origin header.
- * Defends cookie-authenticated mutations against CSRF.
  */
 function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean {
   const origin = request.headers.origin;


### PR DESCRIPTION
## What

Adds consent page. Store user consent in session/cookie (this can be upgrade to database storage in a follow up PR). When user first enters page, it checks if the consent is present. If not, the consent page appears and user can either click Deny or Approve. Deny prevents user from using the agent. Approve stores user's consent in session store and redirects them to the home page. For that same session, the consent is stored and preserved.

Fixes #205 

## How

Adds consent page, stored in session/cookie. Consent page wraps around app routes as it is detected right after login. If consent not present after login, user is sent to consent page. Once user approved, their consent is stored in the session and they are redirected to the home page.

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

## Rollback

revert the commit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)
