### PR TITLE
feat: add feedback comments for thumbs down

### DIFF
--- a/src/frontend/components/ChatMessagesView.tsx
+++ b/src/frontend/components/ChatMessagesView.tsx
@@ -26,7 +26,7 @@ import { SubAgentIndicator } from "./SubAgentIndicator";
 import { ArtifactViewer } from "./ArtifactViewer";
 import { McpAppHostFromToolCall } from "./McpAppHost";
 import { TodoStrip } from "./TodoStrip";
-import { FeedbackButtons } from "./FeedbackButtons";
+import { FeedbackButtons, FeedbackCommentBox, useFeedback } from "./FeedbackButtons";
 import { CustomDataRenderer } from "./CustomDataRenderer";
 import { parseMcpApp } from "../types/mcp-apps";
 
@@ -193,6 +193,44 @@ function MessageCopyButton({ text }: { text: string }) {
     >
       {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
     </button>
+  );
+}
+
+function MessageActionsRow({
+  isLastAiInTurn,
+  copyText,
+  messageId,
+  chatId,
+  traceId,
+  userId,
+  existingFeedback,
+}: {
+  isLastAiInTurn: boolean;
+  copyText: string;
+  messageId: string;
+  chatId: string;
+  traceId: string | null;
+  userId?: string;
+  existingFeedback: 'up' | 'down' | null;
+}) {
+  const fb = useFeedback({ messageId, traceId, chatId, userId, existingFeedback });
+
+  return (
+    <>
+      <div className="pl-11 flex items-center gap-0.5 mt-1">
+        {isLastAiInTurn && (
+          <>
+            <MessageCopyButton text={copyText} />
+            <FeedbackButtons fb={fb} />
+          </>
+        )}
+        <span className="inline-flex items-center gap-1 ml-2 text-[11px] text-muted-foreground" aria-label="AI-generated content">
+          <Bot className="w-2.5 h-2.5" aria-hidden="true" />
+          AI-generated
+        </span>
+      </div>
+      <FeedbackCommentBox fb={fb} />
+    </>
   );
 }
 
@@ -1061,24 +1099,15 @@ export function ChatMessagesView({
                     allDecisionsMade={globalAllDecisionsMade}
                     onSingleDecision={handleGlobalSingleDecision}
                   />
-                  <div className="pl-11 flex items-center gap-0.5 mt-1">
-                    {isLastAiInTurn && (
-                      <>
-                        <MessageCopyButton text={copyText} />
-                        <FeedbackButtons
-                          messageId={message.id ?? `msg-${messageIndex}`}
-                          chatId={chatId}
-                          traceId={traceId}
-                          userId={userId}
-                          existingFeedback={messageFeedback[message.id ?? `msg-${messageIndex}`] ?? null}
-                        />
-                      </>
-                    )}
-                    <span className="inline-flex items-center gap-1 ml-2 text-[11px] text-muted-foreground" aria-label="AI-generated content">
-                      <Bot className="w-2.5 h-2.5" aria-hidden="true" />
-                      AI-generated
-                    </span>
-                  </div>
+                  <MessageActionsRow
+                    isLastAiInTurn={isLastAiInTurn}
+                    copyText={copyText}
+                    messageId={message.id ?? `msg-${messageIndex}`}
+                    chatId={chatId}
+                    traceId={traceId}
+                    userId={userId}
+                    existingFeedback={messageFeedback[message.id ?? `msg-${messageIndex}`] ?? null}
+                  />
                   {showResponseTiming && (
                     <div aria-hidden="true" className="pl-11 mt-1 space-y-0.5 text-muted-foreground">
                       <div className="text-[11px] text-muted-foreground">

--- a/src/frontend/components/FeedbackButtons.tsx
+++ b/src/frontend/components/FeedbackButtons.tsx
@@ -15,39 +15,61 @@ export interface FeedbackButtonsProps {
   existingFeedback?: 'up' | 'down' | null;
 }
 
-export function FeedbackButtons({
+/** State returned by useFeedback */
+export interface FeedbackState {
+  existingFeedback: 'up' | 'down' | null;
+  isSubmitting: boolean;
+  showCommentInput: boolean;
+  comment: string;
+  disabled: boolean;
+  handleThumbsUp: () => void;
+  handleThumbsDown: () => void;
+  handleCommentSubmit: () => void;
+  setComment: (v: string) => void;
+  cancelComment: () => void;
+}
+
+/** Hook that owns all feedback state and side effects */
+export function useFeedback({
   messageId,
   traceId,
   chatId,
   userId,
   existingFeedback = null,
-}: FeedbackButtonsProps) {
+}: FeedbackButtonsProps): FeedbackState {
   const dispatch = useAppDispatch();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showCommentInput, setShowCommentInput] = useState(false);
+  const [comment, setComment] = useState('');
 
   const effectiveTraceId = traceId || chatId;
-  const disabled = !effectiveTraceId || isSubmitting;
+  const locked = !!existingFeedback;
+  const disabled = !effectiveTraceId || isSubmitting || locked;
 
-  const handleVote = useCallback(
-    async (direction: 'up' | 'down') => {
-      if (!effectiveTraceId || isSubmitting) {
-        return;
-      }
-      if (existingFeedback === direction) {
-        dispatch(setMessageFeedback({ chatId, messageId, feedback: null }));
-        return;
-      }
+  const doSendFeedback = useCallback(
+    async (direction: 'up' | 'down', feedbackComment?: string) => {
+      if (!effectiveTraceId || locked) return;
       setIsSubmitting(true);
       try {
         await submitFeedback({
           traceId: effectiveTraceId,
           name: direction === 'up' ? 'thumbs-up' : 'thumbs-down',
           value: direction === 'up' ? 1.0 : 0.0,
+          comment: feedbackComment || undefined,
           threadId: chatId,
           messageId,
           userId: userId || 'anonymous',
         });
         dispatch(setMessageFeedback({ chatId, messageId, feedback: direction }));
+        if (direction === 'down') {
+          dispatch(
+            addToast({
+              title: 'Thank you for your feedback',
+              message: 'We will work to improve.',
+              variant: 'info',
+            }),
+          );
+        }
       } catch (e) {
         dispatch(
           addToast({
@@ -58,46 +80,126 @@ export function FeedbackButtons({
         );
       } finally {
         setIsSubmitting(false);
+        setShowCommentInput(false);
+        setComment('');
       }
     },
-    [effectiveTraceId, isSubmitting, existingFeedback, dispatch, chatId, messageId, userId],
+    [effectiveTraceId, locked, dispatch, chatId, messageId, userId],
   );
 
+  const handleThumbsUp = useCallback(() => {
+    if (locked || isSubmitting) return;
+    void doSendFeedback('up');
+  }, [locked, isSubmitting, doSendFeedback]);
+
+  const handleThumbsDown = useCallback(() => {
+    if (locked || isSubmitting) return;
+    setShowCommentInput(true);
+  }, [locked, isSubmitting]);
+
+  const handleCommentSubmit = useCallback(() => {
+    void doSendFeedback('down', comment.trim() || undefined);
+  }, [doSendFeedback, comment]);
+
+  const cancelComment = useCallback(() => {
+    setShowCommentInput(false);
+    setComment('');
+  }, []);
+
+  return {
+    existingFeedback,
+    isSubmitting,
+    showCommentInput,
+    comment,
+    disabled,
+    handleThumbsUp,
+    handleThumbsDown,
+    handleCommentSubmit,
+    setComment,
+    cancelComment,
+  };
+}
+
+/** Inline thumbs-up and thumbs-down buttons */
+export function FeedbackButtons({ fb }: { fb: FeedbackState }) {
   const baseBtn =
     'inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
 
   return (
-    <div
-      className="mt-1 flex items-center gap-0.5 opacity-80 transition-opacity group-hover:opacity-100"
-      role="group"
-      aria-label="Message feedback"
-    >
+    <>
       <button
         type="button"
         className={cn(
           baseBtn,
-          existingFeedback === 'up' && 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary',
+          fb.existingFeedback === 'up' && 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary',
         )}
-        disabled={disabled}
-        aria-pressed={existingFeedback === 'up' ? true : false}
+        disabled={fb.disabled}
+        aria-pressed={fb.existingFeedback === 'up' ? true : false}
         aria-label="Rate response as helpful"
-        onClick={() => void handleVote('up')}
+        onClick={fb.handleThumbsUp}
       >
-        <ThumbsUp className={cn('h-3.5 w-3.5', existingFeedback === 'up' && 'fill-current')} strokeWidth={2} />
+        <ThumbsUp className={cn('h-3.5 w-3.5', fb.existingFeedback === 'up' && 'fill-current')} strokeWidth={2} />
       </button>
       <button
         type="button"
         className={cn(
           baseBtn,
-          existingFeedback === 'down' && 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary',
+          fb.existingFeedback === 'down' && 'text-primary bg-primary/10 hover:bg-primary/15 hover:text-primary',
         )}
-        disabled={disabled}
-        aria-pressed={existingFeedback === 'down' ? true : false}
+        disabled={fb.disabled}
+        aria-pressed={fb.existingFeedback === 'down' ? true : false}
         aria-label="Rate response as not helpful"
-        onClick={() => void handleVote('down')}
+        onClick={fb.handleThumbsDown}
       >
-        <ThumbsDown className={cn('h-3.5 w-3.5', existingFeedback === 'down' && 'fill-current')} strokeWidth={2} />
+        <ThumbsDown className={cn('h-3.5 w-3.5', fb.existingFeedback === 'down' && 'fill-current')} strokeWidth={2} />
       </button>
+    </>
+  );
+}
+
+/** Comment box for thumbs-down feedback */
+export function FeedbackCommentBox({ fb }: { fb: FeedbackState }) {
+  if (!fb.showCommentInput || !!fb.existingFeedback) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      fb.handleCommentSubmit();
+    } else if (e.key === 'Escape') {
+      fb.cancelComment();
+    }
+  };
+
+  return (
+    <div className="pl-11 mt-1">
+      <div className="rounded-lg border border-border bg-muted/50 p-3 min-w-[280px] max-w-[400px] animate-in fade-in slide-in-from-top-1 duration-200">
+        <textarea
+          value={fb.comment}
+          onChange={(e) => fb.setComment(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="What went wrong? (optional)"
+          className="w-full resize-none border-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+          autoFocus
+          rows={1}
+        />
+        <div className="mt-2 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-md px-3 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={fb.cancelComment}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="rounded-md bg-primary px-3 py-1 text-xs text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
+            disabled={fb.isSubmitting}
+            onClick={fb.handleCommentSubmit}
+          >
+            {fb.isSubmitting ? 'Sending...' : 'Send'}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/frontend/hooks/useStreamingAPI.ts
+++ b/src/frontend/hooks/useStreamingAPI.ts
@@ -513,7 +513,7 @@ export function useStreamingAPI(threadId: string) {
           streamEndedWithInterruptRef.current = false;
 
           const callbacks: StreamCallback = {
-            onToken(content) {
+            onToken(content, messageId) {
               lastTokenTimeRef.current = Date.now();
               lastSuccessfulConnectionRef.current = Date.now();
               setIsStreamStale(false);
@@ -525,7 +525,7 @@ export function useStreamingAPI(threadId: string) {
                   type: 'ai',
                   content,
                   tool_calls: [],
-                  id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+                  id: messageId || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
                 };
                 dispatch(appendMessageToChat({ chatId: threadId, message }));
                 isStreamingTokensRef.current = true;
@@ -1052,14 +1052,14 @@ export function useStreamingAPI(threadId: string) {
       let resumeStreamHadError = false;
 
       const callbacks: StreamCallback = {
-        onToken(content) {
+        onToken(content, messageId) {
           lastTokenTimeRef.current = Date.now();
           if (!isStreamingTokensRef.current) {
             const message: AIMessage = {
               type: 'ai',
               content,
               tool_calls: [],
-              id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+              id: messageId || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
             };
             dispatch(appendMessageToChat({ chatId: threadId, message }));
             isStreamingTokensRef.current = true;
@@ -1181,14 +1181,14 @@ export function useStreamingAPI(threadId: string) {
 
       await new Promise<void>((resolve) => {
         const callbacks: StreamCallback = {
-          onToken(content) {
+          onToken(content, messageId) {
             lastTokenTimeRef.current = Date.now();
             if (!isStreamingTokensRef.current) {
               const message: AIMessage = {
                 type: 'ai',
                 content,
                 tool_calls: [],
-                id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+                id: messageId || `${Date.now()}-${Math.random().toString(36).slice(2)}`,
               };
               dispatch(appendMessageToChat({ chatId: threadId, message }));
               isStreamingTokensRef.current = true;

--- a/src/frontend/lib/streaming/SSEProcessor.ts
+++ b/src/frontend/lib/streaming/SSEProcessor.ts
@@ -2,7 +2,7 @@ import type { Message } from '@langchain/langgraph-sdk';
 import type { HITLInterruptValue } from '@/types/deep-agent';
 
 export type SSEChunk =
-  | { type: 'token'; content: string; chunk_id: number }
+  | { type: 'token'; content: string; chunk_id: number; message_id?: string }
   | { type: 'draft_discard'; chunk_id: number }
   | { type: 'message'; content: Message; chunk_id: number }
   | { type: 'interrupt'; content: { value: HITLInterruptValue | string; resumable: boolean }; chunk_id: number };
@@ -49,7 +49,8 @@ function parseSSEChunkPayload(parsed: unknown): SSEChunk | null {
 
   if (type === 'token') {
     if (typeof contentUnknown !== 'string') return null;
-    return { type: 'token', content: contentUnknown, chunk_id: chunkIdRaw };
+    const msgId = typeof parsed.message_id === 'string' ? parsed.message_id : undefined;
+    return { type: 'token', content: contentUnknown, chunk_id: chunkIdRaw, message_id: msgId };
   }
 
   if (type === 'interrupt') {

--- a/src/frontend/lib/streaming/StreamingManager.test.ts
+++ b/src/frontend/lib/streaming/StreamingManager.test.ts
@@ -72,7 +72,7 @@ describe('StreamingManager', () => {
     const manager = new StreamingManager();
     await manager.stream(BASE_REQUEST, callbacks);
 
-    expect(callbacks.onToken).toHaveBeenCalledWith('Hello');
+    expect(callbacks.onToken).toHaveBeenCalledWith('Hello', undefined);
     expect(callbacks.onDone).toHaveBeenCalledOnce();
     expect(callbacks.onError).not.toHaveBeenCalled();
   });
@@ -124,7 +124,7 @@ describe('StreamingManager', () => {
     await manager.stream(BASE_REQUEST, callbacks);
 
     expect(callbacks.onToken).toHaveBeenCalledTimes(1);
-    expect(callbacks.onToken).toHaveBeenCalledWith('First');
+    expect(callbacks.onToken).toHaveBeenCalledWith('First', undefined);
   });
 
   // ── HTTP error → onError + status 'error' ────────────────────────────────
@@ -241,7 +241,7 @@ describe('StreamingManager', () => {
     await manager.stream(BASE_REQUEST, cb2);
 
     // chunk_id 0 was used in first stream; after cancel+reset it should work again
-    expect(cb2.onToken).toHaveBeenCalledWith('Re-used');
+    expect(cb2.onToken).toHaveBeenCalledWith('Re-used', undefined);
   });
 
   it('includes project_id in the stream request body when provided', async () => {

--- a/src/frontend/lib/streaming/StreamingManager.ts
+++ b/src/frontend/lib/streaming/StreamingManager.ts
@@ -39,7 +39,7 @@ export type StreamMetadataPayload = {
 };
 
 export type StreamCallback = {
-  onToken: (content: string) => void;
+  onToken: (content: string, messageId?: string) => void;
   onDraftDiscard?: () => void;
   onMessage: (message: Message) => void;
   onInterrupt: (interrupt: InterruptPayload) => void;
@@ -94,7 +94,7 @@ export class StreamingManager {
           this.processedChunkIds.add(chunkId);
 
           if (event.data.type === 'token') {
-            callbacks.onToken(event.data.content);
+            callbacks.onToken(event.data.content, event.data.message_id);
           } else if (event.data.type === 'draft_discard') {
             callbacks.onDraftDiscard?.();
           } else if (event.data.type === 'interrupt') {

--- a/src/server/router/proxy.router.ts
+++ b/src/server/router/proxy.router.ts
@@ -639,7 +639,11 @@ async function proxyRoutes(fastify: FastifyInstance) {
                   );
                   if (!isEchoOfPrior) {
                     const delta = nextPartial.slice(prevPartial.length);
-                    reply.raw.write(`data: ${JSON.stringify({ type: 'token', content: delta, chunk_id: chunkId })}\n\n`);
+                    const tokenPayload: Record<string, unknown> = { type: 'token', content: delta, chunk_id: chunkId };
+                    if (currentStreamingMsgId) {
+                      tokenPayload.message_id = currentStreamingMsgId;
+                    }
+                    reply.raw.write(`data: ${JSON.stringify(tokenPayload)}\n\n`);
                     chunkId++;
                     hasEmittedTextTokens = true;
                     textEmittedForCurrentMsg = true;


### PR DESCRIPTION
## What

When a user clicks thumbs-down, show a comment input box before submitting feedback. Lock the buttons after any vote. Propagate the server's message_id from SSE tokens so feedback is tied to the right message.

Fixes #220 

## How

- `src/frontend/components/ChatMessagesView.tsx`: put feedbackCommentBox in same MessageActionsRow component as other action buttons so they stay inline and share same row
- `src/frontend/components/FeedbackButtons.tsx`: api call updated to send feedback comment. comment box only appears for downvoted messages. keeps track for thumbs downs to show comment box.
- `src/frontend/hooks/useStreamingAPI.ts`: propagate message_id field so new messages feedbacks can be saved
- `src/frontend/lib/streaming/SSEProcessor.ts`: propagate message_id 
- `src/frontend/lib/streaming/StreamingManager.ts`: add message_id
- `src/server/router/proxy.router.ts`: match message_id to token chunks

## Testing

- [x] Unit tests added/updated
- [x] Ran locally (`npm run dev`)
- [x] Manual verification (describe below if applicable)

## Rollback

revert the commit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `ci:`, etc.)
- [x] No secrets, credentials, or PII in the diff
- [x] No breaking changes (or documented above with a migration path)
- [x] Lint and tests pass (`npm run lint && npm run test`)
