### PR TITLE
fix: CSRF origin check behind TLS termination

### DIFF
--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -52,7 +52,8 @@ function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean
     return false;
   }
   try {
-    const allowed = new URL(`${request.protocol}://${request.host}`).origin;
+    const proto = (request.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim() || request.protocol;
+    const allowed = new URL(`${proto}://${request.host}`).origin;
     if (new URL(origin).origin !== allowed) {
       reply.code(403).send({ error: "cross_origin_denied", message: "Cross-origin request rejected" });
       return false;
@@ -203,7 +204,7 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.post("/auth/consent/approve", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
-    if (!verifyCsrfOrigin(request, reply)) return;
+    if (!verifyCsrfOrigin(request, reply)) return reply;
     const session = (request as any).session;
     if (!session?.user) {
       return reply.code(401).send({ error: "Not authenticated" });
@@ -261,7 +262,7 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.post("/auth/consent/revoke", AUTH_ROUTE_RATE_LIMIT, async (request, reply) => {
-    if (!verifyCsrfOrigin(request, reply)) return;
+    if (!verifyCsrfOrigin(request, reply)) return reply;
     const session = (request as any).session;
     if (!session?.user) {
       return reply.code(401).send({ error: "Not authenticated" });

--- a/src/server/plugins/auth.plugin.ts
+++ b/src/server/plugins/auth.plugin.ts
@@ -52,7 +52,8 @@ function verifyCsrfOrigin(request: FastifyRequest, reply: FastifyReply): boolean
     return false;
   }
   try {
-    const proto = (request.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim() || request.protocol;
+    const fwdProto = (request.headers["x-forwarded-proto"] as string)?.split(",")[0]?.trim();
+    const proto = (fwdProto === "https" || fwdProto === "http") ? fwdProto : request.protocol;
     const allowed = new URL(`${proto}://${request.host}`).origin;
     if (new URL(origin).origin !== allowed) {
       reply.code(403).send({ error: "cross_origin_denied", message: "Cross-origin request rejected" });


### PR DESCRIPTION
## What

Uses X-Forwarded-Proto instead of request.protocol for CSRF origin validation, which returns http behind OpenShift's TLS-terminating router.

Fixes #205 

## How

<!-- Describe your approach. Call out non-obvious design decisions, trade-offs, or alternatives you considered. -->

## Testing

<!-- How did you verify this works? -->

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

## Rollback

<!-- How would you revert this if it breaks production? "Revert the commit" is fine for most changes. -->

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)
